### PR TITLE
Replace editText value from the props in the case of a empty state while comment edited

### DIFF
--- a/src/components/post-comment.jsx
+++ b/src/components/post-comment.jsx
@@ -96,7 +96,7 @@ export default class PostComment extends React.Component {
 
   saveComment = () => {
     if (!this.props.isSaving) {
-      this.props.saveEditingComment(this.props.id, this.state.editText);
+      this.props.saveEditingComment(this.props.id, this.state.editText || this.props.editText);
     }
   };
 
@@ -172,7 +172,7 @@ export default class PostComment extends React.Component {
               autoFocus={!this.props.isSinglePost}
               inputRef={this.registerCommentTextArea}
               className="comment-textarea"
-              value={this.state.editText}
+              value={this.state.editText || this.props.editText}
               onFocus={this.setCaretToTextEnd}
               onChange={this.handleChange}
               onKeyDown={this.checkSave}


### PR DESCRIPTION
Closes #753

┆Issue is synchronized with this [Trello card](https://trello.com/c/Kqx5Sx3P)
