### PR TITLE
Fix 'Cannot read property 'value' of null' error in SendTo component

### DIFF
--- a/src/components/send-to.jsx
+++ b/src/components/send-to.jsx
@@ -1,38 +1,21 @@
 import React from 'react';
 import Select from 'react-select';
-import {preventDefault} from '../utils';
 
 const MY_FEED_LABEL = 'My feed';
 
 export default class SendTo extends React.Component {
   constructor(props) {
     super(props);
-
-    const options = this.feedsToOptions(props.feeds, props.user.username, props.isDirects);
-
-    this.state = {
-      values: (props.defaultFeed ? [this.defaultOption(options, props.defaultFeed)] : []),
-      options: options,
-      showFeedsOption: !props.defaultFeed,
-      isWarningDisplayed: false
-    };
+    this.state = this.stateFromProps(props);
   }
 
   componentWillReceiveProps(newProps) {
-    const newOptions = this.feedsToOptions(newProps.feeds, newProps.user.username, this.props.isDirects);
-
     // If defaultFeed gets updated (it happens after sign-in), we have to
-    // set values, options and showFeedsOption. Otherwise, only update options.
+    // fully update state. Otherwise, only update options.
     if (this.props.defaultFeed !== newProps.defaultFeed) {
-      this.setState({
-        values: (newProps.defaultFeed ? [this.defaultOption(newOptions, newProps.defaultFeed)] : []),
-        options: newOptions,
-        showFeedsOption: !newProps.defaultFeed
-      });
+      this.setState(this.stateFromProps(newProps));
     } else {
-      this.setState({
-        options: newOptions
-      });
+      this.setState({options: this.optionsFromProps(newProps)});
     }
   }
 
@@ -40,29 +23,33 @@ export default class SendTo extends React.Component {
     return this.state.values.map(item => item.value);
   }
 
-  feedsToOptions = (feeds, username, isDirects) => {
-    let options = feeds.map((item) => ({
-      label: item.user.username,
-      value: item.user.username,
-      type: item.user.type
+  stateFromProps(props) {
+    const options = this.optionsFromProps(props);
+    return {
+      values: options.filter(opt => opt.value === props.defaultFeed),
+      options: options,
+      showFeedsOption: !props.defaultFeed,
+      isWarningDisplayed: false
+    };
+  }
+
+  optionsFromProps({feeds, user: {username}, isDirects}) {
+    const options = feeds.map(({user: {username, type}}) => ({
+      label: username,
+      value: username,
+      type,
     }));
 
-    options.sort((a, b) => {
-      return (a.type !== b.type) ? a.type.localeCompare(b.type) : a.value.localeCompare(b.value);
-    });
+    options.sort((a, b) => (a.type !== b.type) ? a.type.localeCompare(b.type) : a.value.localeCompare(b.value));
 
     // use type "group" for "my feed" option to hide the warning about direct message visibility
     options.unshift({ label: MY_FEED_LABEL, value: username, type: 'group' });
 
-    if (isDirects) {
-      // only mutual friends
-      options = options.filter(opt => opt.type === 'user');
-    }
-
-    return options;
+    // only mutual friends on Directs page
+    return isDirects ? options.filter(opt => opt.type === 'user') : options;
   }
 
-  isGroupsOrDirectsOnly = (values) => {
+  isGroupsOrDirectsOnly(values) {
     const types = {};
     for (const v of values) {
       types[v.type] = v;
@@ -95,10 +82,6 @@ export default class SendTo extends React.Component {
     }
   }
 
-  defaultOption = (options, defaultFeed) => {
-    return options.reduce((found, opt) => (!found && opt.value === defaultFeed) ? opt : found, null);
-  }
-
   render() {
     const defaultOpt = this.state.values[0];
 
@@ -108,7 +91,7 @@ export default class SendTo extends React.Component {
           <div>
             To:&nbsp;
             <span className="Select-value-label-standalone">{this.labelRenderer(defaultOpt)}</span>
-            <a className="p-sendto-toggler" onClick={preventDefault(() => this.toggleSendTo())}>Add/Edit</a>
+            <a className="p-sendto-toggler" onClick={this.toggleSendTo}>Add/Edit</a>
           </div>
         ) : (
           <div>


### PR DESCRIPTION
In old code when a user starts type a post on Directs page with empty “Send to” selector, he was getting error message 'Cannot read property 'value' of null'. In this case state.values wasn't really empty (`[]`) but have one null value (`[null]`).