### PR TITLE
Enable redux-devtools unconditionally

### DIFF
--- a/src/redux/configure-store.js
+++ b/src/redux/configure-store.js
@@ -32,16 +32,10 @@ const middleware = [
   realtimeMiddleware
 ];
 
-const isDevelopment = process.env.NODE_ENV != 'production';
-
 const enhancers = [applyMiddleware(...middleware),];
 
-//tells webpack to include devtool enhancer in dev mode
-if (isDevelopment && window.devToolsExtension) {
-  enhancers.push(window.devToolsExtension());
-}
-
-const storeEnhancer = compose(...enhancers);
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const storeEnhancer = composeEnhancers(...enhancers);
 
 const createStoreWithMiddleware = storeEnhancer(createStore);
 const reducer = combineReducers({...reducers, routing: routerReducer});


### PR DESCRIPTION
1. Enable redux-devtools unconditionally
2. Use newer syntax

This would allow us to debug dataflow issues in production with better reliability and granularity