### PR TITLE
Don't trim long invitation texts

### DIFF
--- a/src/components/invitation-creation-form.jsx
+++ b/src/components/invitation-creation-form.jsx
@@ -106,7 +106,6 @@ class InvitationCreationForm extends React.Component {
                 onChange={this.onInvitationTextChange}
                 minRows={3}
                 maxRows={10}
-                maxLength="1500"
               />
             </div>
             <p>


### PR DESCRIPTION
Remove stupid boundary for invitation text length

┆Issue is synchronized with this [Trello card](https://trello.com/c/VKhcwdr6)
