### PR TITLE
highlight answering comment while editing

### DIFF
--- a/src/components/post-comment.jsx
+++ b/src/components/post-comment.jsx
@@ -66,6 +66,14 @@ export default class PostComment extends React.Component {
   checkSave = (event) => {
     const isEnter = event.keyCode === 13;
     const isShiftPressed = event.shiftKey;
+
+    const arrows = event.target.value.match(/^\^+/);
+    if (arrows) {
+      this.props.highlightArrowComment(arrows[0].length - 1);
+    } else {
+      this.props.clearHighlightComment();
+    }
+
     if (isEnter && !isShiftPressed) {
       event.preventDefault();
       event.target.blur();

--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -38,7 +38,7 @@ export default class PostComments extends React.Component {
     }
   }
 
-  renderAddingComment() {
+  renderAddingComment(last) {
     const props = this.props;
     return (
       <PostComment
@@ -51,6 +51,8 @@ export default class PostComments extends React.Component {
         saveEditingComment={props.addComment}
         toggleEditingComment={props.toggleCommenting}
         errorString={props.commentError}
+        highlightArrowComment={arrows => props.commentEdit.highlightComment(props.post.id, undefined, arrows, last.id)}
+        clearHighlightComment={props.commentEdit.clearHighlightComment}
         isSaving={props.post.isSavingComment}/>
     );
   }
@@ -175,7 +177,7 @@ export default class PostComments extends React.Component {
         {last ? this.renderComment(last) : false}
         {canAddComment
           ? (post.isCommenting
-              ? this.renderAddingComment()
+              ? this.renderAddingComment(last)
               : this.renderAddCommentLink())
           : false}
       </div>


### PR DESCRIPTION
This is a WIP commit for a new feature - highlighting comment which is currently answered.
When you are editing a comment, then putting arrows(^^^) at the beginning will highlight corresponding comment.



┆Issue is synchronized with this [Trello card](https://trello.com/c/8iiYTKgz)
