### PR TITLE
Fix default userpics

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -39,7 +39,9 @@ const userDefaults = {
 }
 
 export function userParser(user) {
-  return {...userDefaults, ...user}
+  user.profilePictureMediumUrl = user.profilePictureMediumUrl || userDefaults.profilePictureMediumUrl
+  user.profilePictureLargeUrl = user.profilePictureLargeUrl || userDefaults.profilePictureLargeUrl
+  return {...user}
 }
 
 


### PR DESCRIPTION
Issue:
Users without userpics should be displayed with default ones, but they don't.

Cause:
That nice-looking ES7 thing (`{...userDefaults, ...user}`) only works when properties
`profilePictureMediumUrl` and `profilePictureLargeUrl` are missing from the `user`
object, but in this case they exist and contain empty strings.