### PR TITLE
Set anchor-like link for notification settings

### DIFF
--- a/src/components/user-notifications-form.jsx
+++ b/src/components/user-notifications-form.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ReactDOM from "react-dom";
 import {preventDefault} from "../utils";
 import throbber16 from "../../assets/images/throbber-16.gif";
 
@@ -10,9 +11,16 @@ export default class UserNotificationsForm extends React.Component {
     };
   }
 
+  componentDidMount() {
+    if (window.location.hash === "#notifications") {
+      const node = ReactDOM.findDOMNode(this);
+      setTimeout(_ => window.scrollTo(0, node.getBoundingClientRect().bottom), 500);
+    }
+  }
+
   render() {
     return <form onSubmit={preventDefault(this.savePreference)}>
-      <h3>Notifications preferences</h3>
+      <h3><a className="setting-link" href="#notifications">Notifications preferences</a></h3>
 
       <p>Email me:</p>
 

--- a/styles/shared/settings.scss
+++ b/styles/shared/settings.scss
@@ -2,6 +2,15 @@
   margin-left: 10px;
 }
 
+.setting-link {
+  &, &:hover {
+    color: rgb(51,51,51);
+    text-decoration: none;
+    outline: none;
+    cursor: default;
+  }
+}
+
 .checkbox-displayNames-useYou {
   margin-top: 20px;
   margin-bottom: 15px;


### PR DESCRIPTION
Unfortunately, neither react-router `<Link>`, nor `<a href="#anchor">` scroll the page on load, as React renders real DOM, so we need to do all the findDOMNode and setTimeout stuff.

┆Issue is synchronized with this [Trello card](https://trello.com/c/ouYDAxOQ)
