### PR TITLE
Disable scroll anchoring for entire site

### DIFF
--- a/styles/helvetica/base.scss
+++ b/styles/helvetica/base.scss
@@ -1,5 +1,6 @@
 body {
   background: #FFF;
+  overflow-anchor: none;
 }
 
 body.transition-active:before {


### PR DESCRIPTION
The new Chrome feature “scroll anchoring” conflicts with our scroll compensation algorithms.

See: https://blog.chromium.org/2017/04/scroll-anchoring-for-web-developers.html