### PR TITLE
Make feed sort text more narrow

### DIFF
--- a/src/components/feed-options-switch.jsx
+++ b/src/components/feed-options-switch.jsx
@@ -29,7 +29,7 @@ class FeedOptionsSwitch extends React.PureComponent {
 
     const toggle = defaultHomeFeedSort === feedSort.sort
       ? <span className="glyphicon glyphicon-option-horizontal" onClick={this.toggleDropdown} />
-      : <span><span className="glyphicon glyphicon-time" />&nbsp;&nbsp;Viewing most recent posts &#183;   <a href="#" onClick={preventDefault(this.switchSortToActivity)}>Back to default view</a>&nbsp;&nbsp;&nbsp;&nbsp;<span className="glyphicon glyphicon-option-horizontal" onClick={this.toggleDropdown} /></span>;
+      : <span><span className="glyphicon glyphicon-time" />&nbsp;{!realtimeActive && <span>Paused,&nbsp;</span>}Most recent posts &#183;   <a href="#" onClick={preventDefault(this.switchSortToActivity)}>To default view</a>&nbsp;&nbsp;<span className="glyphicon glyphicon-option-horizontal" onClick={this.toggleDropdown} /></span>;
 
     const menuOptions = {
       align:   'right',


### PR DESCRIPTION
It's my take on feed sorting texts appearing in the header. Current version from proposal (https://paper.dropbox.com/doc/Feed-sort-order-proposal-for-Freefeed-1NaHOXflvAWKmwofhOkqY) is breaking to the next line on mobile phones, so I've tried to make it shorter without compromising on readability. This still falls to the second line in case of stopped realtime + post sorting by creation time, but it's the most 'subtle' change from the proposal I can imagine. Other options could be changing icon in case of paused realtime updates, but I'm pretty sure it will be puzzling for users