### PR TITLE
Fix user subscriptions in Redux store

### DIFF
--- a/src/redux/action-helpers.js
+++ b/src/redux/action-helpers.js
@@ -1,4 +1,8 @@
-import {HOME, DISCUSSIONS, GET_USER_FEED, GET_USER_COMMENTS, GET_USER_LIKES, DIRECT,SUBSCRIBE, UNSUBSCRIBE} from './action-types';
+import {
+  HOME, DISCUSSIONS, DIRECT, GET_USER_FEED, GET_USER_COMMENTS, GET_USER_LIKES,
+  SIGN_UP, WHO_AM_I, SUBSCRIBE, UNSUBSCRIBE,
+  UPDATE_USER, UPDATE_FRONTEND_PREFERENCES, UPDATE_FRONTEND_REALTIME_PREFERENCES
+} from './action-types';
 
 export const request = (type) =>`${type}_REQUEST`;
 export const response = (type) => `${type}_RESPONSE`;
@@ -12,7 +16,7 @@ export const isFeedRequest = action => feedRequests.indexOf(action.type) !== -1;
 export const isFeedResponse = action => feedResponses.indexOf(action.type) !== -1;
 export const isFeedFail = action => feedFails.indexOf(action.type) !== -1;
 
-export const userChangeActions = [SUBSCRIBE, UNSUBSCRIBE];
+export const userChangeActions = [SIGN_UP, WHO_AM_I, SUBSCRIBE, UNSUBSCRIBE, UPDATE_USER, UPDATE_FRONTEND_PREFERENCES, UPDATE_FRONTEND_REALTIME_PREFERENCES];
 export const userChangeResponses = userChangeActions.map(response);
 export const isUserChangeResponse = action => userChangeResponses.indexOf(action.type) !== -1;
 

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -1154,7 +1154,8 @@ export function user(state = initUser(), action) {
     case response(ActionTypes.UPDATE_USER):
     case response(ActionTypes.UPDATE_FRONTEND_PREFERENCES):
     case response(ActionTypes.UPDATE_FRONTEND_REALTIME_PREFERENCES): {
-      return {...state, ...userParser(action.payload.users)};
+      const subscriptions = _.uniq((action.payload.subscriptions || []).map(sub => sub.user));
+      return {...state, ...userParser(action.payload.users), subscriptions};
     }
     case response(ActionTypes.SEND_SUBSCRIPTION_REQUEST): {
       return {...state,

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -1144,19 +1144,11 @@ const initUser = _ => ({
 });
 
 export function user(state = initUser(), action) {
-  if (ActionHelpers.isUserChangeResponse(action) ||
-      action.type === response(ActionTypes.WHO_AM_I) ||
-      action.type === response(ActionTypes.SIGN_UP)) {
+  if (ActionHelpers.isUserChangeResponse(action)) {
     const subscriptions = _.uniq((action.payload.subscriptions || []).map(sub => sub.user));
     return {...state, ...userParser(action.payload.users), subscriptions};
   }
   switch (action.type) {
-    case response(ActionTypes.UPDATE_USER):
-    case response(ActionTypes.UPDATE_FRONTEND_PREFERENCES):
-    case response(ActionTypes.UPDATE_FRONTEND_REALTIME_PREFERENCES): {
-      const subscriptions = _.uniq((action.payload.subscriptions || []).map(sub => sub.user));
-      return {...state, ...userParser(action.payload.users), subscriptions};
-    }
     case response(ActionTypes.SEND_SUBSCRIPTION_REQUEST): {
       return {...state,
         pendingSubscriptionRequests: [...(state.pendingSubscriptionRequests || []),


### PR DESCRIPTION
Seems like the list of _user IDs_ in `state.subscriptions` is replaced with the list of _subscription IDs_ on UPDATE_USER, UPDATE_FRONTEND_PREFERENCES and UPDATE_FRONTEND_REALTIME_PREFERENCES.

See the code 7 lines above the change for the correct algorithm (line 1150).
