### PR TITLE
Fix display of default userpic for author on single-post page

### DIFF
--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -507,7 +507,7 @@ export function users(state = {}, action) {
       return mergeByIds(state, action.payload.users)
     }
     case response(ActionCreators.GET_SINGLE_POST): {
-      return mergeByIds(state, action.payload.users)
+      return mergeByIds(state, (action.payload.users || []).map(userParser))
     }
     case response(ActionCreators.SHOW_MORE_LIKES_ASYNC): {
       return mergeByIds(state, action.payload.users)


### PR DESCRIPTION
Before:

<img width="708" alt="2015-12-08 20-54-40 default-userpic-1" src="https://cloud.githubusercontent.com/assets/1071933/11666710/27d9c656-9dee-11e5-9855-03b528755bc7.png">

After:

<img width="706" alt="2015-12-08 20-55-17 default-userpic-2" src="https://cloud.githubusercontent.com/assets/1071933/11666715/2cff722a-9dee-11e5-892d-f608983d9caa.png">
