### PR TITLE
Do not show all the likes right away on single-post page

### DIFF
--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -59,7 +59,7 @@ export function getUserFeed(username, offset = 0) {
 export function showMoreComments(postId) {
   return {
     type: ActionTypes.SHOW_MORE_COMMENTS,
-    apiRequest: Api.getPostWithAllCommentsAndLikes,
+    apiRequest: Api.getPostWithAllComments,
     payload: {postId},
   }
 }
@@ -339,7 +339,7 @@ export function updateUserPhoto(picture) {
 export function getSinglePost(postId) {
   return {
     type: ActionTypes.GET_SINGLE_POST,
-    apiRequest: Api.getPostWithAllCommentsAndLikes,
+    apiRequest: Api.getPostWithAllComments,
     nonAuthRequest: true,
     payload: {postId},
   }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -41,9 +41,9 @@ export function getLikesOnly({postId, commentsExpanded}) {
     `${apiConfig.host}/v1/posts/${postId}?maxComments=${maxComments}&maxLikes=all`, getRequestOptions())
 }
 
-export function getPostWithAllCommentsAndLikes({postId}) {
+export function getPostWithAllComments({postId}) {
   return fetch(
-    `${apiConfig.host}/v1/posts/${postId}?maxComments=all&maxLikes=all`, getRequestOptions())
+    `${apiConfig.host}/v1/posts/${postId}?maxComments=all`, getRequestOptions())
 }
 
 export function createPost({feeds, postText, attachmentIds, more}) {


### PR DESCRIPTION
A single-post page should show all the comments, but the list of likes should be collapsed by default.