### PR TITLE
Don't animate 'more' menu

### DIFF
--- a/src/components/post-more-menu.jsx
+++ b/src/components/post-more-menu.jsx
@@ -25,6 +25,7 @@ export default class PostMoreMenu extends React.Component {
       align: 'left',
       close: this.close,
       isOpen: this.state.isOpen,
+      animate: false,
       toggle: <a className="post-action" onClick={this.handleClickOnMore}>More&nbsp;&#x25be;</a>
     };
 


### PR DESCRIPTION
This one definitely needs discussion with management, but:
I've got pretty strong feeling that post 'More' menu animation falls out of place in current frontend design. It jumps way more than anything else in the site, and feels weird every time. For sure I'll be more than ok if this pull doesn't get into prod, but I hope it this menu animation will get a bit of second thought.