### PR TITLE
Remove the link to the twitter account from the footer

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -4,6 +4,6 @@ import {Link} from 'react-router';
 export default () => (
   <footer className="footer">
     &copy; FreeFeed 1.5.1 (October 20, 2016)<br/>
-    <Link to="/about">About</Link> | <Link to="/freefeed">News</Link> | <a href="https://twitter.com/freefeednet" target="_blank">Twitter</a> | <a href="https://status.freefeed.net/" target="_blank">Status</a> | <a href="https://dev.freefeed.net/" target="_blank">Development</a>
+    <Link to="/about">About</Link> | <Link to="/freefeed">News</Link> | <a href="https://status.freefeed.net/" target="_blank">Status</a> | <a href="https://dev.freefeed.net/" target="_blank">Development</a>
   </footer>
 );


### PR DESCRIPTION
Because https://twitter.com/freefeednet hasn't been updated in almost a year.
