### PR TITLE
Groupnames in group posts URLs

### DIFF
--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -54,7 +54,6 @@ const renderAddCommentLink = (props, disabledForOthers) => {
 };
 
 export default (props) => {
-  const entryUrl = `/${props.post.createdBy.username}/${props.post.id}`;
 
   const openAnsweringComment = (answerText) => {
     if (!props.post.isCommenting && !props.post.isSinglePost) {
@@ -69,7 +68,7 @@ export default (props) => {
     }
   };
 
-  const commentMapper = renderComment(entryUrl, openAnsweringComment, props.post.isModeratingComments, props.commentEdit, props.post.id);
+  const commentMapper = renderComment(props.entryUrl, openAnsweringComment, props.post.isModeratingComments, props.commentEdit, props.post.id);
   const totalComments = props.comments.length + props.post.omittedComments; 
   const first = withBackwardNumber(props.comments[0], totalComments);
   const last = withBackwardNumber(props.comments.length > 1 && props.comments[props.comments.length - 1], 1);
@@ -87,7 +86,7 @@ export default (props) => {
         ? <MoreCommentsWrapper
             omittedComments={props.post.omittedComments}
             showMoreComments={showMoreComments}
-            entryUrl={entryUrl}
+            entryUrl={props.entryUrl}
             isLoading={props.post.isLoadingComments}/>
         : false}
       {last ? commentMapper(last) : false}

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -127,6 +127,13 @@ export default class Post extends React.Component {
       </span>
     ));
 
+    // username in url
+    // If posted _only_ into groups, use first recipient's username 
+    let urlName = props.createdBy.username;
+    if (props.recipients.length > 0 && !props.recipients.some(r => r.type === "user")) {
+      urlName = props.recipients[0].username;
+    }
+
     // "Lock icon": check if the post is truly private, "partly private" or public.
     // Truly private:
     // - posted to author's own private feed and/or
@@ -303,7 +310,7 @@ export default class Post extends React.Component {
               <i className="post-lock-icon fa fa-lock" title="This entry is private"></i>
             ) : false}
             {props.isDirect ? (<span>»&nbsp;</span>) : false}
-            <Link to={`/${props.createdBy.username}/${props.id}`} className="post-timestamp">
+            <Link to={`/${urlName}/${props.id}`} className="post-timestamp">
               <time dateTime={createdAtISO} title={createdAtHuman}>{createdAgo}</time>
             </Link>
             {commentLink}
@@ -331,7 +338,8 @@ export default class Post extends React.Component {
             addComment={props.addComment}
             toggleCommenting={props.toggleCommenting}
             showMoreComments={props.showMoreComments}
-            commentEdit={props.commentEdit}/>
+            commentEdit={props.commentEdit}
+            entryUrl={`/${urlName}/${props.id}`}/>
         </div>
       </div>
     ));


### PR DESCRIPTION
If post is published _only_ in groups, use first group username for canonical post URL.
