### PR TITLE
Show transparent images on white background in lightbox

### DIFF
--- a/styles/shared/attachments.scss
+++ b/styles/shared/attachments.scss
@@ -95,6 +95,10 @@
       content: "\f137";
     }
   }
+
+  .pswp__img {
+    background-color: #fff;
+  }
 }
 
 .audio-attachments,


### PR DESCRIPTION


┆Issue is synchronized with this [Trello card](https://trello.com/c/X9avjgXn)
