### PR TITLE
Only clear editing comment state if necessary

### DIFF
--- a/src/components/post-comment.jsx
+++ b/src/components/post-comment.jsx
@@ -64,11 +64,12 @@ export default class PostComment extends React.Component{
     }
   }
 
-  componentWillReceiveProps(newProps){
-    const justSaved = this.props.isSaving && !newProps.isSaving
-    const noError = !newProps.errorString
-    const shouldClearText = justSaved && noError
-    if (shouldClearText){
+  componentWillReceiveProps(newProps) {
+    const wasCommentJustSaved = this.props.isSaving && !newProps.isSaving
+    const wasThereNoError = !newProps.errorString
+    const isItSinglePostAddingComment = newProps.isSinglePost
+    const shouldClearText = (wasCommentJustSaved && wasThereNoError && isItSinglePostAddingComment)
+    if (shouldClearText) {
       this.setState({editText: ''})
     }
   }

--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -84,7 +84,7 @@ export default (props) => {
       {last ? commentMapper(last) : false}
       {canAddComment
         ? (props.post.isCommenting
-            ? renderAddingComment(props, openAnsweringComment)
+            ? renderAddingComment(props)
             : renderAddCommentLink(props, disabledForOthers))
         : false}
     </div>


### PR DESCRIPTION
Fixes T29, which is likely a regression after #335. That update successfully fixed #330 by clearing editText on saving, but it cleared it even when unnecessary, making the following editing broken and causing https://dev.freefeed.net/T29. So this update should fix it.

With this update, I tested adding, editing and multiple editing of comments both in feeds and on single post pages. Works on my machine.™
