### PR TITLE
Minor layout fixes

### DIFF
--- a/src/components/post-attachment-image-container.jsx
+++ b/src/components/post-attachment-image-container.jsx
@@ -90,11 +90,12 @@ export default class ImageAttachmentsContainer extends React.Component {
   }
 
   render() {
+    const isSingleImage = this.props.attachments.length === 1;
     const className = classnames({
       'image-attachments': true,
       'is-folded': this.state.isFolded,
       'needs-folding': this.state.needsFolding,
-      'single-image': this.props.attachments.length === 1
+      'single-image': isSingleImage
     });
 
     const showFolded = (this.state.needsFolding && this.state.isFolded);
@@ -120,12 +121,12 @@ export default class ImageAttachmentsContainer extends React.Component {
             isHidden={showFolded && i > lastVisibleIndex}
             {...a} />
         ))}
-        <div className="show-more">
+        {isSingleImage ? false : (<div className="show-more">
           <i
             className="fa fa-2x fa-chevron-circle-right"
             onClick={this.toggleFolding}
             title={this.state.isFolded ? `Show more (${this.props.attachments.length - lastVisibleIndex - 1})` : "Show less"}/>
-        </div>
+        </div>)}
         <ImageAttachmentsLightbox
           ref={(el) => this.lightbox = el}
           items={this.getLightboxItems()}

--- a/src/components/post-more-menu.jsx
+++ b/src/components/post-more-menu.jsx
@@ -25,7 +25,7 @@ export default class PostMoreMenu extends React.Component {
       align: 'left',
       close: this.close.bind(this),
       isOpen: this.state.isOpen,
-      toggle: <a onClick={this.toggle.bind(this)}>More&nbsp;&#x25be;</a>
+      toggle: <a className="post-action" onClick={this.toggle.bind(this)}>More&nbsp;&#x25be;</a>
     };
 
     return (

--- a/styles/shared/attachments.scss
+++ b/styles/shared/attachments.scss
@@ -140,7 +140,7 @@
   }
 
   .show-more {
-    display: none;
+    display: inline-block;
     width: 24px;
     color: #8ab;
     vertical-align: middle;
@@ -150,12 +150,6 @@
       cursor: pointer;
       transform: rotate(-180deg);
       transition: transform 0.3s 0.1s;
-    }
-  }
-
-  &.needs-folding {
-    .show-more {
-      display: inline-block;
     }
   }
 


### PR DESCRIPTION
This PR is a collection of minor fixes and improvements for HTML layout. The intention is to make theming (in future) or client-side CSS customisations (with Stylish) easier without impacting the existing look of the site too much, and refactoring [slow](https://csswizardry.com/2011/09/writing-efficient-css-selectors/) wide-ended `.something tag {}` into faster `.precise {}` selectors easier.

1. Changes "mobile shortcuts" block (and its parent) to be correctly hidden on medium and large screens using bootstrap classes, without leaving an empty div of 1px height. Also, it changes its width on small screens to be 8 units instead of 6 (because header is 4 units and 4 + 6 is 10, not 12).
2. Adds helpful class names for post action buttons ("Like", "Comment", etc).
3. Adds helpful class names for post userpic, mobile shortcut links and site "logo", refactors related CSS selectors.
4. Adds helpful class names for post likes, simplifies layout for likes (less `<span>`s), refactors related CSS selectors.
5. Changes `.user-name-wrapper` from `<div>` to `<span>` because it has `display: inline` anyway.