### PR TITLE
Expand "collapsed" text by clicking on them

### DIFF
--- a/src/components/expandable.jsx
+++ b/src/components/expandable.jsx
@@ -15,8 +15,6 @@ export default class Expandable extends React.Component {
       userExpanded: false,
       maxHeight:    5000,
     };
-    this.userExpand = this.userExpand.bind(this);
-    this.rewrap = this.rewrap.bind(this);
   }
 
   componentDidMount() {
@@ -44,11 +42,11 @@ export default class Expandable extends React.Component {
     );
   }
 
-  userExpand() {
+  userExpand = () => {
     this.setState({ userExpanded: true });
-  }
+  };
 
-  rewrap() {
+  rewrap = () => {
     const { maxLines, aboveFoldLines } = chooseLineCounts(this.props.config, window.innerWidth);
     const node = ReactDOM.findDOMNode(this);
     const lines = gatherContentLines(node, ".Linkify", ".p-break");
@@ -58,7 +56,7 @@ export default class Expandable extends React.Component {
     const foldedLines = aboveFoldLines || maxLines || DEFAULT_ABOVE_FOLD_LINES;
     const maxHeight = shouldExpand ? "5000" : lines[foldedLines - 1].bottom + readMorePanelHeight;
     this.setState({ expanded: shouldExpand, maxHeight });
-  }
+  };
 }
 
 function gatherContentLines(node, contentSelector, breakSelector) {

--- a/src/components/expandable.jsx
+++ b/src/components/expandable.jsx
@@ -32,7 +32,9 @@ export default class Expandable extends React.Component {
     const style = { maxHeight: expanded ? "300vh" : `${this.state.maxHeight}px` };
     return (
       <div className={cn} style={style}>
-        {this.props.children}
+        <div onClick={this.userExpand}>
+          {this.props.children}
+        </div>
         {!expanded && (
           <div className="expand-panel">
             <div className="expand-button"><i onClick={this.userExpand}><span className="expand-icon"><i className="fa fa-chevron-down" /></span> Read more</i> {this.props.bonusInfo}</div>
@@ -43,6 +45,12 @@ export default class Expandable extends React.Component {
   }
 
   userExpand = () => {
+    // Do not react to clicks if user was selecting text
+    const selection = window.getSelection();
+    if (selection.toString().length > 0) {
+      return;
+    }
+
     this.setState({ userExpanded: true });
   };
 

--- a/src/components/piece-of-text.jsx
+++ b/src/components/piece-of-text.jsx
@@ -109,16 +109,16 @@ export default class PieceOfText extends React.Component {
     this.state = { isExpanded: !!props.isExpanded || props.readMoreStyle === READMORE_STYLE_COMFORT };
   }
 
-  expandText() {
+  expandText = () => {
     this.setState({ isExpanded: true });
-  }
+  };
 
   render() {
     return (this.props.text ? (
       <Linkify userHover={this.props.userHover} arrowHover={this.props.arrowHover} highlightTerms={this.props.highlightTerms}>
         {this.state.isExpanded
           ? getExpandedText(this.props.text)
-          : getCollapsedText(this.props.text, this.expandText.bind(this))}
+          : getCollapsedText(this.props.text, this.expandText)}
       </Linkify>
     ) : <span />);
   }

--- a/src/components/piece-of-text.jsx
+++ b/src/components/piece-of-text.jsx
@@ -74,7 +74,7 @@ const getCollapsedText = (text, expandText) => {
 
     // The text is short but has some newlines
     return [
-      <span key="text" dir="auto">{normalizedText}</span>,
+      <span key="text" dir="auto" onClick={expandText}>{normalizedText}</span>,
       ' ',
       <a key="read-more" className="read-more" onClick={expandText}>Expand</a>
     ];
@@ -84,7 +84,7 @@ const getCollapsedText = (text, expandText) => {
   const shortenedText = shortenText(normalizedText, shortenedTextLength);
 
   return [
-    <span key="text" dir="auto">{shortenedText}</span>,
+    <span key="text" dir="auto" onClick={expandText}>{shortenedText}</span>,
     ' ',
     <a key="read-more" className="read-more" onClick={expandText}>Read more</a>
   ];
@@ -110,6 +110,12 @@ export default class PieceOfText extends React.Component {
   }
 
   expandText = () => {
+    // Do not react to clicks if user was selecting text
+    const selection = window.getSelection();
+    if (selection.toString().length > 0) {
+      return;
+    }
+
     this.setState({ isExpanded: true });
   };
 


### PR DESCRIPTION
Currently, collapsed text are expanded only if user clicks on "Read more" link explicitly. This pull-requests handles clicks on text itself.

I made sure that handling of clicks does not interfere with text-selection. Click would be ignored if it is a part of text selection.

Warning: I did not do any testing on mobiles, but don't expect issues there. Will do if I have more time later