### PR TITLE
Comments disabled (React client)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "raw-loader": "^0.5.1",
     "react": "~0.14.6",
     "react-addons-test-utils": "~0.14.6",
+    "react-dd-menu": "^1.0.5",
     "react-dom": "~0.14.6",
     "react-dropzone-component": "^0.8.1",
     "react-google-recaptcha": "^0.5.2",

--- a/src/components/create-post.jsx
+++ b/src/components/create-post.jsx
@@ -12,20 +12,29 @@ export default class CreatePost extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      disabled: true
+      disabled: true,
+      isMoreOpen: false
     }
   }
 
   createPost = _ => {
-    let postText = this.refs.postText.value
+    // Get all the values
     let feeds = this.refs.selectFeeds.values
+    let postText = this.refs.postText.value
     let attachmentIds = this.props.createPostForm.attachments.map(attachment => attachment.id)
+    let more = {
+      commentsDisabled: (this.refs.commentsDisabled && this.refs.commentsDisabled.checked)
+    }
 
-    this.props.createPost(postText, feeds, attachmentIds)
+    // Send to the server
+    this.props.createPost(feeds, postText, attachmentIds, more)
 
+    // Clear the form afterwards
     this.refs.postText.value = ''
+    this.refs.commentsDisabled.checked = false
     this.setState({
-      disabled: true
+      disabled: true,
+      isMoreOpen: false
     })
     attachmentIds.forEach(attachmentId => this.props.removeAttachment(null, attachmentId))
   }
@@ -52,6 +61,10 @@ export default class CreatePost extends React.Component {
         this.createPost()
       }
     }
+  }
+
+  toggleMore() {
+    this.setState({ isMoreOpen: !this.state.isMoreOpen })
   }
 
   render() {
@@ -122,10 +135,27 @@ export default class CreatePost extends React.Component {
             onFocus={this.props.expandSendTo}/>
         </div>
 
-        <div className="post-edit-attachments dropzone-trigger">
-          <i className="fa fa-cloud-upload"></i>
-          {' '}
-          Add photos or files
+        <div className="post-edit-options">
+          <span className="post-edit-attachments dropzone-trigger">
+            <i className="fa fa-cloud-upload"></i>
+            {' '}
+            Add photos or files
+          </span>
+
+          <a className="post-edit-more-trigger" onClick={this.toggleMore.bind(this)}>More&nbsp;&#x25be;</a>
+
+          {this.state.isMoreOpen ? (
+            <div className="post-edit-more">
+              <label>
+                <input
+                  className="post-edit-more-checkbox"
+                  type="checkbox"
+                  ref="commentsDisabled"
+                  defaultChecked={false}/>
+                <span className="post-edit-more-labeltext">Comments disabled</span>
+              </label>
+            </div>
+          ) : false}
         </div>
 
         <div className="post-edit-actions">

--- a/src/components/feed-post.jsx
+++ b/src/components/feed-post.jsx
@@ -40,6 +40,10 @@ export default class FeedPost extends React.Component {
     const deletePost = () => props.deletePost(props.id)
     const likePost = () => props.likePost(props.id, props.user.id)
     const unlikePost = () => props.unlikePost(props.id, props.user.id)
+
+    const disableComments = () => props.disableComments(props.id)
+    const enableComments = () => props.enableComments(props.id)
+
     const checkSave = (event) => {
       const isEnter = event.keyCode === 13
       if (isEnter) {
@@ -235,7 +239,10 @@ export default class FeedPost extends React.Component {
               <span>
                 {' - '}
                 <PostMoreMenu
+                  post={props}
                   toggleEditingPost={toggleEditingPost}
+                  disableComments={disableComments}
+                  enableComments={enableComments}
                   deletePost={deletePost}/>
               </span>
             ) : false}

--- a/src/components/feed-post.jsx
+++ b/src/components/feed-post.jsx
@@ -195,10 +195,12 @@ export default class FeedPost extends React.Component {
                   maxRows={10}/>
               </div>
 
-              <div className="post-edit-attachments dropzone-trigger">
-                <i className="fa fa-cloud-upload"></i>
-                {' '}
-                Add photos or files
+              <div className="post-edit-options">
+                <span className="post-edit-attachments dropzone-trigger">
+                  <i className="fa fa-cloud-upload"></i>
+                  {' '}
+                  Add photos or files
+                </span>
               </div>
 
               <div className="post-edit-actions">

--- a/src/components/feed-post.jsx
+++ b/src/components/feed-post.jsx
@@ -137,6 +137,28 @@ export default class FeedPost extends React.Component {
       }
     }
 
+    // "Comments disabled" / "Comment"
+    let commentLink
+    if (props.commentsDisabled) {
+      if (props.isEditable) {
+        commentLink = (
+          <span>
+            <i>Comments disabled (not for you)</i>
+            {' - '}
+            <a onClick={preventDefault(toggleCommenting)}>Comment</a>
+          </span>
+        )
+      } else {
+        commentLink = (
+          <i>Comments disabled</i>
+        )
+      }
+    } else {
+      commentLink = (
+        <a onClick={preventDefault(toggleCommenting)}>Comment</a>
+      )
+    }
+
     return (
       <div className={postClass}>
         <div className="post-userpic">
@@ -200,7 +222,7 @@ export default class FeedPost extends React.Component {
               <time dateTime={createdAtISO} title={createdAtISO}>{createdAgo}</time>
             </Link>
             {' - '}
-            <a onClick={preventDefault(toggleCommenting)}>Comment</a>
+            {commentLink}
             {' - '}
             <a onClick={preventDefault(ILikedPost ? unlikePost : likePost)}>{ILikedPost ? 'Un-like' : 'Like'}</a>
             {props.isLiking ? (

--- a/src/components/feed-post.jsx
+++ b/src/components/feed-post.jsx
@@ -15,6 +15,7 @@ import throbber16 from 'assets/images/throbber-16.gif'
 import DropzoneComponent from 'react-dropzone-component'
 import {api as apiConfig} from '../config'
 import {getToken} from '../services/auth'
+import PostMoreMenu from './post-more-menu'
 
 export default class FeedPost extends React.Component {
   render() {
@@ -233,9 +234,9 @@ export default class FeedPost extends React.Component {
             {props.isEditable ? (
               <span>
                 {' - '}
-                <a onClick={preventDefault(toggleEditingPost)}>Edit</a>
-                {' - '}
-                <a onClick={preventDefault(deletePost)}>Delete</a>
+                <PostMoreMenu
+                  toggleEditingPost={toggleEditingPost}
+                  deletePost={deletePost}/>
               </span>
             ) : false}
           </div>

--- a/src/components/home-feed.jsx
+++ b/src/components/home-feed.jsx
@@ -18,6 +18,8 @@ export default (props) => {
               addComment={props.addComment}
               likePost={props.likePost}
               unlikePost={props.unlikePost}
+              disableComments={props.disableComments}
+              enableComments={props.enableComments}
               commentEdit={props.commentEdit} />)
   })
 

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -55,7 +55,7 @@ function selectState(state) {
 function selectActions(dispatch) {
   return {
     ...postActions(dispatch),
-    createPost: (postText, feeds, attachmentIds) => dispatch(createPost(postText, feeds, attachmentIds)),
+    createPost: (feeds, postText, attachmentIds, more) => dispatch(createPost(feeds, postText, attachmentIds, more)),
     expandSendTo: () => dispatch(expandSendTo())
   }
 }

--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -43,6 +43,7 @@ export default (props) => {
   const middle = props.comments.slice(1, props.comments.length - 1).map(commentMapper)
   const showOmittedNumber = props.post.omittedComments > 0
   const showMoreComments = () => props.showMoreComments(props.post.id)
+  const canAddComment = (!props.post.commentsDisabled || props.post.isEditable)
 
   return (
     <div className="comments">
@@ -55,7 +56,11 @@ export default (props) => {
             isLoading={props.post.isLoadingComments}/>
         : false}
       {last ? commentMapper(last) : false}
-      {props.post.isCommenting ? renderAddingComment(props) : renderAddCommentLink(props)}
+      {canAddComment
+        ? (props.post.isCommenting
+            ? renderAddingComment(props)
+            : renderAddCommentLink(props))
+        : false}
     </div>
   )
 }

--- a/src/components/post-more-menu.jsx
+++ b/src/components/post-more-menu.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import DropdownMenu from 'react-dd-menu';
+
+export default class PostMoreMenu extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      isOpen: false
+    }
+  }
+
+  toggle() {
+    this.setState({ isOpen: !this.state.isOpen })
+  }
+
+  close() {
+    this.setState({ isOpen: false })
+  }
+
+  render() {
+    let menuOptions = {
+      align: 'left',
+      close: this.close.bind(this),
+      isOpen: this.state.isOpen,
+      toggle: <a onClick={this.toggle.bind(this)}>More&nbsp;&#x25be;</a>
+    }
+
+    return (
+      <DropdownMenu {...menuOptions}>
+        <li className="dd-menu-item"><a className="dd-menu-item-link" onClick={this.props.toggleEditingPost}>Edit</a></li>
+        <li className="dd-menu-item dd-menu-item-danger"><a className="dd-menu-item-link" onClick={this.props.deletePost}>Delete</a></li>
+      </DropdownMenu>
+    )
+  }
+}

--- a/src/components/post-more-menu.jsx
+++ b/src/components/post-more-menu.jsx
@@ -29,6 +29,9 @@ export default class PostMoreMenu extends React.Component {
     return (
       <DropdownMenu {...menuOptions}>
         <li className="dd-menu-item"><a className="dd-menu-item-link" onClick={this.props.toggleEditingPost}>Edit</a></li>
+        {this.props.post.commentsDisabled
+          ? <li className="dd-menu-item"><a className="dd-menu-item-link" onClick={this.props.enableComments}>Enable comments</a></li>
+          : <li className="dd-menu-item"><a className="dd-menu-item-link" onClick={this.props.disableComments}>Disable comments</a></li>}
         <li className="dd-menu-item dd-menu-item-danger"><a className="dd-menu-item-link" onClick={this.props.deletePost}>Delete</a></li>
       </DropdownMenu>
     )

--- a/src/components/select-utils.js
+++ b/src/components/select-utils.js
@@ -18,7 +18,7 @@ export const joinPostData = state => postId => {
     const comment = state.comments[commentId]
     const commentViewState = state.commentViewState[commentId]
     const author = state.users[comment.createdBy]
-    const isEditable = user.id === comment.createdBy
+    const isEditable = (user.id === comment.createdBy)
     return { ...comment, ...commentViewState, user: author, isEditable }
   })
 
@@ -35,7 +35,7 @@ export const joinPostData = state => postId => {
   }
 
   const createdBy = state.users[post.createdBy]
-  const isEditable = post.createdBy == user.id
+  const isEditable = (post.createdBy === user.id)
   const directFeeds = post.postedTo.map(feedId => state.timelines[feedId]).filter(feed => feed && feed.name === 'Directs')
   const isDirect = directFeeds.length
 

--- a/src/components/select-utils.js
+++ b/src/components/select-utils.js
@@ -1,6 +1,6 @@
 import {showMoreComments, showMoreLikes, toggleEditingPost, cancelEditingPost,
         saveEditingPost, deletePost, addAttachmentResponse, removeAttachment,
-        likePost, unlikePost, toggleCommenting, addComment,
+        likePost, unlikePost, disableComments, enableComments, toggleCommenting, addComment,
         toggleEditingComment, cancelEditingComment, saveEditingComment, deleteComment,
         ban, unban, subscribe, unsubscribe, } from '../redux/action-creators'
 
@@ -80,6 +80,8 @@ export function postActions(dispatch) {
     addComment:(postId, commentText) => dispatch(addComment(postId, commentText)),
     likePost: (postId, userId) => dispatch(likePost(postId, userId)),
     unlikePost: (postId, userId) => dispatch(unlikePost(postId, userId)),
+    disableComments: (postId) => dispatch(disableComments(postId)),
+    enableComments: (postId) => dispatch(enableComments(postId)),
     addAttachmentResponse:(postId, attachments) => dispatch(addAttachmentResponse(postId, attachments)),
     removeAttachment:(postId, attachmentId) => dispatch(removeAttachment(postId, attachmentId)),
     commentEdit: {

--- a/src/components/single-post.jsx
+++ b/src/components/single-post.jsx
@@ -31,6 +31,8 @@ const SinglePostHandler = (props) => {
                   addComment={props.addComment}
                   likePost={props.likePost}
                   unlikePost={props.unlikePost}
+                  disableComments={props.disableComments}
+                  enableComments={props.enableComments}
                   commentEdit={props.commentEdit} />
   }
 

--- a/src/components/user-feed.jsx
+++ b/src/components/user-feed.jsx
@@ -76,7 +76,7 @@ function selectState(state) {
 function selectActions(dispatch) {
   return {
     ...postActions(dispatch),
-    createPost: (postText, feeds, attachmentIds) => dispatch(createPost(postText, feeds, attachmentIds)),
+    createPost: (feeds, postText, attachmentIds, more) => dispatch(createPost(feeds, postText, attachmentIds, more)),
     expandSendTo: () => dispatch(expandSendTo()),
     userActions: userActions(dispatch),
   }

--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -254,10 +254,10 @@ export function deleteComment(commentId){
 
 export const CREATE_POST = 'CREATE_POST'
 
-export function createPost(postText, feeds, attachmentIds) {
+export function createPost(feeds, postText, attachmentIds, more) {
   return {
     type: CREATE_POST,
-    payload: {postText, feeds, attachmentIds},
+    payload: {feeds, postText, attachmentIds, more},
     apiRequest: Api.createPost
   }
 }

--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -199,6 +199,30 @@ export function unlikePost(postId, userId){
   }
 }
 
+export const DISABLE_COMMENTS = 'DISABLE_COMMENTS'
+
+export function disableComments(postId) {
+  return {
+    type: DISABLE_COMMENTS,
+    apiRequest: Api.disableComments,
+    payload: {
+      postId
+    }
+  }
+}
+
+export const ENABLE_COMMENTS = 'ENABLE_COMMENTS'
+
+export function enableComments(postId) {
+  return {
+    type: ENABLE_COMMENTS,
+    apiRequest: Api.enableComments,
+    payload: {
+      postId
+    }
+  }
+}
+
 export const TOGGLE_EDITING_COMMENT = 'TOGGLE_EDITING_COMMENT'
 
 export function toggleEditingComment(commentId){

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -362,6 +362,56 @@ export function postsViewState(state = {}, action) {
         }
       }
     }
+    case request(ActionCreators.DISABLE_COMMENTS): {
+      const post = state[action.payload.postId]
+      return {...state,
+        [post.id]: {...post,
+          isDisablingComments: true
+        }}
+    }
+    case response(ActionCreators.DISABLE_COMMENTS): {
+      const post = state[action.request.postId]
+      return {...state,
+        [post.id]: {...post,
+          isDisablingComments: false,
+          commentsDisabled: true
+        }
+      }
+    }
+    case fail(ActionCreators.DISABLE_COMMENTS): {
+      const post = state[action.request.postId]
+      return {...state,
+        [post.id]: {...post,
+          isDisablingComments: false,
+          disableCommentsError: 'Something went wrong while disabling comments.'
+        }
+      }
+    }
+    case request(ActionCreators.ENABLE_COMMENTS): {
+      const post = state[action.payload.postId]
+      return {...state,
+        [post.id]: {...post,
+          isDisablingComments: true
+        }}
+    }
+    case response(ActionCreators.ENABLE_COMMENTS): {
+      const post = state[action.request.postId]
+      return {...state,
+        [post.id]: {...post,
+          isDisablingComments: false,
+          commentsDisabled: false
+        }
+      }
+    }
+    case fail(ActionCreators.ENABLE_COMMENTS): {
+      const post = state[action.request.postId]
+      return {...state,
+        [post.id]: {...post,
+          isDisablingComments: false,
+          disableCommentsError: 'Something went wrong while enabling comments.'
+        }
+      }
+    }
     case response(ActionCreators.CREATE_POST): {
       const post = action.payload.posts
       const id = post.id
@@ -472,6 +522,22 @@ export function posts(state = {}, action) {
           ...post,
           likes: _.without(post.likes, action.request.userId),
           omittedLikes: (post.omittedLikes > 0 ? post.omittedLikes - 1 : 0)
+        }
+      }
+    }
+    case response(ActionCreators.DISABLE_COMMENTS): {
+      const post = state[action.request.postId]
+      return {...state,
+        [post.id]: {...post,
+          commentsDisabled: true
+        }
+      }
+    }
+    case response(ActionCreators.ENABLE_COMMENTS): {
+      const post = state[action.request.postId]
+      return {...state,
+        [post.id]: {...post,
+          commentsDisabled: false
         }
       }
     }

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -2,7 +2,7 @@ import * as ActionCreators from './action-creators'
 const {request, response, fail} = ActionCreators
 
 import _ from 'lodash'
-import {userParser} from '../utils'
+import {userParser, postParser} from '../utils'
 
 export function signInForm(state={username:'', password:'', error:'', loading: false}, action) {
   switch(action.type) {
@@ -383,12 +383,12 @@ export function postsViewState(state = {}, action) {
 
 function updatePostData(state, action) {
   const postId = action.payload.posts.id
-  return { ...state, [postId]: action.payload.posts }
+  return { ...state, [postId]: postParser(action.payload.posts) }
 }
 
 export function posts(state = {}, action) {
   if (ActionCreators.isFeedResponse(action)){
-    return mergeByIds(state, action.payload.posts)
+    return mergeByIds(state, (action.payload.posts || []).map(postParser))
   }
   switch (action.type) {
     case response(ActionCreators.SHOW_MORE_COMMENTS): {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -144,6 +144,30 @@ export function unlikePost({postId}) {
   })
 }
 
+export function disableComments({postId}) {
+  return fetch(`${apiConfig.host}/v1/posts/${postId}/disableComments`, {
+    'method': 'POST',
+    'headers': {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'X-Authentication-Token': getToken()
+    },
+    'body': '{}'
+  })
+}
+
+export function enableComments({postId}) {
+  return fetch(`${apiConfig.host}/v1/posts/${postId}/enableComments`, {
+    'method': 'POST',
+    'headers': {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'X-Authentication-Token': getToken()
+    },
+    'body': '{}'
+  })
+}
+
 export function signIn({username, password}){
   return fetch(`${apiConfig.host}/v1/session`, {
     headers:{

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -46,7 +46,7 @@ export function getPostWithAllCommentsAndLikes({postId}) {
     `${apiConfig.host}/v1/posts/${postId}?maxComments=all&maxLikes=all`, getRequestOptions())
 }
 
-export function createPost({postText, feeds, attachmentIds}) {
+export function createPost({feeds, postText, attachmentIds, more}) {
   return fetch(`${apiConfig.host}/v1/posts`, {
     'method': 'POST',
     'headers': {
@@ -59,7 +59,10 @@ export function createPost({postText, feeds, attachmentIds}) {
         body: postText,
         attachments: attachmentIds
       },
-      meta: { feeds: feeds }
+      meta: {
+        feeds: feeds,
+        commentsDisabled: !!more.commentsDisabled
+      }
     })
   })
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -44,6 +44,10 @@ export function userParser(user) {
   return {...user}
 }
 
+export function postParser(post) {
+  post.commentsDisabled = (post.commentsDisabled === '1')
+  return {...post}
+}
 
 export function preventDefault(realFunction) {
   return (event) => {

--- a/styles/helvetica/app.scss
+++ b/styles/helvetica/app.scss
@@ -17,3 +17,4 @@
 @import "../shared/pagination";
 @import "player";
 @import "react-select";
+@import "~react-dd-menu/src/scss/react-dd-menu.scss";

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -62,6 +62,30 @@
   }
 }
 
+// "More" menu in post footer
+// (it's just an override, default styles are in react-dd-menu/src/scss/react-dd-menu.scss)
+.dd-menu .dd-menu-items .dd-menu-item {
+  &:hover {
+    background-color: #eee !important;
+  }
+  &.dd-menu-item-danger:hover {
+    color: #300 !important;
+    background-color: #fcc !important;
+  }
+
+  .dd-menu-item-link {
+    padding: 6px 12px !important;
+  }
+  &:first-child .dd-menu-item-link {
+    padding-top: 8px !important;
+    padding-bottom: 5px !important;
+  }
+  &:last-child .dd-menu-item-link {
+    padding-top: 5px !important;
+    padding-bottom: 8px !important;
+  }
+}
+
 // Used in both create-post and edit-post
 .post-editor {
   position: relative; // necessary for proper width of dropzone inside this container

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -90,16 +90,44 @@
 .post-editor {
   position: relative; // necessary for proper width of dropzone inside this container
 
+  // Clearfix (http://www.cssmojo.com/latest_new_clearfix_so_far/)
+  &:after {
+    content: '';
+    display: table;
+    clear: both;
+  }
+
   .post-textarea {
     @include editarea;
   }
 
-  .post-edit-attachments {
+  .post-edit-options {
     float: left;
-    cursor: pointer;
+    margin-bottom: 11px;
 
-    &:hover span:last-child {
-      text-decoration: underline;
+    .post-edit-attachments {
+      cursor: pointer;
+
+      &:hover span:last-child {
+        text-decoration: underline;
+      }
+    }
+
+    .post-edit-more-trigger {
+      color: #333;
+      margin-left: 15px;
+    }
+
+    .post-edit-more {
+      margin-top: 5px;
+
+      .post-edit-more-checkbox {
+        margin: 0 5px 0 1px;
+      }
+      .post-edit-more-labeltext {
+        font-weight: normal;
+        vertical-align: middle;
+      }
     }
   }
 


### PR DESCRIPTION
Full support:
- User can disable comments when creating a post
- User can disable/enable comments for existing posts
- There are "Comments disabled" remarks for those special posts
- There are no forms for commenting the posts with "Comments disabled"

See also:
- https://github.com/FreeFeed/freefeed-server/pull/27 — full support for the server.
- https://github.com/FreeFeed/freefeed-html/pull/23 — partial support for official Ember client.

Now it's time for some pictures:

This is the form for a new post with a tiny little difference:
<img width="725" alt="2016-01-11 01-14-57 comments-disabled-react-1" src="https://cloud.githubusercontent.com/assets/1071933/12225400/31a11dac-b80a-11e5-9549-dc0ef7242421.png">

...which is clickable (of course, checkbox inside is unchecked by default):
<img width="725" alt="2016-01-11 01-20-36 comments-disabled-react-2" src="https://cloud.githubusercontent.com/assets/1071933/12225404/31a21748-b80a-11e5-9774-060d67ed86b4.png">

That's what your new entry will look like after posting:
<img width="725" alt="2016-01-11 01-21-51 comments-disabled-react-3" src="https://cloud.githubusercontent.com/assets/1071933/12225401/31a16eb0-b80a-11e5-9798-7d24b8b209eb.png">

That's what your readers will see:
<img width="725" alt="2016-01-11 01-23-27 comments-disabled-react-4" src="https://cloud.githubusercontent.com/assets/1071933/12225403/31a23516-b80a-11e5-8a9e-d4be14e12e33.png">

And here's the new dropdown menu under "More" link, where you can change anything you want:
<img width="725" alt="2016-01-11 01-28-54 comments-disabled-react-5" src="https://cloud.githubusercontent.com/assets/1071933/12225402/31a1ad80-b80a-11e5-9c2b-68ba10c8d34d.png">

That's all folks! Looking forward to your feedback.