### PR TITLE
More narrow and uniform intervals between paragraphs

### DIFF
--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -14,12 +14,6 @@
     white-space: nowrap;
   }
 
-  .p-break {
-    display: block;
-    height: 10px;
-    font-size: 1px;
-  }
-
   .post-userpic {
     float: left;
     border: 1px #ccc solid;
@@ -55,7 +49,7 @@
 
       color: #000;
       font-size: 16px;
-      line-height: 21px;
+      line-height: 20px;
 
       a {
         color: #000088;
@@ -81,6 +75,22 @@
     }
   }
 }
+
+// paragraph breaks
+.comment .p-break {
+  display: block;
+  font-size: 0;
+  height: 5px;
+}
+
+.single-post .post-text .p-break {
+  height: 7px;
+}
+
+.timeline-post .post-text .p-break {
+  height: 6px;
+}
+
 
 // "More" menu in post footer
 // (it's just an override, default styles are in react-dd-menu/src/scss/react-dd-menu.scss)


### PR DESCRIPTION
Current p-break (10px) is too wide in comments and breaks visual flow (space between comments is 8px). I propose a more narrow intervals agreed with the text line-height in different contexts.

Before:
![image](https://cloud.githubusercontent.com/assets/132120/15601794/229f6938-23fa-11e6-9247-56692a6d5ecd.png)

After:
![image](https://cloud.githubusercontent.com/assets/132120/15601803/3b57d44c-23fa-11e6-8d74-8d9fb0bdb8b8.png)
