### PR TITLE
Enable hiding feeds from non-registered users

### DIFF
--- a/src/components/user-settings-form.jsx
+++ b/src/components/user-settings-form.jsx
@@ -5,15 +5,34 @@ import throbber16 from '../../assets/images/throbber-16.gif';
 import {preventDefault} from '../utils';
 
 export default class UserSettingsForm extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.props.userSettingsChange({
+      isPrivate: this.props.user.isPrivate,
+      isVisibleToAnonymous: this.props.user.isVisibleToAnonymous
+    });
+  }
+
   updateSetting = (setting) => (e) => {
     this.props.userSettingsChange({[setting]: e.target.value});
   }
-  updateChecked = (e) => {
+
+  updateCheckedPrivate = (e) => {
     this.props.userSettingsChange({isPrivate: e.target.checked ? '1' : '0'});
+    if (e.target.checked) {
+      this.props.userSettingsChange({isVisibleToAnonymous: '0'}); // private users must not be visible to anonymous
+    }
   }
+
+  updateCheckedAnonymous = (e) => {
+    this.props.userSettingsChange({isVisibleToAnonymous: e.target.checked ? '1' : '0'});
+  }
+
   updateUser = () => {
     if (!this.props.isSaving) {
-      this.props.updateUser(this.props.user.id, this.props.screenName, this.props.email, this.props.isPrivate, this.props.description);
+      this.props.updateUser(this.props.user.id, this.props.screenName, this.props.email, this.props.isPrivate, this.props.isVisibleToAnonymous, this.props.description);
     }
   }
 
@@ -24,6 +43,8 @@ export default class UserSettingsForm extends React.Component {
       'has-error': this.props.screenName && (this.props.screenName.length < 3 || this.props.screenName.length > 25),
       'has-success': this.props.screenName && (this.props.screenName.length >= 3 && this.props.screenName.length <= 25)
     });
+
+    const disabledAnonymousCheckbox = this.props.isPrivate == '1';
 
     return (
       <form onSubmit={preventDefault(this.updateUser)}>
@@ -46,9 +67,16 @@ export default class UserSettingsForm extends React.Component {
         </div>
         <div className="checkbox">
           <label>
-            <input type="checkbox" name="isPrivate" defaultChecked={this.props.user.isPrivate == '1'} onChange={this.updateChecked}/>
+            <input type="checkbox" name="isPrivate" checked={this.props.isPrivate == '1'} onChange={this.updateCheckedPrivate}/>
             Private feed
             <small> (only let people I approve see my feed)</small>
+          </label>
+        </div>
+        <div className={'checkbox' + (disabledAnonymousCheckbox ? ' checkbox-disabled' : '')}>
+          <label>
+            <input type="checkbox" name="isVisibleToAnonymous" onChange={this.updateCheckedAnonymous} checked={this.props.isVisibleToAnonymous == '1'} disabled={disabledAnonymousCheckbox}/>
+            Visible to anonymous users and search engines
+            <small> (only let people who are logged in see my feed)</small>
           </label>
         </div>
         <p>

--- a/src/components/user.jsx
+++ b/src/components/user.jsx
@@ -40,6 +40,7 @@ const UserHandler = (props) => {
 function selectState(state, ownProps) {
   const user = state.user;
   const authenticated = state.authenticated;
+  const anonymous = !authenticated;
   const visibleEntries = state.feedViewState.visibleEntries.map(joinPostData(state));
   const createPostViewState = state.createPostViewState;
   const createPostForm = joinCreatePostData(state);
@@ -73,6 +74,7 @@ function selectState(state, ownProps) {
   };
 
   statusExtension.canISeeSubsList = statusExtension.isUserFound &&
+    (!anonymous || foundUser.isVisibleToAnonymous === '1') &&
     (foundUser.isPrivate === '0' || statusExtension.subscribed || statusExtension.isItMe);
 
   const canIPostToGroup = statusExtension.subscribed && (foundUser.isRestricted === '0' || amIGroupAdmin);

--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -359,11 +359,11 @@ export function signUpEmpty(errorMessage) {
   };
 }
 
-export function updateUser(id, screenName, email, isPrivate, description) {
+export function updateUser(id, screenName, email, isPrivate, isVisibleToAnonymous, description) {
   return {
     type: ActionTypes.UPDATE_USER,
     apiRequest: Api.updateUser,
-    payload: {id, screenName, email, isPrivate, description},
+    payload: {id, screenName, email, isPrivate, isVisibleToAnonymous, description},
   };
 }
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -281,7 +281,7 @@ export function markAllDirectsAsRead() {
   return fetch(`${apiConfig.host}/v2/users/markAllDirectsAsRead`, getRequestOptions());
 }
 
-export function updateUser({id, screenName, email, isPrivate, description}) {
+export function updateUser({id, screenName, email, isPrivate, isVisibleToAnonymous, description}) {
   return fetch(`${apiConfig.host}/v1/users/${id}`, {
     'method': 'PUT',
     'headers': {
@@ -289,7 +289,7 @@ export function updateUser({id, screenName, email, isPrivate, description}) {
       'Content-Type': 'application/json',
       'X-Authentication-Token': getToken()
     },
-    'body': JSON.stringify({user: {screenName, email, isPrivate, description}})
+    'body': JSON.stringify({user: {screenName, email, isPrivate, isVisibleToAnonymous, description}})
   });
 }
 

--- a/styles/shared/forms.scss
+++ b/styles/shared/forms.scss
@@ -78,3 +78,7 @@ label.option-box {
     padding-bottom: 5px;
   }
 }
+
+.checkbox-disabled label {
+  color: #aaa;
+}


### PR DESCRIPTION
Adds a checkbox to settings page that allows users to hide their feeds from anonymous users (such as unregistered strangers and search engines).

Depends on backend PR https://github.com/FreeFeed/freefeed-server/pull/141

