### PR TITLE
Fix the issue with feeds selector

### DIFF
--- a/src/components/create-post.jsx
+++ b/src/components/create-post.jsx
@@ -12,8 +12,7 @@ const getDefaultState = defaultFeed => ({
   isMoreOpen: false,
   attachmentQueueLength: 0,
   postText:'',
-  commentsDisabled: false,
-  selectFeeds: (defaultFeed ? [defaultFeed] : []),
+  commentsDisabled: false
 });
 
 export default class CreatePost extends React.Component {
@@ -24,7 +23,7 @@ export default class CreatePost extends React.Component {
 
   createPost = _ => {
     // Get all the values
-    let feeds = this.state.selectFeeds;
+    let feeds = this.refs.selectFeeds.values;
     let postText = this.state.postText;
     let attachmentIds = this.props.createPostForm.attachments.map(attachment => attachment.id);
     let more = {
@@ -53,7 +52,7 @@ export default class CreatePost extends React.Component {
   removeAttachment = (attachmentId) => this.props.removeAttachment(null, attachmentId)
 
   checkCreatePostAvailability = (e) => {
-    let isFormEmpty = isTextEmpty(this.state.postText) || this.state.selectFeeds.length === 0;
+    let isFormEmpty = isTextEmpty(this.state.postText) || this.refs.selectFeeds.values === 0;
 
     this.setState({
       isFormEmpty
@@ -62,11 +61,6 @@ export default class CreatePost extends React.Component {
 
   onPostTextChange = (e) => {
     this.setState({postText: e.target.value}, this.checkCreatePostAvailability);
-  }
-
-  selectFeedsChanged = (selectFeeds) => {
-    this.setState({selectFeeds});
-    this.checkCreatePostAvailability();
   }
 
   checkSave = (e) => {
@@ -100,12 +94,12 @@ export default class CreatePost extends React.Component {
       <div className="create-post post-editor">
         <div>
           {this.props.sendTo.expanded ? (
-            <SendTo
+            <SendTo ref="selectFeeds"
               feeds={this.props.sendTo.feeds}
               defaultFeed={this.props.sendTo.defaultFeed}
               isDirects={this.props.isDirects}
               user={this.props.user}
-              onChange={this.selectFeedsChanged}/>
+              onChange={this.checkCreatePostAvailability}/>
           ) : false}
 
           <Dropzone

--- a/src/components/send-to.jsx
+++ b/src/components/send-to.jsx
@@ -11,7 +11,7 @@ export default class SendTo extends React.Component {
     const options = this.feedsToOptions(props.feeds, props.user.username, props.isDirects);
 
     this.state = {
-      values: (props.defaultFeed ? [options[0]] : []),
+      values: (props.defaultFeed ? [this.defaultOption(options, props.defaultFeed)] : []),
       options: options,
       showFeedsOption: !props.defaultFeed,
       isWarningDisplayed: false
@@ -25,7 +25,7 @@ export default class SendTo extends React.Component {
     // set values, options and showFeedsOption. Otherwise, only update options.
     if (this.props.defaultFeed !== newProps.defaultFeed) {
       this.setState({
-        values: (newProps.defaultFeed ? [newOptions[0]] : []),
+        values: (newProps.defaultFeed ? [this.defaultOption(newOptions, newProps.defaultFeed)] : []),
         options: newOptions,
         showFeedsOption: !newProps.defaultFeed
       });
@@ -95,9 +95,12 @@ export default class SendTo extends React.Component {
     }
   }
 
+  defaultOption = (options, defaultFeed) => {
+    return options.reduce((found, opt) => (!found && opt.value === defaultFeed) ? opt : found, null);
+  }
+
   render() {
-    const defaultFeed = this.state.values[0];
-    const defaultOpt = this.state.options.reduce((found, opt) => (!found && opt.value === defaultFeed) ? opt : found, null);
+    const defaultOpt = this.defaultOption(this.state.options, this.state.values[0]);
 
     return (
       <div className="send-to">


### PR DESCRIPTION
When creating new post do not track chosen feeds state manually, SendTo component should do this by himself. Get the feeds from the refs.
