### PR TITLE
Clean the feedViewState when user's not found

### DIFF
--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -193,6 +193,9 @@ export function feedViewState(state = initFeed, action) {
       isHiddenRevealed
     }
   }
+  if (ActionHelpers.isFeedFail(action)) {
+    return initFeed
+  }
 
   switch (action.type) {
     case ActionTypes.UNAUTHENTICATED: {


### PR DESCRIPTION
Otherwise it shows "404 Not Found" ON TOP of the previous feed,
not INSTEAD of it.
