### PR TITLE
Mark postId as not required in ImageAttachmentsContainer

### DIFF
--- a/src/components/post-attachment-image-container.jsx
+++ b/src/components/post-attachment-image-container.jsx
@@ -13,7 +13,7 @@ export default class ImageAttachmentsContainer extends React.Component {
     isSinglePost: pt.bool,
     isEditing: pt.bool,
     removeAttachment: pt.func,
-    postId: pt.string.isRequired,
+    postId: pt.string,
   };
 
   state = {

--- a/src/components/post-attachment-image-lightbox.jsx
+++ b/src/components/post-attachment-image-lightbox.jsx
@@ -20,7 +20,7 @@ export default class ImageAttachmentsLightbox extends React.Component {
       h: pt.number.isRequired,
       pid: pt.string.isRequired,
     })).isRequired,
-    postId: pt.string.isRequired,
+    postId: pt.string,
     getThumbnail: pt.func.isRequired,
   };
 


### PR DESCRIPTION
postId doesnt exists in create post form