### PR TITLE
Allow users to receive direct messages from all

### DIFF
--- a/src/components/select-utils.js
+++ b/src/components/select-utils.js
@@ -215,3 +215,35 @@ export function userActions(dispatch) {
     sendSubscriptionRequest: (username) => dispatch(sendSubscriptionRequest(username))
   };
 }
+
+/**
+ * Returns true/false if this user can (not) accept
+ * direct message from us. Returns undefined if this
+ * information isn't loaded yet.
+ *
+ * @param {object} user
+ * @param {object} state
+ * @returns {boolean|undefined}
+ */
+export function canAcceptDirects(user, state) {
+  if (!user || !user.username) {
+    return undefined;
+  }
+
+  const { user: me, usersNotFound, directsReceivers } = state;
+
+  if (
+    user.type === 'group' ||
+    me.username === user.username ||
+    usersNotFound.includes(user.username)
+  ) {
+    return false;
+  }
+
+  // If user subscribed to us
+  if (me.subscribers.some((s) => s.username === user.username)) {
+    return true;
+  }
+
+  return directsReceivers[user.username];
+}

--- a/src/components/send-to.jsx
+++ b/src/components/send-to.jsx
@@ -12,6 +12,10 @@ const Select = Loadable({
     return <div>Loading selector...</div>;
   },
   loader: () => import('react-select'),
+  render(loaded, props) {
+    const { Creatable } = loaded;
+    return <Creatable {...props} />;
+  }
 });
 
 export default class SendTo extends React.Component {
@@ -37,8 +41,15 @@ export default class SendTo extends React.Component {
   }
 
   stateFromProps(props, options) {
+    const values = options.filter((opt) => opt.value === props.defaultFeed);
+    if (values.length === 0 && props.defaultFeed) {
+      values.push({
+        label: props.defaultFeed,
+        value: props.defaultFeed,
+      });
+    }
     return {
-      values: options.filter((opt) => opt.value === props.defaultFeed),
+      values,
       options,
       showFeedsOption: !props.defaultFeed || props.alwaysShowSelect,
       isWarningDisplayed: false
@@ -90,6 +101,8 @@ export default class SendTo extends React.Component {
     return <span>{icon} {opt.label}</span>;
   };
 
+  promptTextCreator = (label) => `Send direct message to @${label}`;
+
   registerSelector = (el) => {
     this.selector = el;
   };
@@ -120,6 +133,7 @@ export default class SendTo extends React.Component {
               clearable={false}
               autoFocus={this.state.showFeedsOption && !this.props.disableAutoFocus}
               openOnFocus={true}
+              promptTextCreator={this.promptTextCreator}
             />
             {this.state.isWarningDisplayed ? (
               <div className="selector-warning">

--- a/src/components/settings.jsx
+++ b/src/components/settings.jsx
@@ -47,6 +47,7 @@ class Settings extends React.Component {
             <UserSettingsForm
               user={props.user}
               updateUser={props.updateUser}
+              updateUserPreferences={props.updateUserPreferences}
               userSettingsChange={props.userSettingsChange}
               {...props.userSettingsForm}
             />

--- a/src/components/user-card.jsx
+++ b/src/components/user-card.jsx
@@ -7,14 +7,15 @@ import throbber16 from '../../assets/images/throbber-16.gif';
 import { getUserInfo, updateUserPreferences } from '../redux/action-creators';
 import UserFeedStatus from './user-feed-status';
 import UserRelationshipStatus from './user-relationships-status';
-import { userActions } from './select-utils';
+import { userActions, canAcceptDirects } from './select-utils';
 
 class UserCard extends React.Component {
   constructor(props) {
     super(props);
 
     // Load this user's info if it's not in the store already
-    if (!props.user.id) {
+    // or we have not its 'acceptsDirects' field
+    if (!props.user.id || props.canAcceptDirects === undefined) {
       setTimeout(() => props.getUserInfo(props.username), 0);
     }
   }
@@ -116,11 +117,12 @@ class UserCard extends React.Component {
           </div>
         ) : !props.isItMe ? (
           <div className="user-card-actions">
-            {props.isUserSubscribedToMe && props.amISubscribedToUser && props.user.type === 'user' &&
+            {props.canAcceptDirects ? (
               <span>
                 <Link to={`/filter/direct?to=${props.user.username}`}>Direct message</Link>
                 <span> - </span>
               </span>
+            ) : false
             }
             {props.user.isPrivate === '1' && !props.subscribed ? (
               props.hasRequestBeenSent ? (
@@ -167,7 +169,8 @@ const mapStateToProps = (state, ownProps) => {
     hasRequestBeenSent: ((me.pendingSubscriptionRequests || []).indexOf(user.id) > -1),
     blocked: ((me.banIds || []).indexOf(user.id) > -1),
     hidden: (me.frontendPreferences.homefeed.hideUsers.indexOf(user.username) > -1),
-    amIGroupAdmin: (user.type === 'group' && (user.administrators || []).indexOf(me.id) > -1)
+    amIGroupAdmin: (user.type === 'group' && (user.administrators || []).indexOf(me.id) > -1),
+    canAcceptDirects: canAcceptDirects(user, state),
   };
 };
 

--- a/src/components/user-profile.jsx
+++ b/src/components/user-profile.jsx
@@ -16,6 +16,14 @@ export default class UserProfile extends React.Component {
     this.setState({ isUnsubWarningDisplayed: false });
   };
 
+  componentDidUpdate(prevProps) {
+    if (this.props.username !== prevProps.username) {
+      if (this.props.username && this.props.canAcceptDirects === undefined) {
+        this.props.getUserInfo(this.props.username);
+      }
+    }
+  }
+
   handleRequestSubscriptionClick = preventDefault(() => {
     const { id, sendSubscriptionRequest, username } = this.props;
     sendSubscriptionRequest({ username, id });
@@ -104,7 +112,7 @@ export default class UserProfile extends React.Component {
         {props.authenticated && props.isUserFound && !props.isItMe && !props.blocked ? (
           <div className="profile-controls">
             <div className="row">
-              <div className="col-xs-7 col-sm-9 subscribe-controls">
+              <div className="col-xs-7 col-sm-7 subscribe-controls">
                 {props.isPrivate === '1' && !props.subscribed ? (
                   props.hasRequestBeenSent ? (
                     <span><b>{props.screenName}</b> has been sent your subscription request.</span>
@@ -125,23 +133,23 @@ export default class UserProfile extends React.Component {
                   </span>
                 ) : false}
               </div>
-              <div className="col-xs-5 col-sm-3 text-right">
-                {props.type === 'user' && props.subscribed && props.subscribedToMe && (
-                  <span className="profile-stats-item">
-                    <Link to={`/filter/direct?to=${props.username}`}>Direct message</Link>
-                  </span>
-                )}
-                {props.type === 'group' && props.subscribed && (
-                  <span className="profile-stats-item">
-                    <Link to={`/filter/direct?invite=${props.username}`}>Invite</Link>
-                    {((props.type !== 'group' && !props.subscribed) || props.amIGroupAdmin) && ' | '}
-                  </span>
-                )}
-                {props.type !== 'group' && !props.subscribed ? (
-                  <a onClick={this.handleBlockUserClick}>Block this user</a>
-                ) : props.amIGroupAdmin ? (
-                  <Link to={`/${props.username}/settings`}>Settings</Link>
-                ) : false}
+              <div className="col-xs-5 col-sm-5 text-right">
+                <ul className="profile-actions">
+                  {props.canAcceptDirects ? (
+                    <li><Link to={`/filter/direct?to=${props.username}`}>Direct message</Link></li>
+                  ) : false}
+                  {props.type === 'group' && props.subscribed && (
+                    <li>
+                      <Link to={`/filter/direct?invite=${props.username}`}>Invite</Link>
+                      {((props.type !== 'group' && !props.subscribed) || props.amIGroupAdmin) && ' | '}
+                    </li>
+                  )}
+                  {props.type !== 'group' && !props.subscribed ? (
+                    <li><a onClick={this.handleBlockUserClick}>Block this user</a></li>
+                  ) : props.amIGroupAdmin ? (
+                    <li><Link to={`/${props.username}/settings`}>Settings</Link></li>
+                  ) : false}
+                </ul>
               </div>
             </div>
             {this.state.isUnsubWarningDisplayed ? (

--- a/src/components/user-settings-form.jsx
+++ b/src/components/user-settings-form.jsx
@@ -15,12 +15,17 @@ export default class UserSettingsForm extends React.Component {
 
     this.props.userSettingsChange({
       isPrivate: this.props.user.isPrivate,
-      isProtected: this.props.user.isProtected
+      isProtected: this.props.user.isProtected,
+      directsFromAll: this.props.user.preferences.acceptDirectsFrom === 'all',
     });
   }
 
   updateSetting = (setting) => (e) => {
-    this.props.userSettingsChange({ [setting]: e.target.value });
+    if (e.target.type === 'checkbox') {
+      this.props.userSettingsChange({ [setting]: e.target.checked });
+    } else {
+      this.props.userSettingsChange({ [setting]: e.target.value });
+    }
   };
 
   updatePrivacy = (e) => {
@@ -35,7 +40,17 @@ export default class UserSettingsForm extends React.Component {
 
   updateUser = () => {
     if (!this.props.isSaving) {
-      this.props.updateUser(this.props.user.id, this.props.screenName, this.props.email, this.props.isPrivate, this.props.isProtected, this.props.description);
+      this.props.updateUser(
+        this.props.user.id,
+        this.props.screenName,
+        this.props.email,
+        this.props.isPrivate,
+        this.props.isProtected,
+        this.props.description,
+      );
+      this.props.updateUserPreferences(this.props.user.id, {}, {
+        acceptDirectsFrom: this.props.directsFromAll ? 'all' : 'friends'
+      });
     }
   };
 
@@ -113,6 +128,19 @@ export default class UserSettingsForm extends React.Component {
                 onChange={this.updatePrivacy}
               />
               Private &mdash; only people you approve can see your posts
+            </label>
+          </div>
+        </div>
+        <div className="form-group">
+          <div className="checkbox">
+            <label>
+              <input
+                type="checkbox"
+                name="directsFromAll"
+                checked={this.props.directsFromAll || false}
+                onChange={this.updateSetting('directsFromAll')}
+              />
+              Accept direct messages from all users
             </label>
           </div>
         </div>

--- a/src/components/user.jsx
+++ b/src/components/user.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 
-import { createPost, resetPostCreateForm, expandSendTo } from '../redux/action-creators';
+import { createPost, resetPostCreateForm, expandSendTo, getUserInfo } from '../redux/action-creators';
 import { getCurrentRouteName } from '../utils';
-import { joinPostData, joinCreatePostData, postActions, userActions } from './select-utils';
+import { joinPostData, joinCreatePostData, postActions, userActions, canAcceptDirects } from './select-utils';
 import Breadcrumbs from './breadcrumbs';
 import UserProfile from './user-profile';
 import UserFeed from './user-feed';
@@ -31,6 +31,7 @@ const UserHandler = (props) => {
           createPostForm={props.createPostForm}
           addAttachmentResponse={props.addAttachmentResponse}
           removeAttachment={props.removeAttachment}
+          getUserInfo={props.getUserInfo}
         />
       </div>
 
@@ -69,7 +70,8 @@ function selectState(state, ownProps) {
     subscribed: authenticated && foundUser && (user.subscriptions.indexOf(foundUser.id) > -1),
     subscribedToMe: authenticated && foundUser && (_.findIndex(state.user.subscribers, { id: foundUser.id }) > -1),
     blocked: authenticated && foundUser && (user.banIds.indexOf(foundUser.id) > -1),
-    hasRequestBeenSent: authenticated && foundUser && ((user.pendingSubscriptionRequests || []).indexOf(foundUser.id) > -1)
+    hasRequestBeenSent: authenticated && foundUser && ((user.pendingSubscriptionRequests || []).indexOf(foundUser.id) > -1),
+    canAcceptDirects: canAcceptDirects(foundUser, state),
   };
 
   statusExtension.canISeeSubsList = statusExtension.isUserFound &&
@@ -103,6 +105,7 @@ function selectActions(dispatch) {
     resetPostCreateForm: (...args) => dispatch(resetPostCreateForm(...args)),
     expandSendTo: () => dispatch(expandSendTo()),
     userActions: userActions(dispatch),
+    getUserInfo: (username) => dispatch(getUserInfo(username)),
   };
 }
 

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -1327,6 +1327,25 @@ export function usersNotFound(state = [], action) {
   return state;
 }
 
+/**
+ * state is a map [username => status]
+ * status is boolean (user can or canot receive directs from us)
+ */
+export function directsReceivers(state = {}, action) {
+  switch (action.type) {
+    case response(ActionTypes.GET_USER_INFO): {
+      const { payload: { users: { username }, acceptsDirects } } = action;
+      if (state[username] !== acceptsDirects) {
+        return {
+          ...state,
+          [username]: acceptsDirects,
+        };
+      }
+    }
+  }
+  return state;
+}
+
 export function users(state = {}, action) {
   if (ActionHelpers.isFeedResponse(action)) {
     return mergeByIds(state, (action.payload.users || []).map(userParser));

--- a/styles/helvetica/user.scss
+++ b/styles/helvetica/user.scss
@@ -67,3 +67,18 @@
   }
 }
 
+.profile-actions {
+  li {
+    display: inline-block;
+    white-space: nowrap;
+    &::before {
+      content: "\2022";
+      color: #999;
+      margin: 0 0.3em;
+    }
+    &:first-child::before {
+      content: none;
+    }
+  }
+}
+


### PR DESCRIPTION
It is a client-side part of FreeFeed/freefeed-server#348. Includes:

- “Direct message” link in user pop-up floater for users who can receive directs from the current user;
- “Direct message” link on page of users who can receive directs from the current user;
- “Accept direct messages from all user” option on Settings page;
- Ability to enter new (not present in pre-filled options) values to the post destinations selector.

┆Issue is synchronized with this [Trello card](https://trello.com/c/e7n0iyY6)
