### PR TITLE
Allow group admins to moderate posts and comments in their groups

### DIFF
--- a/src/components/notifications.jsx
+++ b/src/components/notifications.jsx
@@ -51,6 +51,36 @@ const notificationTemplates = {
 
   banned_by_user: () => `Notification shouldn't be shown`,
   unbanned_by_user: () => `Notification shouldn't be shown`,
+
+  comment_moderated: (event) => (
+    <div>
+      <Linkify>{`@${event.createdUser.username} has deleted your comment to the `}</Linkify>
+      {postLink(event)}
+      {event.group ? <Linkify>{` in the group @${event.group.username}`}</Linkify> : null}
+    </div>
+  ),
+  comment_moderated_by_another_admin: (event) => (
+    <div>
+      <Linkify>{`@${event.createdUser.username} has removed a comment from @${event.affectedUser.username} to the `}</Linkify>
+      {postLink(event)}
+      <Linkify>{` in the group @${event.group.username}`}</Linkify>
+    </div>
+  ),
+  post_moderated: (event) =>  (
+    <div>
+      <Linkify>{`@${event.createdUser.username} has removed your `}</Linkify>
+      {event.post ? postLink(event) : 'post'}
+      {event.group ? <Linkify>{` from the group @${event.group.username}`}</Linkify> : null}
+    </div>
+  ),
+  post_moderated_by_another_admin: (event) => (
+    <div>
+      <Linkify>{`@${event.createdUser.username} has removed the `}</Linkify>
+      {event.post ? postLink(event) : 'post'}
+      <Linkify>{`from @${event.affectedUser.username} `}</Linkify>
+      {event.group ? <Linkify>{` from the group @${event.group.username}`}</Linkify> : null}
+    </div>
+  ),
 };
 
 const notificationClasses = {
@@ -80,6 +110,10 @@ const notificationClasses = {
   direct_comment: 'direct',
   banned_by_user: 'ban',
   unbanned_by_user: 'ban',
+  comment_moderated: 'group',
+  comment_moderated_by_another_admin: 'group',
+  post_moderated: 'group',
+  post_moderated_by_another_admin: 'group',
 };
 
 const nop = () => false;

--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -66,7 +66,7 @@ export default class PostComments extends React.Component {
 
   renderAddCommentLink() {
     const { props } = this;
-    const disabledForOthers = (props.post.commentsDisabled && props.post.isEditable);
+    const disabledForOthers = (props.post.commentsDisabled && (props.post.isEditable || props.post.isModeratable));
     const toggleCommenting = props.post.isSinglePost ? () => {} : () => props.toggleCommenting(props.post.id);
 
     if (props.comments.length > 2 && !props.post.omittedComments) {
@@ -192,7 +192,7 @@ export default class PostComments extends React.Component {
     const totalComments = comments.length + post.omittedComments;
     const first = withBackwardNumber(comments[0], totalComments);
     const last = withBackwardNumber(comments.length > 1 && comments[comments.length - 1], 1);
-    const canAddComment = (!!post.user && (!post.commentsDisabled || post.isEditable));
+    const canAddComment = (!!post.user && (!post.commentsDisabled || post.isEditable || post.isModeratable));
 
     return (
       <div className="comments" ref={this.registerRootEl}>

--- a/src/components/post-more-menu.jsx
+++ b/src/components/post-more-menu.jsx
@@ -28,9 +28,13 @@ export default class PostMoreMenu extends React.Component {
       toggle: <a className="post-action" onClick={this.handleClickOnMore}>More&nbsp;&#x25be;</a>
     };
 
+    const delLabel = this.props.post.isFullyRemovable ? 'Delete' : 'Remove from group';
+
     return (
       <DropdownMenu {...menuOptions}>
-        <li className="dd-menu-item"><a className="dd-menu-item-link" onClick={this.props.toggleEditingPost}>Edit</a></li>
+        {this.props.post.isEditable
+          ? <li className="dd-menu-item"><a className="dd-menu-item-link" onClick={this.props.toggleEditingPost}>Edit</a></li>
+          : false}
 
         {this.props.post.isModeratingComments
           ? <li className="dd-menu-item"><a className="dd-menu-item-link" onClick={this.props.toggleModeratingComments}>Stop moderating comments</a></li>
@@ -40,7 +44,7 @@ export default class PostMoreMenu extends React.Component {
           ? <li className="dd-menu-item"><a className="dd-menu-item-link" onClick={this.props.enableComments}>Enable comments</a></li>
           : <li className="dd-menu-item"><a className="dd-menu-item-link" onClick={this.props.disableComments}>Disable comments</a></li>}
 
-        <li className="dd-menu-item dd-menu-item-danger"><a className="dd-menu-item-link" onClick={confirmFirst(this.props.deletePost)}>Delete</a></li>
+        <li className="dd-menu-item dd-menu-item-danger"><a className="dd-menu-item-link" onClick={confirmFirst(this.props.deletePost)}>{delLabel}</a></li>
       </DropdownMenu>
     );
   }

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -219,7 +219,7 @@ export default class Post extends React.Component {
     let commentLink;
     if (amIAuthenticated) {
       if (props.commentsDisabled) {
-        if (props.isEditable) {
+        if (props.isEditable || props.isModeratable) {
           commentLink = (
             <span>
               {' - '}
@@ -279,7 +279,7 @@ export default class Post extends React.Component {
     ) : false);
 
     // "More" menu
-    const moreLink = (props.isEditable ? (
+    const moreLink = (props.isEditable || props.isModeratable ? (
       <span>
         {' - '}
         <PostMoreMenu

--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -251,7 +251,11 @@ function isInvitation({ locationBeforeTransitions }) {
 
 export const redirectionMiddleware = (store) => (next) => (action) => {
   //go to home if single post has been removed
-  if (action.type === response(ActionTypes.DELETE_POST) && store.getState().singlePostId) {
+  if (
+    action.type === response(ActionTypes.DELETE_POST)
+    && !action.payload.postStillAvailable
+    && store.getState().singlePostId
+  ) {
     return browserHistory.push('/');
   }
 

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -285,6 +285,9 @@ export function feedViewState(state = initFeed, action) {
       return { ...state, isLastPage: action.payload.isLastPage };
     }
     case response(ActionTypes.DELETE_POST): {
+      if (action.payload.postStillAvailable) {
+        return state;
+      }
       const { postId } = action.request;
       return { ...state,
         visibleEntries: _.without(state.visibleEntries, postId),
@@ -1035,7 +1038,8 @@ export function posts(state = {}, action) {
         [post.id]: { ...post,
           body: action.post.body,
           updatedAt: action.post.updatedAt,
-          attachments: action.post.attachments || []
+          attachments: action.post.attachments || [],
+          postedTo: action.post.postedTo,
         }
       };
     }

--- a/test/unit/redux/reducers/group-moderarion.js
+++ b/test/unit/redux/reducers/group-moderarion.js
@@ -1,0 +1,67 @@
+import { describe, it, beforeEach } from 'mocha';
+import expect from 'unexpected';
+
+import { feedViewState, posts } from '../../../../src/redux/reducers';
+import { response } from '../../../../src/redux/action-helpers';
+import { DELETE_POST, REALTIME_POST_UPDATE } from '../../../../src/redux/action-types';
+
+describe('Group moderation', () => {
+  describe('feedViewState', () => {
+    let state, action;
+    beforeEach(() => {
+      state = {
+        ...feedViewState(undefined, { type: 'init' }),
+        visibleEntries: ['post1', 'post2', 'post3'],
+        hiddenEntries: ['post1', 'post2'],
+      };
+      action = {
+        type: response(DELETE_POST),
+        payload: { postStillAvailable: false },
+        request: { postId: 'post2' },
+      };
+    });
+
+    it('should remove post from feedViewState if it is fully deleted', () => {
+      const newState = feedViewState(state, action);
+      expect(newState.visibleEntries, 'to equal', ['post1', 'post3']);
+      expect(newState.hiddenEntries, 'to equal', ['post1']);
+    });
+
+    it('should not remove post from feedViewState if it is not fully deleted', () => {
+      action.payload.postStillAvailable = true;
+      const newState = feedViewState(state, action);
+      expect(newState, 'to equal', state);
+    });
+  });
+
+  describe('posts', () => {
+    let state, action;
+    beforeEach(() => {
+      state = {
+        // ...posts(undefined, { type: 'init' }),
+        'post1': {
+          id: 'post1',
+          body: 'body',
+          updatedAt: 'updatedAt',
+          attachments: [],
+          postedTo: ['feed1', 'feed2'],
+        },
+      };
+      action = {
+        type: REALTIME_POST_UPDATE,
+        post: {
+          id: 'post1',
+          body: 'new body',
+          updatedAt: 'new updatedAt',
+          attachments: ['att1'],
+          postedTo: ['feed1', 'feed2', 'feed3'],
+        },
+      };
+    });
+
+    it('should update postedTo field of post on REALTIME_POST_UPDATE', () => {
+      const newState = posts(state, action);
+      expect(newState['post1'], 'to equal', action.post);
+    });
+  });
+});


### PR DESCRIPTION
This is a client-side part of group moderation described [here](https://docs.google.com/document/d/1KoZ9seBvZPAA4XNPLt8xDEexmTOuWfr05uzgJig5VXY/edit). Admins can:

- Remove post from groups they manages. If post has not other destination feeds, it deletes.
- Turn on and off post comments.
- Delete post comments.

┆Issue is synchronized with this [Trello card](https://trello.com/c/lklPrSqE)
