### PR TITLE
Do not return undefined from joinPostData

### DIFF
--- a/src/components/select-utils.js
+++ b/src/components/select-utils.js
@@ -50,7 +50,10 @@ const commentHighlighter = ({commentsHighlights, user, postsViewState}, comments
 export const joinPostData = state => postId => {
   const post = state.posts[postId];
   if (!post) {
-    return;
+    if (typeof Raven !== 'undefined') {
+      Raven.captureMessage(`We've got a post that doesn't exists in store`, { extra: { postId }});
+    }
+    return {id: postId};
   }
   const user = state.user;
 


### PR DESCRIPTION
In some rare case joinPostData can not find post in store. It leads to "Cannot read property 'isHidden' of undefined" error in Feed component. Trying to log this case to Sentry and return fake object.