### PR TITLE
Improved error feedback on settings page

### DIFF
--- a/src/components/user-settings-form.jsx
+++ b/src/components/user-settings-form.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {preventDefault} from '../utils';
 import throbber16 from 'assets/images/throbber-16.gif';
+import classnames from 'classnames';
 
 export default class UserSettingsForm extends React.Component {
   updateSetting = (setting) => (e) => {
@@ -19,9 +20,14 @@ export default class UserSettingsForm extends React.Component {
   render() {
     return (
       <form onSubmit={preventDefault(this.updateUser)}>
-        <div className="form-group">
+        <div className={classnames({'form-group': true, 'has-feedback': this.props.screenName, 'has-error': this.props.screenName && (this.props.screenName.length < 3 || this.props.screenName.length > 25), 'has-success': this.props.screenName && (this.props.screenName.length >= 3 && this.props.screenName.length <= 25) })}>
+          {
+            this.props.screenName ? (
+              <span className="help-block displayName-input-hint">{this.props.screenName.length} of 25</span>
+              ) : false
+          }
           <label htmlFor="displayName-input">Display name:</label>
-          <input id="displayName-input" className="form-control" name="screenName" type="text" defaultValue={this.props.user.screenName} onChange={this.updateSetting('screenName')}/>
+          <input id="displayName-input" className="form-control" name="screenName" type="text" defaultValue={this.props.user.screenName} onChange={this.updateSetting('screenName')} maxLength="100"/>
         </div>
         <div className="form-group">
           <label htmlFor="email-input">Email:</label>
@@ -49,7 +55,7 @@ export default class UserSettingsForm extends React.Component {
         {this.props.success ? (
           <div className="alert alert-info" role="alert">Updated!</div>
         ) : this.props.error ? (
-          <div className="alert alert-danger" role="alert">Something went wrong during user settings update</div>
+          <div className="alert alert-danger" role="alert">{this.props.errorMessage}</div>
         ) : false}
       </form>
     );

--- a/src/components/user-settings-form.jsx
+++ b/src/components/user-settings-form.jsx
@@ -18,13 +18,20 @@ export default class UserSettingsForm extends React.Component {
   }
 
   render() {
+    const className = classnames({
+      'form-group': true,
+      'has-feedback': this.props.screenName,
+      'has-error': this.props.screenName && (this.props.screenName.length < 3 || this.props.screenName.length > 25),
+      'has-success': this.props.screenName && (this.props.screenName.length >= 3 && this.props.screenName.length <= 25)
+    });
+
     return (
       <form onSubmit={preventDefault(this.updateUser)}>
-        <div className={classnames({'form-group': true, 'has-feedback': this.props.screenName, 'has-error': this.props.screenName && (this.props.screenName.length < 3 || this.props.screenName.length > 25), 'has-success': this.props.screenName && (this.props.screenName.length >= 3 && this.props.screenName.length <= 25) })}>
+        <div className={className}>
           {
             this.props.screenName ? (
               <span className="help-block displayName-input-hint">{this.props.screenName.length} of 25</span>
-              ) : false
+            ) : false
           }
           <label htmlFor="displayName-input">Display name:</label>
           <input id="displayName-input" className="form-control" name="screenName" type="text" defaultValue={this.props.user.screenName} onChange={this.updateSetting('screenName')} maxLength="100"/>

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -1171,7 +1171,7 @@ export function usersNotFound(state = [], action) {
         const {username} = action.request;
         if (state.indexOf(username) < 0) {
           state = [...state, username];
-        } 
+        }
         return state;
       }
     }
@@ -1362,7 +1362,7 @@ export function userSettingsForm(state={saved: false}, action) {
       return {...state, isSaving: false, success: true, error: false};
     }
     case fail(ActionTypes.UPDATE_USER): {
-      return {...state, isSaving: false, success: false, error: true};
+      return {...state, isSaving: false, success: false, error: true, errorMessage: (action.payload || {}).err};
     }
   }
   return state;

--- a/styles/shared/settings.scss
+++ b/styles/shared/settings.scss
@@ -6,3 +6,14 @@
   margin-top: 20px;
   margin-bottom: 15px;
 }
+
+.has-feedback #displayName-input {
+    padding-right: 75px;
+}
+
+.displayName-input-hint {
+    position: absolute;
+    top: 32px;
+    right: 12px;
+    margin: 0;
+}


### PR DESCRIPTION
Error messages (such as "invalid email" or "username too long") are now properly displayed instead of a generic "something went wrong" one.

Added a character count and visual validation feedback to displayName input field. 

Closes T20
