### PR TITLE
Upload pasted image as JPEG if needed

### DIFF
--- a/src/components/create-post.jsx
+++ b/src/components/create-post.jsx
@@ -65,7 +65,7 @@ export default class CreatePost extends React.Component {
             if (!blob.name) {
               blob.name = 'image.png';
             }
-            this.dropzoneObject.addFile(blob);
+            makeJpegIfNeeded(blob).then((blob) => this.dropzoneObject.addFile(blob));
           }
         }
       }
@@ -223,4 +223,51 @@ export default class CreatePost extends React.Component {
       </div>
     );
   }
+}
+
+/**
+ * Convert 'image/png' blob to 'image/jpeg' blob if:
+ * 1) The PNG size is more than 50 KiB and
+ * 2) JPEG size is less than half the PNG size.
+ *
+ * The returning promise is never failed and returns
+ * either JPEG or the original PNG.
+ *
+ * @param {Blob} blob
+ * @returns {Promise<Blob>}
+ */
+export async function makeJpegIfNeeded(blob) {
+  if (blob.type !== 'image/png' || blob.size < 50 * 1024) {
+    return blob;
+  }
+
+  const src = window.URL.createObjectURL(blob);
+  try {
+    const image = await new Promise((resolve, reject) => {
+      const image = new Image();
+      image.onload = () => resolve(image);
+      image.onerror = () => reject(new Error('Cannot load image'));
+      image.src = src;
+    });
+
+    const canvas = document.createElement('canvas');
+    canvas.width = image.width;
+    canvas.height = image.height;
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "white";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(image, 0, 0);
+
+    const jpeg = await new Promise((resolve) => canvas.toBlob(resolve, "image/jpeg", 0.9));
+    jpeg.name = blob.name.replace(/\.png$/, '.jpg');
+
+    if (jpeg.size < blob.size / 2) {
+      return jpeg;
+    }
+  } catch (e) {
+    // skip any errors
+  } finally {
+    window.URL.revokeObjectURL(src);
+  }
+  return blob;
 }

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -25,6 +25,7 @@ import TimeDisplay from './time-display';
 import LinkPreview from './link-preview/preview';
 import SendTo from './send-to';
 import { destinationsPrivacy } from './select-utils';
+import { makeJpegIfNeeded } from './create-post';
 
 
 class Post extends React.Component {
@@ -53,7 +54,7 @@ class Post extends React.Component {
             if (!blob.name) {
               blob.name = 'image.png';
             }
-            this.dropzoneObject.addFile(blob);
+            makeJpegIfNeeded(blob).then((blob) => this.dropzoneObject.addFile(blob));
           }
         }
       }


### PR DESCRIPTION
Upload pasted image as JPEG if:
1) The PNG size is more than 50 KiB and
2) JPEG size is less than half the PNG size.

This algorithm keeps ever big drawing- and text screenshots as PNG and converts photos to JPEG.