### PR TITLE
Improvements for mobile styles

### DIFF
--- a/styles/helvetica/header.scss
+++ b/styles/helvetica/header.scss
@@ -26,6 +26,7 @@ header {
 
     a {
       margin-right: 30px;
+      @media (max-width: 400px) { margin-right: 15px; }
     }
   }
 

--- a/styles/shared/attachments.scss
+++ b/styles/shared/attachments.scss
@@ -39,6 +39,10 @@
     img {
       max-width: 525px;
       max-height: 175px;
+      @media (max-width: 400px) {
+        max-width: 250px;
+        height: auto;
+     }
     }
 
     &.surplus {
@@ -133,27 +137,27 @@
     border: 2px solid #3d3;
     padding: 0;
   }
-  
+
   .show-more {
     display: none;
     width: 24px;
     color: #8ab;
     vertical-align: middle;
     margin-bottom: 8px;
-    
+
     .fa {
       cursor: pointer;
       transform: rotate(-180deg);
       transition: transform 0.3s 0.1s;
     }
   }
-  
+
   &.needs-folding {
     .show-more {
       display: inline-block;
     }
   }
-  
+
   &.is-folded .show-more .fa {
     transform: rotate(0);
   }

--- a/styles/shared/comments.scss
+++ b/styles/shared/comments.scss
@@ -35,6 +35,7 @@
   }
 
   .comment-body {
+    word-wrap: break-word;
     margin-left: 19px;
   }
 
@@ -73,7 +74,7 @@
   &.highlighted {
     $hl-color: #D9EBFF;
     background-color: $hl-color;
- 
+
     &::before {
       $border-width: 3px;
       content: '';

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -45,6 +45,7 @@
 
     .post-text {
       margin-bottom: 8px;
+      word-wrap: break-word;
       @media (max-width: 767px) { min-height: 31px; }
 
       color: #000;


### PR DESCRIPTION
A number of changes is made to improve the look of the site on small screens such as iPhone 5S in portrait orientation:
1. reduced the margin between top menu elements to make sure they fit on one line
2. added a constraint on max-width of image attachments
3. added word-wrap: break-word to post and comment bodies to prevent long words and links from stretching the page (thanks @clbn)
