### PR TITLE
Fix the attachments staying in the form on create-post

### DIFF
--- a/src/components/create-post.jsx
+++ b/src/components/create-post.jsx
@@ -31,7 +31,6 @@ export default class CreatePost extends React.Component {
 
     // Clear the form afterwards
     this.refs.postText.value = ''
-    this.refs.commentsDisabled.checked = false
     this.setState({
       disabled: true,
       isMoreOpen: false

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -133,18 +133,25 @@ export function feedViewState(state = initFeed, action) {
     }
     case response(ActionCreators.DELETE_POST): {
       const postId = action.request.postId
-      return { visibleEntries: _.without(state.visibleEntries, postId) }
+      return {...state,
+        visibleEntries: _.without(state.visibleEntries, postId),
+        hiddenEntries: _.without(state.hiddenEntries, postId)
+      }
     }
     case response(ActionCreators.CREATE_POST): {
       const postId = action.payload.posts.id
-      return { visibleEntries: [postId, ...state.visibleEntries] }
+      return {...state,
+        visibleEntries: [postId, ...state.visibleEntries]
+      }
     }
     case response(ActionCreators.GET_SINGLE_POST): {
       const postId = action.request.postId
-      return { visibleEntries: [postId] }
+      return {...initFeed,
+        visibleEntries: [postId]
+      }
     }
     case fail(ActionCreators.GET_SINGLE_POST): {
-      return { visibleEntries: [] }
+      return initFeed
     }
 
     case response(ActionCreators.HIDE_POST): {


### PR DESCRIPTION
`this.refs.commentsDisabled` is undefined when "More" is not open,
so there was a JS error. And we actually don't need that line anyway,
since checkbox is getting reset on closing "More" (`isMoreOpen: false`,
3 lines below).