### PR TITLE
Find hostnames in links using regex instead of URL API

### DIFF
--- a/src/utils/parse-text.js
+++ b/src/utils/parse-text.js
@@ -1,5 +1,3 @@
-/*global Raven*/
-import { URL as nodeURL } from 'url';
 import { includes } from 'lodash';
 import {
   withText,
@@ -14,31 +12,24 @@ import {
 
 import config from '../config';
 
-// Webpack can not fully emulate WHATWG URL API object for now,
-// so we use global.URL in browser and nodeURL in node.
-// see https://github.com/webpack/node-libs-browser/issues/69
-const URL = nodeURL || global.URL;
 
 export class Link extends TLink {
-  url = null;
+  hostname = null;
 
   constructor(link) {
     super(link.offset, link.text);
-    try {
-      this.url = new URL(this.href);
-    } catch (e) {
-      if (typeof Raven !== 'undefined') {
-        Raven.captureMessage(`Can not parse URL ${this.href}`, { extra: { url: this.href } });
-      }
+    const m = this.href.match(/^https?:\/\/([^/]+)/i);
+    if (m) {
+      this.hostname = m[1].toLowerCase();
     }
   }
 
   get isLocal() {
-    return this.url && includes(config.siteDomains, this.url.hostname);
+    return this.hostname && includes(config.siteDomains, this.hostname);
   }
 
   get localURI() {
-    return this.url ? this.url.pathname + this.url.search + this.url.hash : '';
+    return this.hostname ? this.href.replace(/^https?:\/\/[^/]+/i, '') : '';
   }
 }
 

--- a/test/unit/utils/parse-text.js
+++ b/test/unit/utils/parse-text.js
@@ -1,0 +1,28 @@
+import { describe, it } from 'mocha';
+import expect from 'unexpected';
+import { Link as TLink } from 'social-text-tokenizer';
+
+import { Link } from '../../../src/utils/parse-text';
+
+
+describe('parse-text', () => {
+  describe('Link class', () => {
+    it('should has thruthy isLocal property for local link', () => {
+      const link = new Link(new TLink(0, 'https://freefeed.net/some/path'));
+      expect(link.isLocal, 'to be true');
+      expect(link.localURI, 'to be', '/some/path');
+    });
+
+    it('should has thruthy isLocal property for local link with mixed-case URL', () => {
+      const link = new Link(new TLink(0, 'hTTps://FreeFeed.net/some/path'));
+      expect(link.isLocal, 'to be true');
+      expect(link.localURI, 'to be', '/some/path');
+    });
+
+    it('should has falsy isLocal property for remote link', () => {
+      const link = new Link(new TLink(0, 'https://github.com/FreeFeed'));
+      expect(link.isLocal, 'to be false');
+      expect(link.localURI, 'to be', '/FreeFeed');
+    });
+  });
+});


### PR DESCRIPTION
Will fix #886