### PR TITLE
Add the authentication token immediately before sending the file

### DIFF
--- a/src/components/dropzone.jsx
+++ b/src/components/dropzone.jsx
@@ -25,8 +25,7 @@ const dropzoneConfig = {
   `,
   clickable: '.dropzone-trigger', // Define the element that should be used as click trigger to select files.
   headers: {
-    'Cache-Control': null,
-    'X-Authentication-Token': getToken()
+    'Cache-Control': null
   }
 };
 
@@ -49,6 +48,10 @@ const dropzoneEventHandlers = ({addAttachmentResponse, addedFile, removedFile}) 
       dropEvent.dataTransfer = { types: e.dataTransfer.types };
     }
     window.dispatchEvent(dropEvent);
+  },
+
+  sending: function(file, xhr, form) {
+    xhr.setRequestHeader('X-Authentication-Token', getToken());
   },
 
   success: function(file, response) {


### PR DESCRIPTION
Because in some scenarios we have not authentication cookie when page loads. It should fix this bug: https://freefeed.net/support/0a5b1e6d-0854-4112-9c0e-c973ce09d6b4.
