### PR TITLE
Fix regression in Linkify

### DIFF
--- a/src/components/linkify.jsx
+++ b/src/components/linkify.jsx
@@ -40,12 +40,15 @@ class Linkify extends React.Component {
   }
 
   parseCounter = 0
+  idx = 0
 
   parseString(string) {
     let elements = []
     if (string === '') {
       return elements
     }
+
+    this.idx = 0
 
     try {
       finder.parse(string).map(it => {


### PR DESCRIPTION
This fixes regression when only the first link in text is highlighted,
and all the next links are REMOVED from the text completely.

It seems to be a regression after recent hotfix (42f20c1).

Before (wrong):
<img width="1440" alt="2016-02-02 15-18-59 freefeed-linkify-1" src="https://cloud.githubusercontent.com/assets/1071933/12752055/db938a58-c9c0-11e5-8b64-a826057525ca.png">

After (correct):
<img width="1440" alt="2016-02-02 15-21-20 freefeed-linkify-2" src="https://cloud.githubusercontent.com/assets/1071933/12752054/db909532-c9c0-11e5-97be-71ed33d170db.png">
