### PR TITLE
Fix conflicting CSS in branch `private-groups`

### DIFF
--- a/src/components/group-feed-type-picker.jsx
+++ b/src/components/group-feed-type-picker.jsx
@@ -9,12 +9,12 @@ export default class GroupFeedTypePicker extends React.Component {
   render() {
     return (
       <div>
-        <div className="form-group">
-          <div className="left-block">
+        <div className="row form-group">
+          <div className="col-sm-3">
             <label>Who can view posts:</label>
           </div>
           
-          <div className="right-block">
+          <div className="col-sm-9">
             <label className="option-box">
               <div className="input">
                 <input type="radio"
@@ -43,12 +43,12 @@ export default class GroupFeedTypePicker extends React.Component {
           </div>
         </div>
 
-        <div className="form-group">
-          <div className="left-block">
+        <div className="row form-group">
+          <div className="col-sm-3">
             <label>Who can write posts:</label>
           </div>
           
-          <div className="right-block">
+          <div className="col-sm-9">
             <label className="option-box">
               <div className="input">
                 <input type="radio"

--- a/styles/shared/forms.scss
+++ b/styles/shared/forms.scss
@@ -1,4 +1,3 @@
-@import "../common/common";
 // @import "../common/select2/4.0.0-rc.2/theme/classic/_defaults";
 // @import "../common/select2/4.0.0-rc.2/theme/classic/_multiple.scss";
 
@@ -65,29 +64,17 @@
   margin-bottom: 3px;
 }
 
-.form-group {
-  .left-block {
-    padding: 3px 0 10px 0;
-    @extend .col-sm-3;
+label.option-box {
+  display: block;
+
+  .input {
+    display: table-cell;
   }
 
-  .right-block {
-    padding: 3px 0 0 0;
-    @extend .col-sm-9;
-
-    label {
-      display: block;
-
-      .input {
-        display: table-cell;
-      }
-
-      .option {
-        display: table-cell;
-        font-weight: normal;
-        padding-left: 10px;
-        padding-bottom: 5px;
-      }
-    }
+  .option {
+    display: table-cell;
+    font-weight: normal;
+    padding-left: 10px;
+    padding-bottom: 5px;
   }
 }


### PR DESCRIPTION
This reverts early import of Bootstrap's CSS that caused incorrect
styles overriding.

---

Before:
<img width="714" alt="2016-03-12 16-17-42 freefeed" src="https://cloud.githubusercontent.com/assets/1071933/13740183/9e1aafd8-e9cf-11e5-8b5f-53e02bde6389.png">

---

After:
![2016-03-12 16-18-51 freefeed](https://cloud.githubusercontent.com/assets/1071933/13740185/9e1d3fb4-e9cf-11e5-9ece-69b83ec78808.png)

---

Before:
<img width="714" alt="2016-03-12 16-19-54 freefeed" src="https://cloud.githubusercontent.com/assets/1071933/13740186/9e1f9cb4-e9cf-11e5-9143-30d8c6a2028c.png">

---

After:
<img width="714" alt="2016-03-12 16-20-57 freefeed" src="https://cloud.githubusercontent.com/assets/1071933/13740184/9e1c61b6-e9cf-11e5-8d84-2adc3c4c4e7d.png">
