### PR TITLE
Two essential fixes for router

### DIFF
--- a/src/components/pagination-links.jsx
+++ b/src/components/pagination-links.jsx
@@ -25,13 +25,13 @@ export default props => (
   <ul className="pager p-pagination-controls">
     {props.offset > 0 ?
       <li>
-        <Link to={{pathname:'', query: offsetObject(minOffset(props.offset))}}
+        <Link to={{pathname: props.location.pathname, query: offsetObject(minOffset(props.offset))}}
               onClick={routingCallback(props, minOffset)}
               className="p-pagination-newer">« Newer items</Link>
       </li>
       : false}
     <li>
-      <Link to={{pathname:'', query:offsetObject(maxOffset(props.offset))}}
+      <Link to={{pathname: props.location.pathname, query: offsetObject(maxOffset(props.offset))}}
             onClick={routingCallback(props, maxOffset)}
             className="p-pagination-older">Older items »</Link>
       </li>

--- a/src/components/user-feed.jsx
+++ b/src/components/user-feed.jsx
@@ -16,7 +16,7 @@ export default props => (
         <p><b>{props.viewUser.screenName}</b> has a private feed.</p>
       </div>
     ) : (
-      <PaginatedView>
+      <PaginatedView {...props}>
         <Feed {...props} isInUserFeed={true}/>
       </PaginatedView>
     )}


### PR DESCRIPTION
- Fix navigating to the second page of user feed
_This fixes a JS error causing a full page reload when visitor clicks
"Older items" on user feed. It's likely a regression after the recent
router update._

- Fix "Older items" for any page which is not Home
_Fixes #338._