### PR TITLE
Fix webpack build warning

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
 //webpack context magic to include all tests we've wrote
-var context = require.context('.', true, /(?!index).*jsx?/)
+var context = require.context('.', true, /^\.\/.*\/.*\.js$/)
 context.keys().forEach(context)
 module.exports = context


### PR DESCRIPTION
To be exact, this one:

```
WARNING in ./test (?!index).*jsx?
Module not found: Error: a dependency to an entry point is not allowed
 @ ./test (?!index).*jsx?
```

Instead of looking for `*.js` files that are not `index.js` (which for some
reason doesn't work for webpack), the new regexp looks for any `*.js` files
in subdirectories. (And we don't really need `*.jsx`, right?)
