### PR TITLE
Transition updates

### DIFF
--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -99,7 +99,7 @@ const loadFeedViewState = posts => {
 
 export function feedViewState(state = initFeed, action) {
   if (isFeedRequest(action)){
-    return initFeed
+    return state
   }
   if (isFeedResponse(action)){
     return loadFeedViewState(action.payload.posts)

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -93,6 +93,7 @@ export function createPostViewState(state = {}, action) {
 const initFeed = {feed: []}
 
 const loadFeedViewState = posts => {
+  scrollTo(0, 0)
   const feed = (posts || []).map(post => post.id)
   return { feed }
 }
@@ -118,6 +119,7 @@ export function feedViewState(state = initFeed, action) {
       return { feed: [postId, ...state.feed] }
     }
     case response(GET_SINGLE_POST): {
+      scrollTo(0, 0)
       const postId = action.request.postId
       return { feed: [postId] }
     }

--- a/src/redux/route-actions.js
+++ b/src/redux/route-actions.js
@@ -1,21 +1,16 @@
 import {home, discussions, direct, getUserFeed, getUserComments, getUserLikes, getSinglePost} from './action-creators'
 
-const scrollToTop = value => {
-  scrollTo(0, 0)
-  return value
-}
-
 //query params are strings, so + hack to convert to number
 const getOffset = nextRoute => +nextRoute.location.query.offset || 0
 
 export const routeActions = {
-  'home': next => scrollToTop(home(getOffset(next))),
-  'discussions': next => scrollToTop(discussions(getOffset(next))),
-  'userFeed': next => scrollToTop(getUserFeed(next.params.userName, getOffset(next))),
-  'userComments': next => scrollToTop(getUserComments(next.params.userName, getOffset(next))),
-  'userLikes': next => scrollToTop(getUserLikes(next.params.userName, getOffset(next))),
-  'post': next => scrollToTop(getSinglePost(next.params.postId)),
-  'direct': next => scrollToTop(direct(getOffset(next))),
+  'home': next => home(getOffset(next)),
+  'discussions': next => discussions(getOffset(next)),
+  'userFeed': next => getUserFeed(next.params.userName, getOffset(next)),
+  'userComments': next => getUserComments(next.params.userName, getOffset(next)),
+  'userLikes': next => getUserLikes(next.params.userName, getOffset(next)),
+  'post': next => getSinglePost(next.params.postId),
+  'direct': next => direct(getOffset(next)),
 }
 
 export const bindRouteActions = dispatch => route => next => {


### PR DESCRIPTION
Ping @kadmil @ujenjt. Any feedback is really appreciated.

* _b237f1f Don't reset current feed on transition request_
This fixes that annoying thing when user is waiting for a page to load and have to stare at a suddenly deserted feed behind the throbber.

* _8910670 Move scroll-to-top from transition request to transition response_
It makes more sense to scroll on response, when new data is received already, instead of jumping to top first and then making user wait for the page to load.