### PR TITLE
Fix user's own private feed

### DIFF
--- a/src/components/user-feed.jsx
+++ b/src/components/user-feed.jsx
@@ -11,7 +11,7 @@ export default props => (
         <p>You have blocked <b>{props.viewUser.screenName}</b>, so all of their posts and comments are invisible to you.</p>
         <p><a onClick={()=>props.userActions.unban({username: props.viewUser.username, id: props.viewUser.id})}>Un-block</a></p>
       </div>
-    ) : props.viewUser.isPrivate === '1' && !props.viewUser.subscribed ? (
+    ) : props.viewUser.isPrivate === '1' && !props.viewUser.subscribed && !props.viewUser.isItMe ? (
       <div className="box-body">
         <p><b>{props.viewUser.screenName}</b> has a private feed.</p>
       </div>


### PR DESCRIPTION
Before: user is shown "user has a private feed" for their own feed.
After: user is shown the feed contents.