### PR TITLE
Fix a bug that caused hidden posts to bump

### DIFF
--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -333,16 +333,20 @@ export function feedViewState(state = initFeed, action) {
     case ActionTypes.REALTIME_LIKE_NEW:
     case ActionTypes.REALTIME_COMMENT_NEW: {
       if (action.post && action.shouldBump) {
-        if (action.post.isHidden && state.separateHiddenEntries) {
+        const postId = action.post.posts.id;
+        const addToHiddens = action.post.posts.isHidden && state.separateHiddenEntries;
+        if (addToHiddens && !state.hiddenEntries.includes(postId)) {
           return {
             ...state,
-            hiddenEntries: [action.post.posts.id, ...state.hiddenEntries],
+            hiddenEntries: [postId, ...state.hiddenEntries],
           };
         }
-        return {
-          ...state,
-          visibleEntries: [action.post.posts.id, ...state.visibleEntries],
-        };
+        if (!addToHiddens && !state.visibleEntries.includes(postId)) {
+          return {
+            ...state,
+            visibleEntries: [postId, ...state.visibleEntries],
+          };
+        }
       }
       return state;
     }

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -982,6 +982,17 @@ export function posts(state = {}, action) {
         }
       };
     }
+    case ActionTypes.REALTIME_POST_HIDE: {
+      const post = state[action.postId];
+      if (!post) {
+        return state;
+      }
+      return { ...state,
+        [post.id]: { ...post,
+          isHidden: true
+        }
+      };
+    }
     case response(ActionTypes.UNHIDE_POST): {
       const post = state[action.request.postId];
       return { ...state,

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -221,10 +221,12 @@ const hidePostInFeed = function (state, postId) {
     return state;
   }
   // Add it to hiddenEntries, but don't remove from visibleEntries just yet
-  // (for the sake of "Undo"). And check first if it's already in hiddenEntries,
-  // since realtime event might come first.
-  const itsAlreadyThere = (state.hiddenEntries.indexOf(postId) > -1);
-  if (itsAlreadyThere) {
+  // (for the sake of "Undo"). Do not touch state if if post is already in
+  // hiddenEntries (since realtime event might come first) or is not at the
+  // page at all.
+  const inHidden = (state.hiddenEntries.indexOf(postId) > -1);
+  const inVisible = (state.visibleEntries.indexOf(postId) > -1);
+  if (inHidden || !inHidden && !inVisible) {
     return state;
   }
   return { ...state,
@@ -239,9 +241,13 @@ const unhidePostInFeed = function (state, postId) {
   // Remove it from hiddenEntries and add to visibleEntries
   // (but check first if it's already in there, since this might be an "Undo" happening,
   // and/or realtime event might come first).
-  const itsStillThere = (state.visibleEntries.indexOf(postId) > -1);
+  const inHidden = (state.hiddenEntries.indexOf(postId) > -1);
+  const inVisible = (state.visibleEntries.indexOf(postId) > -1);
+  if (!inHidden) {
+    return state;
+  }
   return { ...state,
-    visibleEntries: (itsStillThere ? state.visibleEntries : [...state.visibleEntries, postId]),
+    visibleEntries: (inVisible ? state.visibleEntries : [...state.visibleEntries, postId]),
     hiddenEntries: _.without(state.hiddenEntries, postId)
   };
 };

--- a/test/unit/redux/reducers/realtime.js
+++ b/test/unit/redux/reducers/realtime.js
@@ -8,6 +8,8 @@ import {
   REALTIME_LIKE_NEW,
   REALTIME_POST_NEW,
   REALTIME_GLOBAL_USER_UPDATE,
+  REALTIME_POST_HIDE,
+  REALTIME_POST_UNHIDE,
 } from '../../../../src/redux/action-types';
 import {
   realtimeSubscribe,
@@ -181,6 +183,46 @@ describe('realtime events', () => {
       const result = posts(postsBefore, newLikeWithPost);
 
       expect(result, 'to have key', newPost.id);
+    });
+
+    it('should hide post on REALTIME_POST_HIDE', () => {
+      const state = { '1': { id: '1', isHidden: false } };
+      const action = {
+        type: REALTIME_POST_HIDE,
+        postId: '1',
+      };
+      const newState = posts(state, action);
+      expect(newState['1'], 'to satisfy', { id: '1', isHidden: true });
+    });
+
+    it('should not hide missing post on REALTIME_POST_HIDE', () => {
+      const state = { '1': { id: '1', isHidden: false } };
+      const action = {
+        type: REALTIME_POST_HIDE,
+        postId: '2',
+      };
+      const newState = posts(state, action);
+      expect(newState, 'to be', state);
+    });
+
+    it('should unhide post on REALTIME_POST_UNHIDE', () => {
+      const state = { '1': { id: '1', isHidden: true } };
+      const action = {
+        type: REALTIME_POST_UNHIDE,
+        postId: '1',
+      };
+      const newState = posts(state, action);
+      expect(newState['1'], 'to satisfy', { id: '1', isHidden: false });
+    });
+
+    it('should not unhide missing post on REALTIME_POST_UNHIDE', () => {
+      const state = { '1': { id: '1', isHidden: true } };
+      const action = {
+        type: REALTIME_POST_UNHIDE,
+        postId: '2',
+      };
+      const newState = posts(state, action);
+      expect(newState, 'to be', state);
     });
   });
 

--- a/test/unit/redux/reducers/realtime.js
+++ b/test/unit/redux/reducers/realtime.js
@@ -290,6 +290,39 @@ describe('realtime events', () => {
         expect(newState.hiddenEntries, 'not to contain', '1');
       });
     });
+
+    describe('on REALTIME_COMMENT_NEW on hidden post', () => {
+      const action = {
+        type: REALTIME_COMMENT_NEW,
+        post: { posts: { id: '1', isHidden: true } },
+        shouldBump: true,
+      };
+
+      it('should not touch state if post is already hidden', () => {
+        state = {
+          ...state,
+          hiddenEntries: [...state.hiddenEntries, '1'],
+        };
+        const newState = feedViewState(state, action);
+        expect(newState, 'to be', state);
+      });
+
+      it('should add post to hiddens if it is not', () => {
+        const newState = feedViewState(state, action);
+        expect(newState.visibleEntries, 'not to contain', '1');
+        expect(newState.hiddenEntries, 'to contain', '1');
+      });
+
+      it('should add post to visibles if it is not and separateHiddenEntries is false', () => {
+        state = {
+          ...state,
+          separateHiddenEntries: false,
+        };
+        const newState = feedViewState(state, action);
+        expect(newState.visibleEntries, 'to contain', '1');
+        expect(newState.hiddenEntries, 'not to contain', '1');
+      });
+    });
   });
 
   describe('postsViewState()', () => {


### PR DESCRIPTION
In fact, the main bug was that the isHidden flag of the post was incorrectly determined in feedViewState reducer: it should be action.post.posts.isHidden, not action.post.isHidden.

The other changes fixes some other minor bugs.

┆Issue is synchronized with this [Trello card](https://trello.com/c/tt5pzfW7)
