### PR TITLE
Remove unnecessary importing of DropzoneJS CSS

### DIFF
--- a/styles/helvetica/app.scss
+++ b/styles/helvetica/app.scss
@@ -17,4 +17,3 @@
 @import "../shared/pagination";
 @import "player";
 @import "react-select";
-@import "~react-dropzone-component/node_modules/dropzone/dist/min/dropzone.min.css";


### PR DESCRIPTION
It breaks building with npm3, and we are not using those style anyway.