### PR TITLE
Transparent comment-likes

### DIFF
--- a/styles/shared/comment-likes.scss
+++ b/styles/shared/comment-likes.scss
@@ -46,6 +46,7 @@
 
 .comment-likes {
   display: inline-flex;
+  opacity: 0.3;
   align-items: flex-end;
   margin-right: 2px;
   margin-top: 1px;
@@ -116,6 +117,10 @@
       display: block;
     }
   }
+}
+
+.comment-likes:hover {
+  opacity: 1;
 }
 
 .comment:hover .comment-likes:not(.liked) {


### PR DESCRIPTION
Comment-likes are too bright and distract users from content. This pull-request fades them out by default and shows them fully only on `:hover`

* 30% opacity by default
* 100% opacity on hover