### PR TITLE
Do not change domain part of freefeed's subdomain links

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -20,10 +20,7 @@ const config = {
     sentinel: null // keep always last
   },
   siteDomains: [ // for transform links in the posts, comments, etc.
-    'freefeed.net',
-    'm.freefeed.net',
-    'beta.freefeed.net',
-    'old.freefeed.net'
+    'freefeed.net'
   ],
   sentry: {
     publicDSN: null,


### PR DESCRIPTION
So links to m.freefeed.net will stay untouched in posts and comments.