### PR TITLE
Don't try to clear text editing in comment after comment is posted / …

### DIFF
--- a/src/components/post-comment.jsx
+++ b/src/components/post-comment.jsx
@@ -117,13 +117,6 @@ export default class PostComment extends React.Component {
   };
 
   componentWillReceiveProps(newProps) {
-    const wasCommentJustSaved = this.props.isSaving && !newProps.isSaving;
-    const wasThereNoError = !newProps.errorString;
-    const isItSinglePostAddingComment = newProps.isSinglePost;
-    const shouldClearText = (wasCommentJustSaved && wasThereNoError && isItSinglePostAddingComment);
-    if (shouldClearText) {
-      this.setState({ editText: '' });
-    }
     if ((this.props.editText || '') !== newProps.editText) {
       this.setState({ editText: newProps.editText });
     }


### PR DESCRIPTION
Kinda fixes #780.

Unfortunatelly, I wasn't able to find the commit about the code deleted. Looks like it covered some use-case, but I hadn't found anything neither on single post page nor in regular feed. If this would work well on staging — let's merge.

┆Issue is synchronized with this [Trello card](https://trello.com/c/BIp4gqR3)
