### PR TITLE
Better look of image attachments with extremal dimensions

### DIFF
--- a/styles/shared/attachments.scss
+++ b/styles/shared/attachments.scss
@@ -33,10 +33,7 @@
     border: 1px solid silver;
     padding: 1px;
     margin: 0 8px 8px 0;
-    height: 175px;
     box-sizing: content-box;
-    line-height: 170px;
-    min-width: 50px;
     text-align: center;
 
     img {
@@ -46,6 +43,13 @@
 
     &.surplus {
       display: none;
+    }
+
+    a {
+      display: block;
+      min-width: 32px;
+      min-height: 32px;
+      line-height: 30px;
     }
   }
 
@@ -136,6 +140,8 @@
     display: none;
     width: 24px;
     color: #8ab;
+    vertical-align: middle;
+    margin-bottom: 8px;
     
     .fa {
       cursor: pointer;


### PR DESCRIPTION
No more fixed preview heights, minimal preview click zone is 32×32 px.

![image](https://cloud.githubusercontent.com/assets/132120/15960858/7b666664-2f0a-11e6-86bf-3ab49edc80ed.png)
