### PR TITLE
Add attachments on create-post and edit-post

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "0.14.3",
     "react-addons-test-utils": "^0.14.3",
     "react-dom": "0.14.3",
+    "react-dropzone-component": "^0.8.1",
     "react-linkify": "0.0.4",
     "react-google-recaptcha": "^0.5.2",
     "react-redux": "^4.0.0",

--- a/src/components/create-post.jsx
+++ b/src/components/create-post.jsx
@@ -27,6 +27,7 @@ export default class CreatePost extends React.Component {
     this.setState({
       disabled: true
     })
+    attachmentIds.forEach(attachmentId => this.props.removeAttachment(null, attachmentId))
   }
 
   isPostTextEmpty = (postText) => {

--- a/src/components/create-post.jsx
+++ b/src/components/create-post.jsx
@@ -3,6 +3,10 @@ import {preventDefault} from '../utils'
 import Textarea from 'react-textarea-autosize'
 import throbber from 'assets/images/throbber.gif'
 import SendTo from './send-to'
+import DropzoneComponent from 'react-dropzone-component'
+import {api as apiConfig} from '../config'
+import {getToken} from '../services/auth'
+import PostAttachments from './post-attachments'
 
 export default class CreatePost extends React.Component {
   constructor(props) {
@@ -15,9 +19,10 @@ export default class CreatePost extends React.Component {
   createPost = _ => {
     let postText = this.refs.postText.value
     let feeds = this.refs.selectFeeds.values
+    let attachmentIds = this.props.createPostForm.attachments.map(attachment => attachment.id)
 
-    this.props.createPost(postText, feeds)
-    
+    this.props.createPost(postText, feeds, attachmentIds)
+
     this.refs.postText.value = ''
     this.setState({
       disabled: true
@@ -49,44 +54,100 @@ export default class CreatePost extends React.Component {
   }
 
   render() {
+    let props = this.props
+
+    // DropzoneJS configuration
+    const dropzoneComponentConfig = {
+      postUrl: `${apiConfig.host}/v1/attachments`
+    }
+    const dropzoneConfig = {
+      dictDefaultMessage: 'Drop files here', // The message that gets displayed before any files are dropped.
+      previewsContainer: '.dropzone-previews', // Define the container to display the previews.
+      clickable: '.dropzone-trigger', // Define the element that should be used as click trigger to select files.
+      headers: {
+        'Cache-Control': null,
+        'X-Authentication-Token': getToken()
+      }
+    }
+    const dropzoneEventHandlers = {
+      // DropzoneJS uses stopPropagation() for dragenter and drop events, so
+      // they are not being propagated to window and it breaks crafty handling
+      // of those events we have in the Layout component. So here we have to
+      // re-dispatch them to let event handlers in Layout work as they should.
+      // The events don't need to be real, just mimic some important parts.
+      dragenter: function(e) {
+        var dragEnterEvent = new Event('dragenter')
+        if (e.dataTransfer && e.dataTransfer.types) {
+          dragEnterEvent.dataTransfer = { types: e.dataTransfer.types }
+        }
+        window.dispatchEvent(dragEnterEvent)
+      },
+      drop: function(e) {
+        var dropEvent = new Event('drop')
+        if (e.dataTransfer && e.dataTransfer.types) {
+          dropEvent.dataTransfer = { types: e.dataTransfer.types }
+        }
+        window.dispatchEvent(dropEvent)
+      },
+
+      success: function(file, response) {
+        // 'attachments' in this response will be an attachment object, not an array of objects
+        props.addAttachmentResponse(null, response.attachments)
+      }
+    }
+
     return (
-      <div className='create-post p-timeline-post-create'>
-        <div className='p-create-post-view'>
+      <div className="create-post post-editor">
+        <div>
           {this.props.sendTo.expanded ? (
             <SendTo ref="selectFeeds"
-                    feeds={this.props.sendTo.feeds}
-                    user={this.props.user} 
-                    onChange={this.checkCreatePostAvailability}/>
+              feeds={this.props.sendTo.feeds}
+              user={this.props.user}
+              onChange={this.checkCreatePostAvailability}/>
           ) : false}
 
-          <Textarea className='edit-post-area'
-                    ref='postText'
-                    onChange={this.checkCreatePostAvailability}
-                    minRows={3}
-                    maxRows={10}
-                    onKeyDown={this.checkSave}
-                    onFocus={this.props.expandSendTo}/>
+          <DropzoneComponent
+            config={dropzoneComponentConfig}
+            djsConfig={dropzoneConfig}
+            eventHandlers={dropzoneEventHandlers}/>
+
+          <Textarea
+            className="post-textarea"
+            ref="postText"
+            onChange={this.checkCreatePostAvailability}
+            minRows={3}
+            maxRows={10}
+            onKeyDown={this.checkSave}
+            onFocus={this.props.expandSendTo}/>
         </div>
-          <div className='row'>
-            <div className='pull-right'>
 
-              {this.props.createPostViewState.isPending ? (
-                <span className="throbber">
-                  <img width="16" height="16" src={throbber}/>
-                </span>
-              ) : false}
+        <div className="post-edit-attachments dropzone-trigger">
+          <i className="fa fa-cloud-upload"></i>
+          {' '}
+          Add photos or files
+        </div>
 
-              <button className='btn btn-default btn-xs create-post-action'
-                      onClick={preventDefault(this.createPost)}
-                      disabled={this.state.disabled || this.props.createPostViewState.isPending}>Post</button>
-            </div>
-          </div>
-
-          {this.props.createPostViewState.isError ? (
-            <div className='create-post-error'>
-              {this.props.createPostViewState.errorString}
-            </div>
+        <div className="post-edit-actions">
+          {this.props.createPostViewState.isPending ? (
+            <span className="throbber">
+              <img width="16" height="16" src={throbber}/>
+            </span>
           ) : false}
+
+          <button className="btn btn-default btn-xs"
+            onClick={preventDefault(this.createPost)}
+            disabled={this.state.disabled || this.props.createPostViewState.isPending}>Post</button>
+        </div>
+
+        <PostAttachments attachments={this.props.createPostForm.attachments}/>
+
+        <div className="dropzone-previews"></div>
+
+        {this.props.createPostViewState.isError ? (
+          <div className="create-post-error">
+            {this.props.createPostViewState.errorString}
+          </div>
+        ) : false}
       </div>
     )
   }

--- a/src/components/feed-post.jsx
+++ b/src/components/feed-post.jsx
@@ -18,7 +18,7 @@ import {getToken} from '../services/auth'
 
 export default class FeedPost extends React.Component {
   render() {
-    let props = this.props;
+    let props = this.props
 
     const createdAt = new Date(props.createdAt - 0)
     const createdAtISO = moment(createdAt).format()
@@ -71,7 +71,7 @@ export default class FeedPost extends React.Component {
       postUrl: `${apiConfig.host}/v1/attachments`
     }
     const dropzoneConfig = {
-      dictDefaultMessage: '^', // The message that gets displayed before any files are dropped.
+      dictDefaultMessage: 'Drop files here', // The message that gets displayed before any files are dropped.
       previewsContainer: '.dropzone-previews', // Define the container to display the previews.
       clickable: '.dropzone-trigger', // Define the element that should be used as click trigger to select files.
       headers: {
@@ -80,7 +80,20 @@ export default class FeedPost extends React.Component {
       }
     }
     const dropzoneEventHandlers = {
-      success: function (file, response) {
+      // DropzoneJS uses stopPropagation() for dragenter and drop events, so
+      // they are not being propagated to window and it breaks crafty handling
+      // of those events we have in the Layout component. So here we have to
+      // re-dispatch them to let event handlers in Layout work as they should.
+      dragenter: function() {
+        var dragEnterEvent = new DragEvent('dragenter')
+        window.dispatchEvent(dragEnterEvent)
+      },
+      drop: function() {
+        var dropEvent = new DragEvent('drop')
+        window.dispatchEvent(dropEvent)
+      },
+
+      success: function(file, response) {
         // 'attachments' in this response will be an attachment object, not an array of objects
         props.addAttachmentResponse(props.id, response.attachments)
       }
@@ -101,7 +114,12 @@ export default class FeedPost extends React.Component {
           </div>
 
           {props.isEditing ? (
-            <div>
+            <div className="post-editor">
+              <DropzoneComponent
+                config={dropzoneComponentConfig}
+                djsConfig={dropzoneConfig}
+                eventHandlers={dropzoneEventHandlers}/>
+
               <div>
                 <Textarea
                   className="post-textarea"
@@ -112,14 +130,11 @@ export default class FeedPost extends React.Component {
                   maxRows={10}/>
               </div>
 
-              <div className="post-edit-add-attachments">
-                <DropzoneComponent
-                  config={dropzoneComponentConfig}
-                  djsConfig={dropzoneConfig}
-                  eventHandlers={dropzoneEventHandlers}/>
+              <div className="post-edit-attachments dropzone-trigger">
+                <i className="fa fa-cloud-upload"></i>
+                {' '}
+                Add photos or files
               </div>
-
-              <div className="dropzone-trigger">Add photos or files</div>
 
               <div className="post-edit-actions">
                 {props.isSaving ? (

--- a/src/components/feed-post.jsx
+++ b/src/components/feed-post.jsx
@@ -12,6 +12,9 @@ import {preventDefault} from '../utils'
 import PieceOfText from './piece-of-text'
 import Textarea from 'react-textarea-autosize'
 import throbber16 from 'assets/images/throbber-16.gif'
+import DropzoneComponent from 'react-dropzone-component'
+import {api as apiConfig} from '../config'
+import {getToken} from '../services/auth'
 
 export default (props) => {
   const createdAt = new Date(props.createdAt - 0)
@@ -55,6 +58,26 @@ export default (props) => {
   const directReceivers = props.directReceivers
                                 .map((receiver, index) => ( <span key={index}><UserName className='post-addressee post-addressee-direct' user={receiver}/>{index !== props.directReceivers.length -1 ? ',' : false}</span>))
 
+  // DropzoneJS configuration
+  const dropzoneComponentConfig = {
+    postUrl: `${apiConfig.host}/v1/attachments`
+  }
+  const dropzoneConfig = {
+    dictDefaultMessage: '^', // The message that gets displayed before any files are dropped.
+    previewsContainer: '.dropzone-previews', // Define the container to display the previews.
+    clickable: '.dropzone-trigger', // Define the element that should be used as click trigger to select files.
+    headers: {
+      'Cache-Control': null,
+      'X-Authentication-Token': getToken()
+    }
+  }
+  const dropzoneEventHandlers = {
+    success: function(file, response) {
+      // 'attachments' in this response will be an attachment object, not an array of objects
+      props.addAttachmentResponse(props.id, response.attachments)
+    }
+  }
+
   return (
     <div className={postClass}>
       <div className="post-userpic">
@@ -81,6 +104,12 @@ export default (props) => {
                 maxRows={10}/>
             </div>
 
+            <div className="post-edit-add-attachments">
+              <DropzoneComponent config={dropzoneComponentConfig} djsConfig={dropzoneConfig} eventHandlers={dropzoneEventHandlers}/>
+            </div>
+
+            <div className="dropzone-trigger">Add photos or files</div>
+
             <div className="post-edit-actions">
               {props.isSaving ? (
                 <span className="post-edit-throbber">
@@ -98,6 +127,8 @@ export default (props) => {
         )}
 
         <PostAttachments attachments={props.attachments}/>
+
+        <div className="dropzone-previews"></div>
 
         <div className="post-footer">
           {props.isDirect ? (<span>»&nbsp;</span>) : false}

--- a/src/components/feed-post.jsx
+++ b/src/components/feed-post.jsx
@@ -16,164 +16,176 @@ import DropzoneComponent from 'react-dropzone-component'
 import {api as apiConfig} from '../config'
 import {getToken} from '../services/auth'
 
-export default (props) => {
-  const createdAt = new Date(props.createdAt - 0)
-  const createdAtISO = moment(createdAt).format()
-  const createdAgo = fromNowOrNow(createdAt)
+export default class FeedPost extends React.Component {
+  render() {
+    let props = this.props;
 
-  let editingPostText = props.editingText
-  let editingPostTextChange = (e) => {
-    editingPostText = e.target.value
-  }
-  const toggleEditingPost = () => props.toggleEditingPost(props.id, editingPostText)
-  const cancelEditingPost = () => props.cancelEditingPost(props.id, editingPostText)
-  const saveEditingPost = () => {
-    if (!props.isSaving) {
-      let attachmentIds = props.attachments.map(item => item.id) || []
-      props.saveEditingPost(props.id, { body: editingPostText, attachments: attachmentIds })
+    const createdAt = new Date(props.createdAt - 0)
+    const createdAtISO = moment(createdAt).format()
+    const createdAgo = fromNowOrNow(createdAt)
+
+    let editingPostText = props.editingText
+    let editingPostTextChange = (e) => {
+      editingPostText = e.target.value
     }
-  }
-  const deletePost = () => props.deletePost(props.id)
-  const likePost = () => props.likePost(props.id, props.user.id)
-  const unlikePost = () => props.unlikePost(props.id, props.user.id)
-  const checkSave = (event) => {
-    const isEnter = event.keyCode === 13
-    if (isEnter) {
-      event.preventDefault()
-      saveEditingPost()
+    const toggleEditingPost = () => props.toggleEditingPost(props.id, editingPostText)
+    const cancelEditingPost = () => props.cancelEditingPost(props.id, editingPostText)
+    const saveEditingPost = () => {
+      if (!props.isSaving) {
+        let attachmentIds = props.attachments.map(item => item.id) || []
+        props.saveEditingPost(props.id, {body: editingPostText, attachments: attachmentIds})
+      }
     }
-  }
-  const ILikedPost = _.find(props.usersLikedPost, {id:props.user.id})
-  const profilePicture = props.isSinglePost ?
-    props.createdBy.profilePictureLargeUrl : props.createdBy.profilePictureMediumUrl
-  const postClass = classnames({
-    'post': true,
-    'single-post': props.isSinglePost,
-    'timeline-post': !props.isSinglePost,
-    'direct-post': props.isDirect
-  })
-
-  const toggleCommenting = props.isSinglePost ? () => {} : () => props.toggleCommenting(props.id)
-
-  const directReceivers = props.directReceivers
-                                .map((receiver, index) => ( <span key={index}><UserName className='post-addressee post-addressee-direct' user={receiver}/>{index !== props.directReceivers.length -1 ? ',' : false}</span>))
-
-  // DropzoneJS configuration
-  const dropzoneComponentConfig = {
-    postUrl: `${apiConfig.host}/v1/attachments`
-  }
-  const dropzoneConfig = {
-    dictDefaultMessage: '^', // The message that gets displayed before any files are dropped.
-    previewsContainer: '.dropzone-previews', // Define the container to display the previews.
-    clickable: '.dropzone-trigger', // Define the element that should be used as click trigger to select files.
-    headers: {
-      'Cache-Control': null,
-      'X-Authentication-Token': getToken()
+    const deletePost = () => props.deletePost(props.id)
+    const likePost = () => props.likePost(props.id, props.user.id)
+    const unlikePost = () => props.unlikePost(props.id, props.user.id)
+    const checkSave = (event) => {
+      const isEnter = event.keyCode === 13
+      if (isEnter) {
+        event.preventDefault()
+        saveEditingPost()
+      }
     }
-  }
-  const dropzoneEventHandlers = {
-    success: function(file, response) {
-      // 'attachments' in this response will be an attachment object, not an array of objects
-      props.addAttachmentResponse(props.id, response.attachments)
+    const ILikedPost = _.find(props.usersLikedPost, {id: props.user.id})
+    const profilePicture = props.isSinglePost ?
+      props.createdBy.profilePictureLargeUrl : props.createdBy.profilePictureMediumUrl
+    const postClass = classnames({
+      'post': true,
+      'single-post': props.isSinglePost,
+      'timeline-post': !props.isSinglePost,
+      'direct-post': props.isDirect
+    })
+
+    const toggleCommenting = props.isSinglePost ? () => {
+    } : () => props.toggleCommenting(props.id)
+
+    const directReceivers = props.directReceivers.map((receiver, index) => (
+      <span key={index}>
+        <UserName className="post-addressee post-addressee-direct" user={receiver}/>
+        {index !== props.directReceivers.length - 1 ? ',' : false}
+      </span>
+    ))
+
+    // DropzoneJS configuration
+    const dropzoneComponentConfig = {
+      postUrl: `${apiConfig.host}/v1/attachments`
     }
-  }
+    const dropzoneConfig = {
+      dictDefaultMessage: '^', // The message that gets displayed before any files are dropped.
+      previewsContainer: '.dropzone-previews', // Define the container to display the previews.
+      clickable: '.dropzone-trigger', // Define the element that should be used as click trigger to select files.
+      headers: {
+        'Cache-Control': null,
+        'X-Authentication-Token': getToken()
+      }
+    }
+    const dropzoneEventHandlers = {
+      success: function (file, response) {
+        // 'attachments' in this response will be an attachment object, not an array of objects
+        props.addAttachmentResponse(props.id, response.attachments)
+      }
+    }
 
-  return (
-    <div className={postClass}>
-      <div className="post-userpic">
-        <Link to={`/${props.createdBy.username}`}>
-          <img src={profilePicture}/>
-        </Link>
-      </div>
-      <div className="post-body">
-        <div className="post-header">
-          <UserName className="post-author" user={props.createdBy}/>
-          {props.isDirect ? (<span>&nbsp;to&nbsp;</span>) : false}
-          {props.isDirect ? directReceivers : false}
-        </div>
-
-        {props.isEditing ? (
-          <div>
-            <div>
-              <Textarea
-                className="post-textarea"
-                defaultValue={props.editingText}
-                onKeyDown={checkSave}
-                onChange={editingPostTextChange}
-                minRows={2}
-                maxRows={10}/>
-            </div>
-
-            <div className="post-edit-add-attachments">
-              <DropzoneComponent config={dropzoneComponentConfig} djsConfig={dropzoneConfig} eventHandlers={dropzoneEventHandlers}/>
-            </div>
-
-            <div className="dropzone-trigger">Add photos or files</div>
-
-            <div className="post-edit-actions">
-              {props.isSaving ? (
-                <span className="post-edit-throbber">
-                  <img width="16" height="16" src={throbber16}/>
-                </span>
-              ) : false}
-              <a className="post-cancel" onClick={preventDefault(cancelEditingPost)}>Cancel</a>
-              <button className="btn btn-default btn-xs" onClick={preventDefault(saveEditingPost)}>Update</button>
-            </div>
-          </div>
-        ) : (
-          <div className="post-text">
-            <PieceOfText text={props.body}/>
-          </div>
-        )}
-
-        <PostAttachments attachments={props.attachments}/>
-
-        <div className="dropzone-previews"></div>
-
-        <div className="post-footer">
-          {props.isDirect ? (<span>»&nbsp;</span>) : false}
-          <Link to={`/${props.createdBy.username}/${props.id}`} className="post-timestamp">
-            <time dateTime={createdAtISO} title={createdAtISO}>{createdAgo}</time>
+    return (
+      <div className={postClass}>
+        <div className="post-userpic">
+          <Link to={`/${props.createdBy.username}`}>
+            <img src={profilePicture}/>
           </Link>
-          {' - '}
-          <a onClick={preventDefault(toggleCommenting)}>Comment</a>
-          {' - '}
-          <a onClick={preventDefault(ILikedPost ? unlikePost : likePost)}>{ILikedPost ? 'Un-like' : 'Like'}</a>
-          {props.isLiking ? (
-            <span className="post-like-throbber">
-              <img width="16" height="16" src={throbber16}/>
-            </span>
-          ) : false}
-          {props.isEditable ? (
-            <span>
-              {' - '}
-              <a onClick={preventDefault(toggleEditingPost)}>Edit</a>
-              {' - '}
-              <a onClick={preventDefault(deletePost)}>Delete</a>
-            </span>
-          ) : false}
         </div>
-
-        {props.isError ? (
-          <div className='post-error'>
-            {props.errorString}
+        <div className="post-body">
+          <div className="post-header">
+            <UserName className="post-author" user={props.createdBy}/>
+            {props.isDirect ? (<span>&nbsp;to&nbsp;</span>) : false}
+            {props.isDirect ? directReceivers : false}
           </div>
-        ) : false}
 
-        <PostLikes
-          post={props}
-          likes={props.usersLikedPost}
-          showMoreLikes={props.showMoreLikes}/>
+          {props.isEditing ? (
+            <div>
+              <div>
+                <Textarea
+                  className="post-textarea"
+                  defaultValue={props.editingText}
+                  onKeyDown={checkSave}
+                  onChange={editingPostTextChange}
+                  minRows={2}
+                  maxRows={10}/>
+              </div>
 
-        <PostComments
-          post={props}
-          comments={props.comments}
-          creatingNewComment={props.isCommenting}
-          addComment={props.addComment}
-          toggleCommenting={props.toggleCommenting}
-          showMoreComments={props.showMoreComments}
-          commentEdit={props.commentEdit}/>
+              <div className="post-edit-add-attachments">
+                <DropzoneComponent
+                  config={dropzoneComponentConfig}
+                  djsConfig={dropzoneConfig}
+                  eventHandlers={dropzoneEventHandlers}/>
+              </div>
+
+              <div className="dropzone-trigger">Add photos or files</div>
+
+              <div className="post-edit-actions">
+                {props.isSaving ? (
+                  <span className="post-edit-throbber">
+                    <img width="16" height="16" src={throbber16}/>
+                  </span>
+                ) : false}
+                <a className="post-cancel" onClick={preventDefault(cancelEditingPost)}>Cancel</a>
+                <button className="btn btn-default btn-xs" onClick={preventDefault(saveEditingPost)}>Update</button>
+              </div>
+            </div>
+          ) : (
+            <div className="post-text">
+              <PieceOfText text={props.body}/>
+            </div>
+          )}
+
+          <PostAttachments attachments={props.attachments}/>
+
+          <div className="dropzone-previews"></div>
+
+          <div className="post-footer">
+            {props.isDirect ? (<span>»&nbsp;</span>) : false}
+            <Link to={`/${props.createdBy.username}/${props.id}`} className="post-timestamp">
+              <time dateTime={createdAtISO} title={createdAtISO}>{createdAgo}</time>
+            </Link>
+            {' - '}
+            <a onClick={preventDefault(toggleCommenting)}>Comment</a>
+            {' - '}
+            <a onClick={preventDefault(ILikedPost ? unlikePost : likePost)}>{ILikedPost ? 'Un-like' : 'Like'}</a>
+            {props.isLiking ? (
+              <span className="post-like-throbber">
+                <img width="16" height="16" src={throbber16}/>
+              </span>
+            ) : false}
+            {props.isEditable ? (
+              <span>
+                {' - '}
+                <a onClick={preventDefault(toggleEditingPost)}>Edit</a>
+                {' - '}
+                <a onClick={preventDefault(deletePost)}>Delete</a>
+              </span>
+            ) : false}
+          </div>
+
+          {props.isError ? (
+            <div className='post-error'>
+              {props.errorString}
+            </div>
+          ) : false}
+
+          <PostLikes
+            post={props}
+            likes={props.usersLikedPost}
+            showMoreLikes={props.showMoreLikes}/>
+
+          <PostComments
+            post={props}
+            comments={props.comments}
+            creatingNewComment={props.isCommenting}
+            addComment={props.addComment}
+            toggleCommenting={props.toggleCommenting}
+            showMoreComments={props.showMoreComments}
+            commentEdit={props.commentEdit}/>
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 }

--- a/src/components/feed-post.jsx
+++ b/src/components/feed-post.jsx
@@ -84,12 +84,19 @@ export default class FeedPost extends React.Component {
       // they are not being propagated to window and it breaks crafty handling
       // of those events we have in the Layout component. So here we have to
       // re-dispatch them to let event handlers in Layout work as they should.
-      dragenter: function() {
-        var dragEnterEvent = new DragEvent('dragenter')
+      // The events don't need to be real, just mimic some important parts.
+      dragenter: function(e) {
+        var dragEnterEvent = new Event('dragenter')
+        if (e.dataTransfer && e.dataTransfer.types) {
+          dragEnterEvent.dataTransfer = { types: e.dataTransfer.types }
+        }
         window.dispatchEvent(dragEnterEvent)
       },
-      drop: function() {
-        var dropEvent = new DragEvent('drop')
+      drop: function(e) {
+        var dropEvent = new Event('drop')
+        if (e.dataTransfer && e.dataTransfer.types) {
+          dropEvent.dataTransfer = { types: e.dataTransfer.types }
+        }
         window.dispatchEvent(dropEvent)
       },
 

--- a/src/components/home-feed.jsx
+++ b/src/components/home-feed.jsx
@@ -12,6 +12,7 @@ export default (props) => {
               cancelEditingPost={props.cancelEditingPost}
               saveEditingPost={props.saveEditingPost}
               deletePost={props.deletePost}
+              addAttachmentResponse={props.addAttachmentResponse}
               toggleCommenting={props.toggleCommenting}
               addComment={props.addComment}
               likePost={props.likePost}

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -17,7 +17,8 @@ const FeedHandler = (props) => {
       createPost={props.createPost}
       expandSendTo={props.expandSendTo}
       createPostForm={props.createPostForm}
-      addAttachmentResponse={props.addAttachmentResponse}/>
+      addAttachmentResponse={props.addAttachmentResponse}
+      removeAttachment={props.removeAttachment}/>
   )
 
   return (

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {connect} from 'react-redux'
 import {createPost, expandSendTo} from '../redux/action-creators'
-import {joinPostData, postActions} from './select-utils'
+import {joinPostData, joinCreatePostData, postActions} from './select-utils'
 import {getQuery} from '../utils'
 
 import CreatePost from './create-post'
@@ -9,18 +9,23 @@ import HomeFeed from './home-feed'
 import PaginatedView from './paginated-view'
 
 const FeedHandler = (props) => {
-  const createPostForm = (<CreatePost createPostViewState={props.createPostViewState}
-                                      sendTo={props.sendTo}
-                                      user={props.user}
-                                      createPost={props.createPost}
-                                      expandSendTo={props.expandSendTo} />)
+  const createPostComponent = (
+    <CreatePost
+      createPostViewState={props.createPostViewState}
+      sendTo={props.sendTo}
+      user={props.user}
+      createPost={props.createPost}
+      expandSendTo={props.expandSendTo}
+      createPostForm={props.createPostForm}
+      addAttachmentResponse={props.addAttachmentResponse}/>
+  )
 
   return (
     <div className='box'>
       <div className='box-header-timeline'>
         {props.boxHeader}
       </div>
-      <PaginatedView firstPageHead={createPostForm}>
+      <PaginatedView firstPageHead={createPostComponent}>
         {props.feed && props.feed.length ? <HomeFeed {...props}/> : false}
       </PaginatedView>
       <div className='box-footer'>
@@ -32,17 +37,18 @@ function selectState(state) {
   const user = state.user
   const feed = state.feedViewState.feed.map(joinPostData(state))
   const createPostViewState = state.createPostViewState
+  const createPostForm = joinCreatePostData(state)
   const timelines = state.timelines
   const boxHeader = state.boxHeader
   const sendTo = state.sendTo
 
-  return { feed, user, timelines, createPostViewState, boxHeader, sendTo }
+  return { feed, user, timelines, createPostViewState, createPostForm, boxHeader, sendTo }
 }
 
 function selectActions(dispatch) {
   return {
     ...postActions(dispatch),
-    createPost: (postText, feeds) => dispatch(createPost(postText, feeds)),
+    createPost: (postText, feeds, attachmentIds) => dispatch(createPost(postText, feeds, attachmentIds)),
     expandSendTo: () => dispatch(expandSendTo())
   }
 }

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -38,7 +38,13 @@ class Layout extends React.Component {
 
   containsFiles(e) {
     if (e.dataTransfer && e.dataTransfer.types) {
-      return (e.dataTransfer.types.indexOf('Files') !== -1)
+      // Event.dataTransfer.types is DOMStringList (not Array) in Firefox,
+      // so we can't just use indexOf().
+      for (let i=0; i<e.dataTransfer.types.length; i++) {
+        if (e.dataTransfer.types[i] === 'Files') {
+          return true
+        }
+      }
     }
     return false
   }

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Link} from 'react-router'
-import {connect } from 'react-redux'
+import {connect} from 'react-redux'
+import classnames from 'classnames'
 
 import {unauthenticated} from '../redux/action-creators'
 import Footer from './footer'
@@ -17,11 +18,68 @@ const InternalLayout = ({authenticated, children}) => (
 
 
 class Layout extends React.Component {
+  // Here we have some handling of drag-n-drop, because standard dragenter
+  // and dragleave events suck. Current implementation is using ideas from
+  // Ben Smithett, see http://bensmithett.github.io/dragster/ for details
+
+  constructor(props) {
+    super(props)
+
+    this.state = { isDragOver: false }
+
+    this.handleDragEnter = this.handleDragEnter.bind(this)
+    this.handleDragLeave = this.handleDragLeave.bind(this)
+
+    this.dragFirstLevel = false
+    this.dragSecondLevel = false
+  }
+
+  handleDragEnter(e) {
+    if (this.dragFirstLevel) {
+      this.dragSecondLevel = true
+      return
+    }
+    this.dragFirstLevel = true
+
+    this.setState({ isDragOver: true })
+
+    e.preventDefault()
+  }
+
+  handleDragLeave(e) {
+    if (this.dragSecondLevel) {
+      this.dragSecondLevel = false
+    } else if (this.dragFirstLevel) {
+      this.dragFirstLevel = false
+    }
+
+    if (!this.dragFirstLevel && !this.dragSecondLevel) {
+      this.setState({ isDragOver: false })
+    }
+
+    e.preventDefault()
+  }
+
+  componentDidMount() {
+    window.addEventListener('dragenter', this.handleDragEnter)
+    window.addEventListener('dragleave', this.handleDragLeave)
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('dragenter', this.handleDragEnter)
+    window.removeEventListener('dragleave', this.handleDragLeave)
+  }
+
   render() {
     let props = this.props
 
+    let layoutClassNames = classnames({
+      'container': true,
+      'dragover': this.state.isDragOver
+    })
+
     return (
-      <div className='container'>
+      <div className={layoutClassNames}>
         <div className='row header-row'>
           <div className='col-md-4'>
             <div className='header'>

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -29,6 +29,7 @@ class Layout extends React.Component {
 
     this.handleDragEnter = this.handleDragEnter.bind(this)
     this.handleDragLeave = this.handleDragLeave.bind(this)
+    this.handleDragOver = this.handleDragOver.bind(this)
     this.handleDrop = this.handleDrop.bind(this)
 
     this.dragFirstLevel = false
@@ -43,43 +44,49 @@ class Layout extends React.Component {
   }
 
   handleDragEnter(e) {
-    if (this.dragFirstLevel) {
-      this.dragSecondLevel = true
-      return
-    }
-    this.dragFirstLevel = true
-
     if (this.containsFiles(e)) {
-      this.setState({ isDragOver: true })
-    }
+      if (this.dragFirstLevel) {
+        this.dragSecondLevel = true
+        return
+      }
+      this.dragFirstLevel = true
 
-    e.preventDefault()
+      this.setState({ isDragOver: true })
+
+      e.preventDefault()
+    }
   }
 
   handleDragLeave(e) {
-    if (this.dragSecondLevel) {
-      this.dragSecondLevel = false
-    } else if (this.dragFirstLevel) {
-      this.dragFirstLevel = false
-    }
+    if (this.containsFiles(e)) {
+      if (this.dragSecondLevel) {
+        this.dragSecondLevel = false
+      } else if (this.dragFirstLevel) {
+        this.dragFirstLevel = false
+      }
 
-    if (!this.dragFirstLevel && !this.dragSecondLevel) {
-      this.setState({ isDragOver: false })
-    }
+      if (!this.dragFirstLevel && !this.dragSecondLevel) {
+        this.setState({ isDragOver: false })
+      }
 
-    e.preventDefault()
+      e.preventDefault()
+    }
   }
 
   // Prevent browser from loading the file if user drops it outside of a dropzone
   // (both `handleDragOver` and `handleDrop` are necessary)
   handleDragOver(e) {
-    e.preventDefault()
+    if (this.containsFiles(e)) {
+      e.preventDefault()
+    }
   }
   handleDrop(e) {
-    this.setState({ isDragOver: false })
-    this.dragFirstLevel = false
-    this.dragSecondLevel = false
-    e.preventDefault()
+    if (this.containsFiles(e)) {
+      this.setState({ isDragOver: false })
+      this.dragFirstLevel = false
+      this.dragSecondLevel = false
+      e.preventDefault()
+    }
   }
 
   componentDidMount() {

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -29,6 +29,7 @@ class Layout extends React.Component {
 
     this.handleDragEnter = this.handleDragEnter.bind(this)
     this.handleDragLeave = this.handleDragLeave.bind(this)
+    this.handleDrop = this.handleDrop.bind(this)
 
     this.dragFirstLevel = false
     this.dragSecondLevel = false
@@ -60,14 +61,30 @@ class Layout extends React.Component {
     e.preventDefault()
   }
 
+  // Prevent browser from loading the file if user drops it outside of a dropzone
+  // (both `handleDragOver` and `handleDrop` are necessary)
+  handleDragOver(e) {
+    e.preventDefault()
+  }
+  handleDrop(e) {
+    this.setState({ isDragOver: false })
+    this.dragFirstLevel = false
+    this.dragSecondLevel = false
+    e.preventDefault()
+  }
+
   componentDidMount() {
     window.addEventListener('dragenter', this.handleDragEnter)
     window.addEventListener('dragleave', this.handleDragLeave)
+    window.addEventListener('dragover', this.handleDragOver)
+    window.addEventListener('drop', this.handleDrop)
   }
 
   componentWillUnmount() {
     window.removeEventListener('dragenter', this.handleDragEnter)
     window.removeEventListener('dragleave', this.handleDragLeave)
+    window.removeEventListener('dragover', this.handleDragOver)
+    window.removeEventListener('drop', this.handleDrop)
   }
 
   render() {

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -16,50 +16,56 @@ const InternalLayout = ({authenticated, children}) => (
 )
 
 
-const Layout = (props) => (
-  <div className='container'>
-    <div className='row header-row'>
-      <div className='col-md-4'>
-        <div className='header'>
-          <h1 className='title'>
-            <Link to='/'>FreeFeed-beta</Link>
-          </h1>
-        </div>
-      </div>
+class Layout extends React.Component {
+  render() {
+    let props = this.props
 
-      <div className='col-md-8'>
-        <div className='row'>
-          <div className='col-md-6 search-field'>
-            <div className='form-inline'>
-            {/*<input className='form-control input-sm search-input p-search-input' />
-            <button className='btn btn-default btn-sm p-search-action'>Search</button>*/}
+    return (
+      <div className='container'>
+        <div className='row header-row'>
+          <div className='col-md-4'>
+            <div className='header'>
+              <h1 className='title'>
+                <Link to='/'>FreeFeed-beta</Link>
+              </h1>
             </div>
           </div>
-          <div className='col-md-6'>
-            {props.authenticated ? false : (
-              <div className='signin-toolbar'>
-                <Link to='/signin'>Sign In</Link>
+
+          <div className='col-md-8'>
+            <div className='row'>
+              <div className='col-md-6 search-field'>
+                <div className='form-inline'>
+                {/*<input className='form-control input-sm search-input p-search-input' />
+                <button className='btn btn-default btn-sm p-search-action'>Search</button>*/}
+                </div>
               </div>
-            )}
+              <div className='col-md-6'>
+                {props.authenticated ? false : (
+                  <div className='signin-toolbar'>
+                    <Link to='/signin'>Sign In</Link>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <LoaderContainer loading={props.loadingView} fullPage={true}>
+          <div className='row'>
+            <InternalLayout {...props}/>
+            {props.authenticated ? <Sidebar {...props}/> : false}
+          </div>
+        </LoaderContainer>
+
+        <div className='row'>
+          <div className='col-md-12'>
+          <Footer/>
           </div>
         </div>
       </div>
-    </div>
-
-    <LoaderContainer loading={props.loadingView} fullPage={true}>
-      <div className='row'>
-        <InternalLayout {...props}/>
-        {props.authenticated ? <Sidebar {...props}/> : false}
-      </div>
-    </LoaderContainer>
-
-    <div className='row'>
-      <div className='col-md-12'>
-      <Footer/>
-      </div>
-    </div>
-  </div>
-)
+    )
+  }
+}
 
 function select(state) {
   return {

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -35,6 +35,13 @@ class Layout extends React.Component {
     this.dragSecondLevel = false
   }
 
+  containsFiles(e) {
+    if (e.dataTransfer && e.dataTransfer.types) {
+      return (e.dataTransfer.types.indexOf('Files') !== -1)
+    }
+    return false
+  }
+
   handleDragEnter(e) {
     if (this.dragFirstLevel) {
       this.dragSecondLevel = true
@@ -42,7 +49,9 @@ class Layout extends React.Component {
     }
     this.dragFirstLevel = true
 
-    this.setState({ isDragOver: true })
+    if (this.containsFiles(e)) {
+      this.setState({ isDragOver: true })
+    }
 
     e.preventDefault()
   }

--- a/src/components/select-utils.js
+++ b/src/components/select-utils.js
@@ -1,5 +1,5 @@
 import {showMoreComments, showMoreLikes, toggleEditingPost, cancelEditingPost,
-        saveEditingPost, deletePost, likePost, unlikePost, toggleCommenting, addComment,
+        saveEditingPost, deletePost, addAttachmentResponse, likePost, unlikePost, toggleCommenting, addComment,
         toggleEditingComment, cancelEditingComment, saveEditingComment, deleteComment,
         ban, unban, subscribe, unsubscribe, } from '../redux/action-creators'
 
@@ -57,6 +57,7 @@ export function postActions(dispatch) {
     addComment:(postId, commentText) => dispatch(addComment(postId, commentText)),
     likePost: (postId, userId) => dispatch(likePost(postId, userId)),
     unlikePost: (postId, userId) => dispatch(unlikePost(postId, userId)),
+    addAttachmentResponse:(postId, attachments) => dispatch(addAttachmentResponse(postId, attachments)),
     commentEdit: {
       toggleEditingComment: (commentId) => dispatch(toggleEditingComment(commentId)),
       saveEditingComment: (commentId, newValue) => dispatch(saveEditingComment(commentId, newValue)),

--- a/src/components/select-utils.js
+++ b/src/components/select-utils.js
@@ -45,6 +45,13 @@ export const joinPostData = state => postId => {
   return { ...post, attachments, comments, usersLikedPost, createdBy, ...postViewState, isEditable, isDirect, directReceivers }
 }
 
+export function joinCreatePostData(state) {
+  const createPostForm = state.createPostForm
+  return {...createPostForm,
+    attachments: (createPostForm.attachments || []).map(attachmentId => state.attachments[attachmentId])
+  }
+}
+
 export function postActions(dispatch) {
   return {
     showMoreComments: (postId) => dispatch(showMoreComments(postId)),

--- a/src/components/select-utils.js
+++ b/src/components/select-utils.js
@@ -1,5 +1,6 @@
 import {showMoreComments, showMoreLikes, toggleEditingPost, cancelEditingPost,
-        saveEditingPost, deletePost, addAttachmentResponse, likePost, unlikePost, toggleCommenting, addComment,
+        saveEditingPost, deletePost, addAttachmentResponse, removeAttachment,
+        likePost, unlikePost, toggleCommenting, addComment,
         toggleEditingComment, cancelEditingComment, saveEditingComment, deleteComment,
         ban, unban, subscribe, unsubscribe, } from '../redux/action-creators'
 
@@ -65,6 +66,7 @@ export function postActions(dispatch) {
     likePost: (postId, userId) => dispatch(likePost(postId, userId)),
     unlikePost: (postId, userId) => dispatch(unlikePost(postId, userId)),
     addAttachmentResponse:(postId, attachments) => dispatch(addAttachmentResponse(postId, attachments)),
+    removeAttachment:(postId, attachmentId) => dispatch(removeAttachment(postId, attachmentId)),
     commentEdit: {
       toggleEditingComment: (commentId) => dispatch(toggleEditingComment(commentId)),
       saveEditingComment: (commentId, newValue) => dispatch(saveEditingComment(commentId, newValue)),

--- a/src/components/single-post.jsx
+++ b/src/components/single-post.jsx
@@ -26,6 +26,7 @@ const SinglePostHandler = (props) => {
                   cancelEditingPost={props.cancelEditingPost}
                   saveEditingPost={props.saveEditingPost}
                   deletePost={props.deletePost}
+                  addAttachmentResponse={props.addAttachmentResponse}
                   toggleCommenting={props.toggleCommenting}
                   addComment={props.addComment}
                   likePost={props.likePost}

--- a/src/components/user-feed.jsx
+++ b/src/components/user-feed.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {connect} from 'react-redux'
 import {createPost, expandSendTo} from '../redux/action-creators'
-import {joinPostData, postActions, userActions} from './select-utils'
+import {joinPostData, joinCreatePostData, postActions, userActions} from './select-utils'
 import {getQuery, getCurrentRouteName} from '../utils'
 
 import CreatePost from './create-post'
@@ -25,7 +25,9 @@ const UserFeedHandler = (props) => {
           sendTo={props.sendTo}
           expandSendTo={props.expandSendTo}
           createPostViewState={props.createPostViewState}
-          createPost={props.createPost}/>
+          createPost={props.createPost}
+          createPostForm={props.createPostForm}
+          addAttachmentResponse={props.addAttachmentResponse}/>
       </div>
       {props.viewUser.blocked ?
         false :
@@ -41,6 +43,7 @@ function selectState(state) {
   const user = state.user
   const feed = state.feedViewState.feed.map(joinPostData(state))
   const createPostViewState = state.createPostViewState
+  const createPostForm = joinCreatePostData(state)
   const timelines = state.timelines
   const boxHeader = state.boxHeader
   const foundUser = Object.getOwnPropertyNames(state.users)
@@ -67,13 +70,13 @@ function selectState(state) {
 
   const sendTo = state.sendTo
 
-  return { feed, user, timelines, createPostViewState, boxHeader, viewUser, breadcrumbs, sendTo }
+  return { feed, user, timelines, createPostViewState, createPostForm, boxHeader, viewUser, breadcrumbs, sendTo }
 }
 
 function selectActions(dispatch) {
   return {
     ...postActions(dispatch),
-    createPost: (postText, feeds) => dispatch(createPost(postText, feeds)),
+    createPost: (postText, feeds, attachmentIds) => dispatch(createPost(postText, feeds, attachmentIds)),
     expandSendTo: () => dispatch(expandSendTo()),
     userActions: userActions(dispatch),
   }

--- a/src/components/user-profile.jsx
+++ b/src/components/user-profile.jsx
@@ -35,11 +35,14 @@ export default props => (
     </div>
   </div>
   {props.me ?
-    <CreatePost createPostViewState={props.createPostViewState}
-                sendTo={props.sendTo}
-                user={props.user}
-                createPost={props.createPost}
-                expandSendTo={props.expandSendTo} />
+    <CreatePost
+      createPostViewState={props.createPostViewState}
+      sendTo={props.sendTo}
+      user={props.user}
+      createPost={props.createPost}
+      expandSendTo={props.expandSendTo}
+      createPostForm={props.createPostForm}
+      addAttachmentResponse={props.addAttachmentResponse}/>
    : props.blocked ?
     <div>
       You have blocked {props.username}, so all of {props.username}'s posts and comments are invisible to you.

--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -247,6 +247,15 @@ export function addAttachmentResponse(postId, attachments) {
   }
 }
 
+export const REMOVE_ATTACHMENT = 'REMOVE_ATTACHMENT'
+
+export function removeAttachment(postId, attachmentId) {
+  return {
+    type: REMOVE_ATTACHMENT,
+    payload: {postId, attachmentId}
+  }
+}
+
 export const SIGN_IN_CHANGE = 'SIGN_IN_CHANGE'
 
 export function signInChange(username, password){

--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -230,10 +230,10 @@ export function deleteComment(commentId){
 
 export const CREATE_POST = 'CREATE_POST'
 
-export function createPost(postText, feeds){
+export function createPost(postText, feeds, attachmentIds) {
   return {
     type: CREATE_POST,
-    payload: {postText, feeds},
+    payload: {postText, feeds, attachmentIds},
     apiRequest: Api.createPost
   }
 }

--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -238,6 +238,15 @@ export function createPost(postText, feeds){
   }
 }
 
+export const ADD_ATTACHMENT_RESPONSE = 'ADD_ATTACHMENT_RESPONSE'
+
+export function addAttachmentResponse(postId, attachments) {
+  return {
+    type: ADD_ATTACHMENT_RESPONSE,
+    payload: {postId, attachments}
+  }
+}
+
 export const SIGN_IN_CHANGE = 'SIGN_IN_CHANGE'
 
 export function signInChange(username, password){

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -380,6 +380,12 @@ export function posts(state = {}, action) {
       return updatePostData(state, action)
     }
     case ActionCreators.ADD_ATTACHMENT_RESPONSE: {
+      // If this is an attachment for create-post (non-existent post),
+      // it should be handled in createPostForm(), not here
+      if (!action.payload.postId) {
+        return state
+      }
+
       const post = state[action.payload.postId]
       return {...state,
         [post.id]: {
@@ -780,6 +786,24 @@ export function sendTo(state = INITIAL_SEND_TO_STATE, action) {
       return {
         expanded: true,
         feeds: state.feeds
+      }
+    }
+  }
+
+  return state
+}
+
+export function createPostForm(state = {}, action) {
+  switch (action.type) {
+    case ActionCreators.ADD_ATTACHMENT_RESPONSE: {
+      // If this is an attachment for edit-post (existent post),
+      // it should be handled in posts(), not here
+      if (action.payload.postId) {
+        return state
+      }
+
+      return {...state,
+        attachments: [...(state.attachments || []), action.payload.attachments.id]
       }
     }
   }

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -806,6 +806,17 @@ export function createPostForm(state = {}, action) {
         attachments: [...(state.attachments || []), action.payload.attachments.id]
       }
     }
+    case ActionCreators.REMOVE_ATTACHMENT: {
+      // If this is an attachment for edit-post (existent post),
+      // it should be handled in posts(), not here
+      if (action.payload.postId) {
+        return state
+      }
+
+      return {...state,
+        attachments: _.without((state.attachments || []), action.payload.attachmentId)
+      }
+    }
   }
 
   return state

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -379,6 +379,15 @@ export function posts(state = {}, action) {
     case response(ActionCreators.SAVE_EDITING_POST): {
       return updatePostData(state, action)
     }
+    case ActionCreators.ADD_ATTACHMENT_RESPONSE: {
+      const post = state[action.payload.postId]
+      return {...state,
+        [post.id]: {
+          ...post,
+          attachments: [...(post.attachments || []), action.payload.attachments.id]
+        }
+      }
+    }
     case response(ActionCreators.DELETE_COMMENT): {
       const commentId = action.request.commentId
       const commentedPost = _(state).find(post => (post.comments||[]).indexOf(commentId) !== -1)
@@ -430,11 +439,18 @@ export function posts(state = {}, action) {
 }
 
 export function attachments(state = {}, action) {
-  if (ActionCreators.isFeedResponse(action)){
+  if (ActionCreators.isFeedResponse(action)) {
     return mergeByIds(state, action.payload.attachments)
   }
-  if(action.type == response(ActionCreators.GET_SINGLE_POST)){
-    return mergeByIds(state, action.payload.attachments)
+  switch (action.type) {
+    case response(ActionCreators.GET_SINGLE_POST): {
+      return mergeByIds(state, action.payload.attachments)
+    }
+    case ActionCreators.ADD_ATTACHMENT_RESPONSE: {
+      return {...state,
+        [action.payload.attachments.id]: action.payload.attachments
+      }
+    }
   }
   return state
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -46,7 +46,7 @@ export function getPostWithAllCommentsAndLikes({postId}) {
     `${apiConfig.host}/v1/posts/${postId}?maxComments=all&maxLikes=all`, getRequestOptions())
 }
 
-export function createPost({postText, feeds}) {
+export function createPost({postText, feeds, attachmentIds}) {
   return fetch(`${apiConfig.host}/v1/posts`, {
     'method': 'POST',
     'headers': {
@@ -55,7 +55,10 @@ export function createPost({postText, feeds}) {
       'X-Authentication-Token': getToken()
     },
     'body': JSON.stringify({
-      post: { body: postText },
+      post: {
+        body: postText,
+        attachments: attachmentIds
+      },
       meta: { feeds: feeds }
     })
   })

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -46,6 +46,21 @@ export function getPostWithAllCommentsAndLikes({postId}) {
     `${apiConfig.host}/v1/posts/${postId}?maxComments=all&maxLikes=all`, getRequestOptions())
 }
 
+export function createPost({postText, feeds}) {
+  return fetch(`${apiConfig.host}/v1/posts`, {
+    'method': 'POST',
+    'headers': {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'X-Authentication-Token': getToken()
+    },
+    'body': JSON.stringify({
+      post: { body: postText },
+      meta: { feeds: feeds }
+    })
+  })
+}
+
 export function updatePost({postId, newPost}) {
   return fetch(`${apiConfig.host}/v1/posts/${postId}`, {
     'method': 'PUT',
@@ -99,21 +114,6 @@ export function deleteComment({commentId}) {
       'Accept': 'application/json',
       'X-Authentication-Token': getToken()
     }
-  })
-}
-
-export function createPost({postText, feeds}) {
-  return fetch(`${apiConfig.host}/v1/posts`, {
-    'method': 'POST',
-    'headers': {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-      'X-Authentication-Token': getToken()
-    },
-    'body': JSON.stringify({
-      post: { body: postText },
-      meta: { feeds: feeds }
-    })
   })
 }
 

--- a/styles/helvetica/app.scss
+++ b/styles/helvetica/app.scss
@@ -17,3 +17,4 @@
 @import "../shared/pagination";
 @import "player";
 @import "react-select";
+@import "~react-dropzone-component/node_modules/dropzone/dist/min/dropzone.min.css";

--- a/styles/shared/attachments.scss
+++ b/styles/shared/attachments.scss
@@ -97,3 +97,15 @@
   }
 }
 
+.dropzone {
+  min-height: 0;
+  padding: 0;
+
+  .dz-message {
+    margin: 0;
+  }
+}
+
+.dropzone-previews {
+  display: none;
+}

--- a/styles/shared/attachments.scss
+++ b/styles/shared/attachments.scss
@@ -98,8 +98,25 @@
 }
 
 .dropzone {
+  display: none;
+}
+.dragover .dropzone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  position: absolute;
+  z-index: 1000;
+
+  width: 100.16%;
+  height: 105px;
   min-height: 0;
   padding: 0;
+  border: 5px dotted #ccc;
+  background-color: #eee;
+  margin-left: -1px;
+
+  font-size: 16px;
 
   .dz-message {
     margin: 0;

--- a/styles/shared/create-post.scss
+++ b/styles/shared/create-post.scss
@@ -3,63 +3,6 @@
   border-bottom: 1px solid #eee;
   margin-bottom: 14px;
 
-  .attachments {
-    margin: 0 0 5px 0;
-
-    // Clearfix (http://www.cssmojo.com/latest_new_clearfix_so_far/)
-    &:after {
-      content: '';
-      display: table;
-      clear: both;
-    }
-  }
-
-  .image-attachments {
-    > .ember-view {
-      display: inline-block;
-      vertical-align: middle;
-    }
-
-    .attachment {
-      display: inline-block;
-      vertical-align: middle;
-      border: 1px solid silver;
-      padding: 1px;
-      margin: 0 8px 8px 0;
-
-      img {
-        max-width: 525px;
-        max-height: 175px;
-      }
-    }
-  }
-
-  .audio-attachments {
-    .attachment {
-      display: block;
-      margin: 0 8px 8px 0;
-
-      i {
-        color: #666666;
-        padding: 0 1px;
-        margin-right: 4px;
-      }
-    }
-  }
-
-  .general-attachments {
-    .attachment {
-      display: inline-block;
-      margin: 0 8px 8px 0;
-
-      i {
-        color: #666666;
-        padding: 0 1px;
-        margin-right: 4px;
-      }
-    }
-  }
-
   .uploading-attachments {
     > .ember-view {
       display: inline-block;
@@ -119,30 +62,6 @@
     }
   }
 
-  .create-attachment {
-    cursor: pointer;
-    color: #555;
-    font-weight: normal;
-    margin: 0;
-
-    input[type="file"] {
-      position: fixed;
-      top: -1000px;
-    }
-
-    i {
-      padding-right: 1px;
-    }
-
-    &:hover span {
-      text-decoration: underline;
-    }
-  }
-  
-  .create-post-action {
-    margin-right: 15px;
-  }
-  
   .create-post-error {
     font-size: 12px;
     color: #FF5A5F;

--- a/styles/shared/forms.scss
+++ b/styles/shared/forms.scss
@@ -63,12 +63,3 @@
   max-width: 100%;
   margin-bottom: 3px;
 }
-.edit-post-area {
-  @include editarea;
-  min-height: 68px;
-  border: 1px solid #ccc;
-  border-bottom-color: #ccc;
-  border-top-color: #ccc;
-  background-image: none;
-  
-}

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -46,16 +46,26 @@
       }
     }
 
+    .post-editor {
+      position: relative; // necessary for proper width of dropzone inside this container
+    }
+
     .post-textarea {
       @include editarea;
     }
 
-    .post-edit-add-attachments {
+    .post-edit-attachments {
       float: left;
+      cursor: pointer;
+
+      &:hover span:last-child {
+        text-decoration: underline;
+      }
     }
 
     .post-edit-actions {
       text-align: right;
+      margin-bottom: 8px;
     }
 
     .post-cancel {

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -46,36 +46,6 @@
       }
     }
 
-    .post-editor {
-      position: relative; // necessary for proper width of dropzone inside this container
-    }
-
-    .post-textarea {
-      @include editarea;
-    }
-
-    .post-edit-attachments {
-      float: left;
-      cursor: pointer;
-
-      &:hover span:last-child {
-        text-decoration: underline;
-      }
-    }
-
-    .post-edit-actions {
-      text-align: right;
-      margin-bottom: 8px;
-    }
-
-    .post-cancel {
-      margin-right: 10px;
-    }
-
-    .post-edit-throbber {
-      margin-right: 10px;
-    }
-
     .post-footer {
       .post-timestamp {
         color: #666;
@@ -85,6 +55,37 @@
         margin-left: 10px;
       }
     }
+  }
+}
+
+// Used in both create-post and edit-post
+.post-editor {
+  position: relative; // necessary for proper width of dropzone inside this container
+
+  .post-textarea {
+    @include editarea;
+  }
+
+  .post-edit-attachments {
+    float: left;
+    cursor: pointer;
+
+    &:hover span:last-child {
+      text-decoration: underline;
+    }
+  }
+
+  .post-edit-actions {
+    text-align: right;
+    margin-bottom: 8px;
+  }
+
+  .post-cancel {
+    margin-right: 10px;
+  }
+
+  .post-edit-throbber {
+    margin-right: 10px;
   }
 }
 

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -50,6 +50,10 @@
       @include editarea;
     }
 
+    .post-edit-add-attachments {
+      float: left;
+    }
+
     .post-edit-actions {
       text-align: right;
     }


### PR DESCRIPTION
Sorry for the huge PR. Hope it's easier to review commits one by one, most of them are small enough.

What it does now:
- User can add attachments on create-post (both on home page and on user page).
- User can add attachments on edit-post (both on feed page and on single-post page).
- Drag-n-drop works with all above-mentioned things (tested in Chrome, Firefox and Safari).

What to do next:
- Add ability to remove attachments.
- Add displaying of upload progress.
- Make dropzones look nicer / more flexible (now they have fixed height).