### PR TITLE
Fixes for clikes

### DIFF
--- a/src/components/comment-likes.jsx
+++ b/src/components/comment-likes.jsx
@@ -2,7 +2,8 @@ import React from "react";
 import classnames from "classnames";
 import Portal from "react-portal";
 import UserName from "./user-name";
-import TimeDisplay from './time-display';
+import TimeDisplay from "./time-display";
+
 
 export default class CommentLikes extends React.Component {
   constructor(props) {
@@ -14,7 +15,11 @@ export default class CommentLikes extends React.Component {
     };
   }
   render() {
-    return <div className="comment-likes-container" onTouchStart={this.startTouch} onTouchEnd={this.endTouch}>
+    return <div className="comment-likes-container"
+                onTouchStart={this.startTouch}
+                onTouchEnd={this.endTouch}
+                onMouseDown={this.startMouseDown}
+                onMouseUp={this.endMouseDown}>
         {this.renderHeart()}
         {this.renderBubble()}
         {this.renderPopup()}
@@ -31,7 +36,7 @@ export default class CommentLikes extends React.Component {
         {this.state.likeListVisible ? this.renderLikesList() : ""}
       </div>
       <div className="comment-heart" onClick={this.toggleLike}>
-        <i  className={`fa fa-heart${this.props.forbidLiking ? "-o" : ""} icon`}
+        <i  className={`fa fa-heart${this.props.forbidLiking ? "-o" : ""} ${this.state.liked ? "liked" : ""} icon`}
             title={this.props.forbidLiking ? "Your own comment" : this.props.hasOwnLike ? "Un-like" : "Like"}>
         </i>
       </div>
@@ -41,13 +46,13 @@ export default class CommentLikes extends React.Component {
     return this.props.createdAt
             ? <TimeDisplay className="comment-time" timeStamp={+this.props.createdAt} timeAgoInTitle={true}>
                <a
-                  className={`comment-icon fa ${this.props.omitBubble ? 'feed-comment-dot' : 'fa-comment-o'}`}
+                  className={`comment-icon fa ${this.props.omitBubble ? "feed-comment-dot" : "fa-comment-o"}`}
                   id={`comment-${this.props.commentId}`}
                   href={`${this.props.entryUrl}#comment-${this.props.commentId}`}
                   onClick={this.openAnsweringComment}></a>
               </TimeDisplay>
             : <span className="comment-time">
-                <a className={`comment-icon fa ${this.props.omitBubble ? 'feed-comment-dot' : 'fa-comment-o'}`}
+                <a className={`comment-icon fa ${this.props.omitBubble ? "feed-comment-dot" : "fa-comment-o"}`}
                    href={`${this.props.entryUrl}#comment-${this.props.commentId}`}/>
               </span>
             ;
@@ -59,10 +64,11 @@ export default class CommentLikes extends React.Component {
   startTouch = (e) => {
     e.preventDefault();
     this.popupTimeout = setTimeout(() => {
-      this.setState({showActionsPanel: true})
+      this.setState({showActionsPanel: true});
       this.clearTouchTimeout();
     }, 300);
   }
+  endMouseDown = () => this.clearTouchTimeout();
   endTouch = (e) => {
     e.preventDefault();
     if (this.popupTimeout) {
@@ -75,10 +81,19 @@ export default class CommentLikes extends React.Component {
       }
     }
   }
-  openAnsweringComment = (event) => {
-    event.preventDefault();
-    if (event.button === 0) {
-      const withCtrl = event.ctrlKey || event.metaKey;
+  startMouseDown = () => {
+    if (!this.state.showActionsPanel) {
+      this.popupTimeout = setTimeout(() => {
+        this.setState({showActionsPanel: true});
+        this.clearTouchTimeout();
+      }, 300);
+    }
+  }
+  openAnsweringComment = (e) => {
+    e.preventDefault();
+    this.clearTouchTimeout();
+    if (e.button === 0) {
+      const withCtrl = e.ctrlKey || e.metaKey;
       if (withCtrl) {
         this.props.reply();
       } else {
@@ -87,44 +102,48 @@ export default class CommentLikes extends React.Component {
     }
   }
   renderPopup = () => {
+    const likesStyle = {
+      height: !this.state.showActionButtons && this.state.panelHeight || "auto",
+    };
     return this.state.showActionsPanel && <Portal isOpened={true}>
             <div className="actions-overlay" onClick={this.toggleActionsPanel}>
             <div className="container">
             <div className="row">
             <div className="col-md-9">
-              <div className="actions-panel">
-                <div className={`likes-panel ${this.state.showActionButtons ? "" : "big"}`} onClick={e=>e.stopPropagation()}>
+              <div className="actions-panel" ref={r=>this.actionsPanel = r}>
+                <div className={`likes-panel ${this.state.showActionButtons ? "padded" : ""}`}
+                      onClick={e=>e.stopPropagation()}
+                      style={likesStyle}>
                   <div className="arrow" onClick={this.arrowClick}><i className="fa fa-angle-left" aria-hidden="true"/></div>
                   <div className="likes">
                     {this.state.showActionButtons
-                      ? renderLikesLabel(this.props.likes, this.props.hasOwnLike, this.props.forbidLiking, this.showLikesList)
+                      ? this.renderLikesLabel(this.props)
                       : renderMobileLikesList(this.props.likesList)
                     }
                   </div>
                 </div>
-                {this.state.showActionButtons &&
-                  <div className="mention-actions">
-                    {this.props.forbidLiking
-                    ? <div className="mention-action non-likable">
-                        <i className="fa fa-heart-o" aria-hidden="true"/>
-                        It's your own comment
-                      </div>
-                    : <button  className={`mention-action ${this.props.hasOwnLike ? "un":""}like`}
-                            onClick={this.props.toggleLike}>
-                        <i className="fa fa-heart" aria-hidden="true"/>
-                        {`${this.props.hasOwnLike ? "Un-like" : "Like"} comment`}
-                      </button>}
-                    <button  className='mention-action reply'
-                          onClick={this.props.reply}>
-                      <i className="fa fa-angle-up" aria-hidden="true"/>
-                      Reply to comment
-                    </button>
-                    <button  className='mention-action mention'
-                          onClick={this.props.mention}>
-                      <i className="fa fa-at" aria-hidden="true"/>
-                      Mention username
-                    </button>
-                  </div>}
+                <div className='mention-actions' style={{transform:`translateY(${this.state.showActionButtons ? "0%" : "100%"})`}}>
+                  {this.props.forbidLiking
+                  ? <div className="mention-action non-likable">
+                      <i className="fa fa-heart-o" aria-hidden="true"/>
+                      It"s your own comment
+                    </div>
+                  : <button  className={`mention-action ${this.props.hasOwnLike ? "un":""}like`}
+                          onClick={this.props.toggleLike}>
+                      <i className="fa fa-heart" aria-hidden="true"/>
+                      {`${this.props.hasOwnLike ? "Un-like" : "Like"} comment`}
+                    </button>}
+                  <button  className="mention-action reply"
+                        onClick={this.props.reply}>
+                    <i className="fa fa-angle-up" aria-hidden="true"/>
+                    Reply to comment
+                  </button>
+                  <button  className="mention-action mention"
+                        onClick={this.props.mention}>
+                    <i className="fa fa-at" aria-hidden="true"/>
+                    Mention username
+                  </button>
+                </div>
               </div>
               </div>
               <div className="col-md-3"></div>
@@ -133,12 +152,15 @@ export default class CommentLikes extends React.Component {
           </Portal>;
   }
   toggleLike = () => {
+    this.clearTouchTimeout();
     if (!this.props.forbidLiking) {
+      this.setState({liked: !this.props.hasOwnLike});
       this.props.toggleLike();
     }
   }
   toggleLikeList = (e) => {
     e.stopPropagation();
+    this.clearTouchTimeout();
     const likeListVisible = !this.state.likeListVisible;
     this.setState({likeListVisible});
     if (likeListVisible) {
@@ -146,8 +168,8 @@ export default class CommentLikes extends React.Component {
     } else {
       window.removeEventListener("click", this.toggleLikeList, true);
     }
-    if (likeListVisible && this.props.likesList.likes.length === 0 && !this.props.likesList.loading) {
-      this.props.getCommentLikes();
+    if (likeListVisible) {
+      this.getCommentLikes();
     }
   }
   toggleActionsPanel = () => {
@@ -165,10 +187,12 @@ export default class CommentLikes extends React.Component {
   }
   showLikesList = (e) => {
     e.preventDefault();
+    const panelHeight = this.actionsPanel && this.actionsPanel.getBoundingClientRect().height;
     this.setState({
       showActionButtons: false,
+      panelHeight,
     });
-    this.props.getCommentLikes();
+    this.getCommentLikes();
   }
   arrowClick = () => {
     if (this.state.showActionButtons) {
@@ -176,6 +200,30 @@ export default class CommentLikes extends React.Component {
     } else {
       this.setState({showActionButtons: true});
     }
+  }
+  getCommentLikes = () => {
+    if ((this.props.likesList.likes.length === 0 || this.props.likesList.likes.length !== this.props.likes) && !this.props.likesList.loading) {
+      this.props.getCommentLikes();
+    }
+  }
+  renderLikesLabel = () => {
+    const {likes, hasOwnLike, forbidLiking, likesList} = this.props;
+    if (likes === 0) {
+      return <i>No one has liked this comment yet. {!forbidLiking && "You will be the first to like it!"}</i>;
+    }
+    setTimeout(this.getCommentLikes, 0);
+    const {loading, likes: likeUsers} = likesList;
+    if (loading) {
+      const likesNumber = hasOwnLike ? likes-1 : likes;
+      return <span>{hasOwnLike && "You and "}{likesNumber > 0 &&
+          <a className="likes-list-toggle" onClick={this.showLikesList} href="#">{likesNumber} {usersPluralize(likesNumber)}</a>}
+          <span> liked this comment</span>
+        </span>;
+    }
+    const otherLikesToRender = likeUsers.slice(0,4);
+    const otherLikes = renderUserLikesList(otherLikesToRender);
+    const hiddenLikesNumber = likes - otherLikes.length;
+    return <span>{otherLikes}{hiddenLikesNumber > 0 && <span> and <a className="likes-list-toggle" onClick={this.showLikesList} href="#">{hiddenLikesNumber} more {usersPluralize(hiddenLikesNumber)}</a></span>} liked this comment</span>;
   }
 }
 
@@ -187,38 +235,27 @@ function renderMobileLikesList(likesList) {
   if (error) {
     return <div className="comment-likes-list error">Error</div>;
   }
-  const maxIndex = likes.length - 1;
   return <div className="comment-likes-list">
-          Comment liked by {likes.map((likeUser, i) => <span key={i}>
-            <UserName user={likeUser}/>{i < maxIndex ? ", ": ""}
-          </span>)}
+          {renderUserLikesList(likes)} liked this comment
         </div>;
+}
+
+function renderUserLikesList(userLikes) {
+  const maxIndex = userLikes.length - 1;
+  return userLikes.map((likeUser, i) => <span key={i}>
+            <UserName user={likeUser}/>{i < maxIndex ? ", ": ""}
+          </span>);
 }
 
 const usersPluralize = count => `user${count > 1 ? "s" : ""}`;
 
-function renderLikesLabel(likes, hasOwnLike, forbidLiking, showLikesList) {
-  return likes > 0
-    ? hasOwnLike
-      ? <span>You{likes-1 > 0 &&
-          <span>
-            <span> and </span>
-            <a className="likes-list-toggle" onClick={showLikesList} href="#">{likes-1} {usersPluralize(likes-1)}</a>
-          </span>
-          }
-        <span> liked this comment</span>
-        </span>
-      : <span><a className="likes-list-toggle" onClick={showLikesList} href="#">{likes} {usersPluralize(likes)}</a> liked this comment</span>
-    : <i>No one has liked this comment yet. {!forbidLiking && 'You will be the first to like it!'}</i>;
-}
-
 function isBubble(vNode) {
-  return vNode.classList.contains('comment-time')
-  || vNode.classList.contains('comment-icon');
+  return vNode.classList.contains("comment-time")
+  || vNode.classList.contains("comment-icon");
 }
 
 function isHeart(vNode) {
-  return vNode.classList.contains('comment-heart')
-  || vNode.classList.contains('fa-heart')
-  || vNode.classList.contains('comment-likes');
+  return vNode.classList.contains("comment-heart")
+  || vNode.classList.contains("fa-heart")
+  || vNode.classList.contains("comment-likes");
 }

--- a/src/components/more-comments-wrapper.jsx
+++ b/src/components/more-comments-wrapper.jsx
@@ -13,7 +13,16 @@ export default (props) => (
     <a className="more-comments-link"
        href={props.entryUrl}
        onClick={preventDefault(()=>props.showMoreComments())}>
-      {`${props.omittedComments}`} more comments
+      {getText(props)}
     </a>
   </div>
 );
+
+function getText({omittedComments, omittedCommentLikes}) {
+  const ommitedLikes = omittedCommentLikes > 0 ? ` with ${omittedCommentLikes} like${plural(omittedCommentLikes)}` : "";
+  return `${omittedComments} more comment${plural(omittedComments)}${ommitedLikes}`;
+}
+
+function plural(count) {
+  return count > 1 ? "s" : "";
+}

--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -145,6 +145,8 @@ export default class PostComments extends React.Component {
           omittedComments={foldedCount}
           showMoreComments={this.showMoreComments}
           entryUrl={entryUrl}
+          omittedCommentLikes={post.omittedCommentLikes}
+          omittedOwnCommentLikes={post.omittedOwnCommentLikes}
           isLoading={post.isLoadingComments}/>
       );
     }

--- a/styles/shared/comment-likes.scss
+++ b/styles/shared/comment-likes.scss
@@ -18,6 +18,8 @@
 
 .comment-time {
   margin-right: 2px;
+  flex-shrink: 0;
+  flex-basis: auto;
 }
 
 .comment-icon {
@@ -58,6 +60,8 @@
   }
 
   .comment-heart {
+    flex-shrink: 0;
+    flex-basis: auto;
     position: relative;
     font-size: 10px;
     .icon.liked {

--- a/styles/shared/comment-likes.scss
+++ b/styles/shared/comment-likes.scss
@@ -60,10 +60,15 @@
   .comment-heart {
     position: relative;
     font-size: 10px;
+    .icon.liked {
+      animation: .3s like;
+    }
   }
-  .comment-heart:hover .icon {
-    transform: scale(1.3);
-    transition: transform .25s;
+  @media (min-width: 769px) {
+    .comment-heart:hover .icon {
+      transform: scale(1.3);
+      transition: transform .25s;
+    }
   }
 
   .icon {
@@ -73,8 +78,10 @@
   }
 
   &.non-likable {
-    .comment-heart:hover .icon {
-      transform: none;
+    @media (min-width: 769px) {
+      .comment-heart:hover .icon {
+        transform: none;
+      }
     }
     .icon {
       cursor: auto;
@@ -89,12 +96,12 @@
     @media (min-width: 769px) {
       margin-right: 6px;
     }
+    &:hover, &:active {
+      text-decoration: underline;
+    }
     font-size: 12px;
     width: 7px;
     color: #898989;
-    &:hover {
-      text-decoration: underline;
-    }
   }
 
   &.has-my-like {
@@ -113,19 +120,17 @@
     box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.3);
     white-space: nowrap;
     text-align: left;
+    max-height: 200px;
     .user-name-wrapper {
       display: block;
     }
   }
 }
 
-.comment-likes-container:hover .comment-likes:not(.liked) {
-  opacity: 1;
-  transition: opacity .25s;
-  @media (max-width: 768px) {
-    &:not(.has-my-like, .liked) {
-      display: inline-flex;
-    }
+@media (min-width: 769px) {
+  .comment-likes-container:hover .comment-likes:not(.liked) {
+    opacity: 1;
+    transition: opacity .25s;
   }
 }
 
@@ -144,6 +149,18 @@
   }
   to {
     transform: translateY(0);
+  }
+}
+
+@keyframes like {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.3);
+  }
+  100% {
+    transform: scale(1);
   }
 }
 
@@ -179,20 +196,23 @@
   .likes-panel {
     display: flex;
 
-    &.big {
-      height: 190px;
+    &.padded {
+      padding-bottom: 150px;
     }
 
     .arrow {
       width: 35px;
       font-size: 22px;
-      line-height: 40px;
+      padding-top: 12px;
+      line-height: 24px;
       text-align: center;
     }
 
     .likes {
       flex: 1;
-      line-height: 40px;
+      line-height: 24px;
+      padding-top: 12px;
+      padding-bottom: 12px;
       font-size: 16px;
       margin: 0;
       padding-right: 15px;
@@ -200,18 +220,21 @@
     }
   }
 
-  .comment-likes-list {
-    padding-top: 8px;
-    line-height: 24px;
-  }
-
   .mention-actions {
     width: 100%;
     background-color: white;
-    padding: 12px 0;
+    padding-top: 12px;
+    transition: transform .2s;
+    transform: translateY(0);
+    position: absolute;
+    bottom: 0;
   }
 
   .mention-action {
+    &:last-child {
+      height: 54px;
+      padding-bottom: 12px;
+    }
     height: 42px;
     font-size: 16px;
     line-height: 42px;

--- a/styles/shared/comment-likes.scss
+++ b/styles/shared/comment-likes.scss
@@ -49,6 +49,8 @@
 .comment-likes {
   display: inline-flex;
   align-items: flex-end;
+  flex-shrink: 0;
+  flex-basis: auto;
   margin-right: 2px;
   margin-top: 1px;
   @media (min-width: 769px) {


### PR DESCRIPTION
This request addresses number of improvements/bugs in comment likes.

1. Getting rid of hover states on narrow devices.
2. Showing mobile menu on long clicks, not only taps.
3. Showing names of liked users without extra clicks.
4. Showing number of omitted comment likes.
5. Fixing issue with old safari splashing together bubble and heart icons.