### PR TITLE
Fix for subscriber pages showing subscribers of currently logged in user

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -69,7 +69,7 @@ const friendsActions = next => {
 
 // needed to display mutual friends
 const subscribersSubscriptionsActions = next => {
-  const username = store.getState().user.username;
+  const username = next.params.userName;
   store.dispatch(ActionCreators.subscribers(username));
   store.dispatch(ActionCreators.subscriptions(username));
 };


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/FreeFeed/freefeed-react-client/pull/492: subscriber/subscriptions pages for other accounts show people subscribed to currently logged in user, not to the owner of that account (https://freefeed.net/support/5043362f-67d8-4ead-8bf5-8ecc5bc40ce6)
