### PR TITLE
Added a notice explaining the lack of a post form on restricted group pages

### DIFF
--- a/src/components/user-profile.jsx
+++ b/src/components/user-profile.jsx
@@ -118,7 +118,7 @@ export default class UserProfile extends React.Component {
                   </p>
                 </div>
               </div>
-            ) : false} 
+            ) : false}
           </div>
         ) : false}
 
@@ -134,6 +134,12 @@ export default class UserProfile extends React.Component {
             addAttachmentResponse={props.addAttachmentResponse}
             removeAttachment={props.removeAttachment}/>
         ) : false}
+
+        {!props.canIPostHere && props.isRestricted === '1' ? (
+          <div className="create-post create-post-restricted">
+            Only administrators can post to this group.
+          </div>
+          ) : false}
       </div>
     );
   }


### PR DESCRIPTION
Some groups have posting access restricted only to group administrators. This change adds a notice explaining the lack of a new post form when viewed by a non-admin user.

https://freefeed.net/support/f83652ca-4289-4997-b349-a7932b628ba4
