### PR TITLE
Fix setCaretToTextEnd()

### DIFF
--- a/src/components/post-comment.jsx
+++ b/src/components/post-comment.jsx
@@ -34,8 +34,9 @@ export default class PostComment extends React.Component{
   }
 
   setCaretToTextEnd = (event) => {
-    setTimeout(function() {
-      const input = event.target
+    const input = event.target
+
+    setTimeout(() => {
       if (typeof input.selectionStart === 'number') {
         input.selectionStart = input.selectionEnd = input.value.length
       } else if (input.createTextRange !== undefined) {


### PR DESCRIPTION
After the recent update of some unknown node module `event` suddenly
became undefined in setTimeout callback. Mystery.

Fixes #233.