### PR TITLE
Replace useless SERVER_ERROR action to _BREAKDOWN modifier

### DIFF
--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -1,13 +1,6 @@
 import * as Api from '../services/api';
 import * as ActionTypes from './action-types';
 
-export function serverError(error) {
-  return {
-    type: ActionTypes.SERVER_ERROR,
-    error
-  };
-}
-
 export function unauthenticated(payload) {
   return {
     type: ActionTypes.UNAUTHENTICATED,

--- a/src/redux/action-helpers.js
+++ b/src/redux/action-helpers.js
@@ -7,6 +7,7 @@ import {
 export const request = (type) =>`${type}_REQUEST`;
 export const response = (type) => `${type}_RESPONSE`;
 export const fail = (type) => `${type}_FAIL`;
+export const breakdown = (type) => `${type}_BREAKDOWN`;
 
 export const feedGeneratingActions = [HOME, DISCUSSIONS, GET_USER_FEED, GET_USER_COMMENTS, GET_USER_LIKES, DIRECT, GET_SEARCH, GET_BEST_OF];
 export const feedRequests = feedGeneratingActions.map(request);

--- a/src/redux/action-types.js
+++ b/src/redux/action-types.js
@@ -1,4 +1,3 @@
-export const SERVER_ERROR = 'SERVER_ERROR';
 export const UNAUTHENTICATED = 'UNAUTHENTICATED';
 export const STATIC_PAGE = 'STATIC_PAGE';
 export const WHO_AM_I = 'WHO_AM_I';

--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -8,7 +8,7 @@ import {userParser, delay} from '../utils';
 
 import * as ActionCreators from './action-creators';
 import * as ActionTypes from './action-types';
-import {request, response, fail, requiresAuth, isFeedRequest, isFeedResponse} from './action-helpers';
+import {request, response, fail, breakdown, requiresAuth, isFeedRequest, isFeedResponse} from './action-helpers';
 
 //middleware for api requests
 export const apiMiddleware = store => next => async (action) => {
@@ -37,7 +37,7 @@ export const apiMiddleware = store => next => async (action) => {
     if (typeof Raven !== 'undefined') {
       Raven.captureException(e, { level: 'error', tags: { area: 'redux/apiMiddleware' }, extra: { action } });
     }
-    return store.dispatch(ActionCreators.serverError(e));
+    return store.dispatch({...action, type: breakdown(action.type), apiRequest: null});
   }
 };
 

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -161,15 +161,6 @@ export function signUpForm(state=INITIAL_SIGN_UP_FORM_STATE, action) {
   return state;
 }
 
-export function serverError(state = false, action) {
-  switch (action.type) {
-    case ActionTypes.SERVER_ERROR: {
-      return true;
-    }
-  }
-  return state;
-}
-
 const CREATE_POST_ERROR = 'Something went wrong while creating the post...';
 
 export function createPostViewState(state = {}, action) {


### PR DESCRIPTION
In case of network failure during some 'FOO' API request, fire a 'FOO_BREAKDOWN' action.