### PR TITLE
Don't pass username of current user to the feed selector on Directs page

### DIFF
--- a/src/components/discussions.jsx
+++ b/src/components/discussions.jsx
@@ -40,10 +40,10 @@ function selectState(state) {
   const { authenticated, boxHeader, createPostViewState, timelines, user } = state;
   const visibleEntries = state.feedViewState.visibleEntries.map(joinPostData(state));
   const createPostForm = joinCreatePostData(state);
-  const defaultFeed = state.routing.locationBeforeTransitions.query.to || user.username;
+  const isDirects = state.routing.locationBeforeTransitions.pathname.indexOf('direct') !== -1;
+  const defaultFeed = state.routing.locationBeforeTransitions.query.to || !isDirects && user.username;
   const invitation = formatInvitation(state.routing.locationBeforeTransitions.query.invite);
   const sendTo = { ...state.sendTo, defaultFeed, invitation };
-  const isDirects = state.routing.locationBeforeTransitions.pathname.indexOf('direct') !== -1;
   if (isDirects) {
     sendTo.expanded = true;
   }


### PR DESCRIPTION
Fixes the following bug:

> Я как пользователь А захожу в свои директы (https://candy.freefeed.net/filter/direct) и вижу что в поле To автоматоим подставился мой собственный юзернейм. Так не должно быть, поле должно быть пустое, как сейчас на проде. Причем предупреждения о том, что это будет запощено в мой фид и все это увидят, нет! А должно быть.

┆Issue is synchronized with this [Trello card](https://trello.com/c/KtvD9DGC)
