### PR TITLE
Post's recipients

### DIFF
--- a/src/components/feed-post.jsx
+++ b/src/components/feed-post.jsx
@@ -59,9 +59,23 @@ export default class FeedPost extends React.Component {
     const toggleCommenting = props.isSinglePost ? () => {
     } : () => props.toggleCommenting(props.id)
 
+    const recipientCustomDisplay = function(recipient) {
+      if (recipient.id !== props.createdBy.id) {
+        return false
+      }
+      if (recipient.username[recipient.username.length - 1] === 's') {
+        return recipient.username + "' feed"
+      } else {
+        return recipient.username + "'s feed"
+      }
+    }
+
     const recipients = props.recipients.map((recipient, index) => (
       <span key={index}>
-        <UserName className="post-recipient" user={recipient}/>
+        <UserName
+          className="post-recipient"
+          user={recipient}
+          display={recipientCustomDisplay(recipient)}/>
         {index < props.recipients.length - 2 ? ', ' : false}
         {index === props.recipients.length - 2 ? ' and ' : false}
       </span>

--- a/src/components/feed-post.jsx
+++ b/src/components/feed-post.jsx
@@ -62,7 +62,8 @@ export default class FeedPost extends React.Component {
     const recipients = props.recipients.map((recipient, index) => (
       <span key={index}>
         <UserName className="post-recipient" user={recipient}/>
-        {index !== props.recipients.length - 1 ? ',' : false}
+        {index < props.recipients.length - 2 ? ', ' : false}
+        {index === props.recipients.length - 2 ? ' and ' : false}
       </span>
     ))
 

--- a/src/components/feed-post.jsx
+++ b/src/components/feed-post.jsx
@@ -59,10 +59,10 @@ export default class FeedPost extends React.Component {
     const toggleCommenting = props.isSinglePost ? () => {
     } : () => props.toggleCommenting(props.id)
 
-    const directReceivers = props.directReceivers.map((receiver, index) => (
+    const recipients = props.recipients.map((recipient, index) => (
       <span key={index}>
-        <UserName className="post-addressee post-addressee-direct" user={receiver}/>
-        {index !== props.directReceivers.length - 1 ? ',' : false}
+        <UserName className="post-recipient" user={recipient}/>
+        {index !== props.recipients.length - 1 ? ',' : false}
       </span>
     ))
 
@@ -116,8 +116,8 @@ export default class FeedPost extends React.Component {
         <div className="post-body">
           <div className="post-header">
             <UserName className="post-author" user={props.createdBy}/>
-            {props.isDirect ? (<span>&nbsp;to&nbsp;</span>) : false}
-            {props.isDirect ? directReceivers : false}
+            {recipients.length > 0 ? ' to ' : false}
+            {recipients}
           </div>
 
           {props.isEditing ? (

--- a/src/components/user-name.jsx
+++ b/src/components/user-name.jsx
@@ -21,7 +21,9 @@ const UserName = (props) => (
     className={`user-name-info ${props.className}`}
     to={`/${props.user.username}`}
   >
-    <DisplayUsername mode={props.settings.userNameMode} user={props.user}/>
+    {props.display
+      ? <span>{props.display}</span>
+      : <DisplayUsername mode={props.settings.userNameMode} user={props.user}/>}
   </Link>
 )
 

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -31,6 +31,10 @@
         font-weight: bold;
         color: #000088;
       }
+
+      .post-recipient {
+        font-weight: 500;
+      }
     }
 
     .post-text {
@@ -143,10 +147,4 @@
 
 .single-post-error {
   color: #FF5A5F;
-}
-
-.post-addressee-direct {
-  padding-left: 13px;
-  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 48 48'><path fill='%23666666' d='M24 24c4.42 0 8-3.59 8-8 0-4.42-3.58-8-8-8s-8 3.58-8 8c0 4.41 3.58 8 8 8zm0 4c-5.33 0-16 2.67-16 8v4h32v-4c0-5.33-10.67-8-16-8z'/></svg>") no-repeat left center;
-  white-space: nowrap;
 }


### PR DESCRIPTION
Properly display all the recipients of the post (directs, groups, own feed), not just directs.

_P.S. There's an issue with single-post page: the list of recipients might be empty on hard reload due to race condition. It's not caused by this commit and should be fixed separately (on higher component level). I will file the issue as soon as this is merged._