### PR TITLE
Add a maxheight parameter to noembed.com URL

### DIFF
--- a/src/components/link-preview/video.jsx
+++ b/src/components/link-preview/video.jsx
@@ -172,7 +172,7 @@ function getDefaultAspectRatio(url) {
 async function getVideoInfo(url) {
   switch (getVideoType(url)) {
     case T_YOUTUBE_VIDEO: {
-      const data = await cachedFetch(`https://noembed.com/embed?url=${encodeURIComponent(url)}`);
+      const data = await cachedFetch(`https://noembed.com/embed?url=${encodeURIComponent(url)}&maxheight`);
       if (data.error) {
         return { error: data.error };
       }


### PR DESCRIPTION
noembed.com cannot show some YouTube videos without this parameter: https://github.com/leedo/noembed/issues/98

See: https://freefeed.net/dreikanter/75c8b116-61fa-42ce-b4ee-055ff868f45d