### PR TITLE
Fix unreliable highlighting of direct messages

### DIFF
--- a/src/components/select-utils.js
+++ b/src/components/select-utils.js
@@ -50,12 +50,18 @@ export const joinPostData = state => postId => {
 
   const createdBy = state.users[post.createdBy]
   const isEditable = (post.createdBy === user.id)
-  const directFeeds = post.postedTo.map(feedId => state.timelines[feedId]).filter(feed => feed && feed.name === 'Directs')
-  const isDirect = directFeeds.length
+
+  // Check if the post is a direct message
+  const directRecipients = post.postedTo
+    .filter((subscriptionId) => {
+      let subscriptionType = (state.subscriptions[subscriptionId]||{}).name
+      return (subscriptionType === 'Directs')
+    })
+  const isDirect = !!directRecipients.length
 
   // Get the list of post's recipients
-  let recipients = post.postedTo
-    .map(function(subscriptionId) {
+  const recipients = post.postedTo
+    .map((subscriptionId) => {
       let userId = (state.subscriptions[subscriptionId]||{}).user
       let subscriptionType = (state.subscriptions[subscriptionId]||{}).name
       if (userId === post.createdBy && subscriptionType === 'Directs') {


### PR DESCRIPTION
Use state.subscriptions instead of state.timelines as a source
of truth (as in the piece for post's recipients a couple lines below).

Fixes #161.