### PR TITLE
Add a semicolon to make linter happy

### DIFF
--- a/src/components/discussions.jsx
+++ b/src/components/discussions.jsx
@@ -43,7 +43,7 @@ function selectState(state) {
   const defaultFeed = state.routing.locationBeforeTransitions.query.to || user.username;
   const invitation = formatInvitation(state.routing.locationBeforeTransitions.query.invite);
   const sendTo = { ...state.sendTo, defaultFeed, invitation };
-  const isDirects = state.routing.locationBeforeTransitions.pathname.indexOf('direct') !== -1
+  const isDirects = state.routing.locationBeforeTransitions.pathname.indexOf('direct') !== -1;
   if (isDirects) {
     sendTo.expanded = true;
   }


### PR DESCRIPTION


┆Issue is synchronized with this [Trello card](https://trello.com/c/mr2Jvgzq)
