### PR TITLE
Prevent erasing of user display preferences on UserSettingsForm update

### DIFF
--- a/src/components/user-settings-form.jsx
+++ b/src/components/user-settings-form.jsx
@@ -48,7 +48,7 @@ export default class UserSettingsForm extends React.Component {
         this.props.isProtected,
         this.props.description,
       );
-      this.props.updateUserPreferences(this.props.user.id, {}, {
+      this.props.updateUserPreferences(this.props.user.id, this.props.user.frontendPreferences, {
         acceptDirectsFrom: this.props.directsFromAll ? 'all' : 'friends'
       });
     }


### PR DESCRIPTION


┆Issue is synchronized with this [Trello card](https://trello.com/c/y0Y0MmG9)
