### PR TITLE
Enable to remove posts by specific users or groups from the homefeed

### DIFF
--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -77,6 +77,18 @@ export default class Post extends React.Component {
       props.createdBy.profilePictureLargeUrl : props.createdBy.profilePictureMediumUrl;
     const profilePictureSize = props.isSinglePost ? 75 : 50;
 
+    // Hidden user or group
+    if (props.isInHomeFeed) {
+      const hiddenUsers = props.user.frontendPreferences.homefeed.hideUsers;
+      if (!_.isEmpty(hiddenUsers)) {
+        const rcpNames = props.recipients.map(u => u.username);
+        rcpNames.push(props.createdBy.username);
+        if (!_.isEmpty(_.intersection(rcpNames, hiddenUsers))) {
+          return false;
+        }
+      }
+    }
+
     const postClass = classnames({
       'post': true,
       'single-post': props.isSinglePost,

--- a/src/components/user-frontend-preferences-form.jsx
+++ b/src/components/user-frontend-preferences-form.jsx
@@ -8,6 +8,7 @@ export default class UserFrontendPreferencesForm extends React.Component {
   constructor(props) {
     super(props);
     this.state = this.props.preferences;
+    this.state.sHideUsers = this.state.homefeed.hideUsers.join(', ');
   }
 
   changeDisplayOption = (event) => {
@@ -52,9 +53,18 @@ export default class UserFrontendPreferencesForm extends React.Component {
     });
   }
 
+  chandeHideUsers = (event) => {
+    this.setState({
+      sHideUsers: event.target.value
+    });
+  }
+
   savePreferences = () => {
     if (this.props.status !== 'loading') {
-      this.props.updateFrontendPreferences(this.props.userId, this.state);
+      const prefs = {...this.state};
+      prefs.homefeed.hideUsers = prefs.sHideUsers.toLowerCase().match(/[\w-]+/g) || [];
+      delete prefs.sHideUsers;
+      this.props.updateFrontendPreferences(this.props.userId, prefs);
     }
   }
 
@@ -125,6 +135,12 @@ export default class UserFrontendPreferencesForm extends React.Component {
             <input type="checkbox" name="bubbles" value="1" checked={this.state.allowLinksPreview} onChange={this.changeAllowLinksPreview}/>
               Show preview for links in post. Link should start with http(s)://, post should have no attached images. If you don't want to have link preview, add ! before a link without spaces.
           </label>
+        </div>
+
+        <div className="form-group">
+          Hide posts from these users/groups in homefeed 
+          (enter comma separated list of usernames/groupnames):<br/>
+          <textarea className="form-control" value={this.state.sHideUsers} onChange={this.chandeHideUsers}/>
         </div>
 
         <p>

--- a/src/config.js
+++ b/src/config.js
@@ -41,7 +41,10 @@ const config = {
         omitRepeatedBubbles: true,
         highlightComments: true
       },
-      allowLinksPreview: false
+      allowLinksPreview: false,
+      homefeed: {
+        hideUsers: []
+      }
     }
   }
 };


### PR DESCRIPTION
This is a client-side "soft hide": user can remove posts by specific users or groups from his/her homefeed. User can manage hide list from the Settings page or (per-user) from the floaters with user information.

Please review.
