### PR TITLE
Hide unread notifications counter for desktop and mobile

### DIFF
--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -142,7 +142,7 @@ class Layout extends React.Component {
             <div className="col-xs-12 col-sm-8 hidden-md hidden-lg">
               <div className="mobile-shortcuts">
                 <Link className="mobile-shortcut-link" to="/filter/discussions">Discussions</Link>
-                <Link className="mobile-shortcut-link" to="/filter/notifications">Notifications{props.user.unreadNotificationsNumber > 0 && ` (${props.user.unreadNotificationsNumber})`}</Link>
+                <Link className="mobile-shortcut-link" to="/filter/notifications">Notifications{(props.user.unreadNotificationsNumber > 0 && !props.user.frontendPreferences.hideUnreadNotifications) && ` (${props.user.unreadNotificationsNumber})`}</Link>
                 <Link className="mobile-shortcut-link" to="/filter/direct">Directs{props.user.unreadDirectsNumber > 0 && ` (${props.user.unreadDirectsNumber})`}</Link>
                 <Link className="mobile-shortcut-link" to={`/${props.user.username}`}>My feed</Link>
               </div>

--- a/src/components/sidebar.jsx
+++ b/src/components/sidebar.jsx
@@ -41,8 +41,9 @@ const SideBarFriends = ({ user }) => (
         <li className="p-my-discussions"><Link to="/filter/discussions">My discussions</Link></li>
         <li className="p-best-of"><Link to="/summary/1">Best of day</Link></li>
         <li className="p-home">
-          <Link to="/filter/notifications" style={user.unreadNotificationsNumber > 0 ? { fontWeight: 'bold' } : {}}>
-            Notifications {user.unreadNotificationsNumber > 0 ? `(${user.unreadNotificationsNumber})` : ''}
+          <Link to="/filter/notifications" style={(user.unreadNotificationsNumber > 0 && !user.frontendPreferences.hideUnreadNotifications) ? { fontWeight: 'bold' } : {}}>
+            Notifications {(user.unreadNotificationsNumber > 0
+              && !user.frontendPreferences.hideUnreadNotifications) ? `(${user.unreadNotificationsNumber})` : ''}
           </Link>
         </li>
       </ul>

--- a/src/components/user-preferences-form.jsx
+++ b/src/components/user-preferences-form.jsx
@@ -67,6 +67,12 @@ export default class UserPreferencesForm extends React.Component {
     });
   };
 
+  hideUnreadNotifications = (event) => {
+    this.setState({
+      hideUnreadNotifications: event.target.checked
+    });
+  };
+
   isCommentTypeHidden = (hideType) => _.includes(this.state.hideCommentsOfTypes, hideType);
 
   changeHideComments = (event) => {
@@ -175,6 +181,13 @@ export default class UserPreferencesForm extends React.Component {
             </label>
           </div>
         </div>
+        <div className="checkbox">
+          <label>
+            <input type="checkbox" name="bubbles" value="1" checked={this.state.hideUnreadNotifications} onChange={this.hideUnreadNotifications} />
+            Hide unread notifications counter
+          </label>
+        </div>
+
         <div className="checkbox">
           <label>
             <input type="checkbox" name="bubbles" value="1" checked={this.state.comments.omitRepeatedBubbles} onChange={this.changeOmitBubbles} />


### PR DESCRIPTION
* Add `hideUnreadNotifications` for user settings
* Displaying received notifications according `hideUnreadNotifications`

┆Issue is synchronized with this [Trello card](https://trello.com/c/2ZK09jQr)
