### PR TITLE
Post header doesn't jump anymore then 'via somebody' hides

### DIFF
--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -299,6 +299,7 @@ $post-line-height: 20px;
 .post-via-sources {
   font-size: 12px;
   margin-left: 0.4em;
+  line-height: 16px;
 }
 
 .post-via-more {


### PR DESCRIPTION
Then the feed shows up, sometimes posts have 'via somebody' postfix; then this postfix hides, post header changes height and jumps. This pull fixes the issue; tested in desktop chrome and firefox.