### PR TITLE
Hide 'http(s)://' from URL's in posts and comments texts

### DIFF
--- a/src/components/linkify.jsx
+++ b/src/components/linkify.jsx
@@ -75,7 +75,7 @@ class Linkify extends React.Component {
         let href;
 
         if (it.type === LINK) {
-          displayedLink = shorten(it.text, MAX_URL_LENGTH);
+          displayedLink = shorten(it.text, MAX_URL_LENGTH).replace(/^https?:\/\//, '');
           href = it.url;
         } else if (it.type === AT_LINK) {
           elements.push(<UserName 
@@ -85,7 +85,7 @@ class Linkify extends React.Component {
             key={`match${++this.idx}`}/>);
           return;
         } else if (it.type === LOCAL_LINK) {
-          displayedLink = shorten(it.text, MAX_URL_LENGTH);
+          displayedLink = shorten(it.text, MAX_URL_LENGTH).replace(/^https?:\/\//, '');
           href = it.uri;
         } else if (it.type === EMAIL) {
           href = `mailto:${it.address}`;


### PR DESCRIPTION
This will lead to a cleaner appearance of the text.
