### PR TITLE
Adds retina support for thumbnails, ported from gamma by @clbn

### DIFF
--- a/src/components/post-attachment-image.jsx
+++ b/src/components/post-attachment-image.jsx
@@ -8,11 +8,19 @@ export default (props) => {
 
   const removeAttachment = () => props.removeAttachment(props.id);
 
+  let srcSet;
+  if (props.imageSizes.t2 && props.imageSizes.t2.url) {
+    srcSet = props.imageSizes.t2.url + ' 2x';
+  } else if (props.imageSizes.o && props.imageSizes.t && props.imageSizes.o.w <= props.imageSizes.t.w * 2) {
+    srcSet = (props.imageSizes.o.url || props.url) + ' 2x';
+  }
+
   const imageAttributes = {
-    src: props.thumbnailUrl,
+    src: props.imageSizes.t && props.imageSizes.t.url || props.thumbnailUrl,
+    srcSet,
     alt: nameAndSize,
-    width: props.imageSizes.t ? props.imageSizes.t.w : undefined,
-    height: props.imageSizes.t ? props.imageSizes.t.h : undefined
+    width: props.imageSizes.t && props.imageSizes.t.w || undefined,
+    height: props.imageSizes.t && props.imageSizes.t.h || undefined
   };
 
   return (


### PR DESCRIPTION
When original size is less than double thumbnail size we can use
original image for Retina-ready thumbnail.
