### PR TITLE
Fixes for a few comment-related minor bugs

### DIFF
--- a/src/components/comment-likes.jsx
+++ b/src/components/comment-likes.jsx
@@ -8,6 +8,9 @@ import TimeDisplay from "./time-display";
 export default class CommentLikes extends React.Component {
   actionsPanel;
 
+  likesListEl;
+  setLikesList = (el) => this.likesListEl = el;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -74,6 +77,9 @@ export default class CommentLikes extends React.Component {
     this.popupTimeout = undefined;
   };
   startTouch = (e) => {
+    if (this.likesListEl && this.likesListEl.contains(e.target)) {
+      return;
+    }
     e.preventDefault();
     this.popupTimeout = setTimeout(() => {
       this.setState({ showActionsPanel: true });
@@ -93,7 +99,10 @@ export default class CommentLikes extends React.Component {
       }
     }
   };
-  startMouseDown = () => {
+  startMouseDown = (e) => {
+    if (this.likesListEl && this.likesListEl.contains(e.target)) {
+      return;
+    }
     if (!this.state.showActionsPanel) {
       this.popupTimeout = setTimeout(() => {
         this.setState({ showActionsPanel: true });
@@ -212,13 +221,18 @@ export default class CommentLikes extends React.Component {
   };
   renderLikesList = () => {
     const { loading, likes, error } = this.props.likesList;
-    if (loading) {
-      return <div className="comment-likes-list loading">Loading...</div>;
-    }
-    if (error) {
-      return <div className="comment-likes-list error">Error</div>;
-    }
-    return <div className="comment-likes-list">{likes.map((likeUser, i) => <UserName user={likeUser} key={i} />)}</div>;
+    return (
+      <div
+        className={classnames("comment-likes-list", { loading, error })}
+        ref={this.setLikesList}
+      >
+        {
+          loading ? 'Loading...' :
+            error ? 'Error' :
+              likes.map((likeUser, i) => <UserName user={likeUser} key={i} />)
+        }
+      </div>
+    );
   };
   showLikesList = (e) => {
     e.preventDefault();

--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { Link } from 'react-router';
 import { StickyContainer, Sticky } from 'react-sticky';
 import _ from 'lodash';
 
@@ -11,6 +11,8 @@ import MoreCommentsWrapper from './more-comments-wrapper';
 const minCommentsToFold = 12;
 
 export default class PostComments extends React.Component {
+  static defaultProps = { user: {} };
+
   addingCommentForm;
   rootEl;
 
@@ -186,27 +188,43 @@ export default class PostComments extends React.Component {
     return middleComments;
   }
 
-  registerRootEl = (el) => {
-    this.rootEl = el ? ReactDOM.findDOMNode(el) : null;
-  };
+  registerRootEl = (el) => this.rootEl = el;
+
+  renderAddComment() {
+    const { post, user } = this.props;
+    const canAddComment = (!post.commentsDisabled || post.isEditable || post.isModeratable);
+    if (!canAddComment) {
+      return false;
+    }
+    if (!user.id) {
+      return post.isCommenting ? (
+        <div className="comment">
+          <span className="comment-icon fa-stack fa-1x">
+            <i className="fa fa-comment-o fa-stack-1x" />
+            <i className="fa fa-square fa-inverse fa-stack-1x" />
+            <i className="fa fa-plus fa-stack-1x" />
+          </span>
+          <span><Link to="/signin">Sign In</Link> to add comment</span>
+        </div>
+      ) : false;
+    }
+    return post.isCommenting ?
+      this.renderAddingComment() :
+      this.renderAddCommentLink();
+  }
 
   render() {
     const { post, comments } = this.props;
     const totalComments = comments.length + post.omittedComments;
     const first = withBackwardNumber(comments[0], totalComments);
     const last = withBackwardNumber(comments.length > 1 && comments[comments.length - 1], 1);
-    const canAddComment = (!!post.user && (!post.commentsDisabled || post.isEditable || post.isModeratable));
 
     return (
       <div className="comments" ref={this.registerRootEl}>
         {first ? this.renderComment(first) : false}
         {this.renderMiddle()}
         {last ? this.renderComment(last) : false}
-        {canAddComment
-          ? (post.isCommenting
-            ? this.renderAddingComment()
-            : this.renderAddCommentLink())
-          : false}
+        {this.renderAddComment()}
       </div>
     );
   }

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -506,6 +506,7 @@ class Post extends React.Component {
             highlightTerms={props.highlightTerms}
             isSinglePost={props.isSinglePost}
             showTimestamps={this.state.showTimestamps}
+            user={props.user}
           />
         </div>
       </div>

--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -305,9 +305,10 @@ export function unlikeComment(commentId) {
 
 export function getCommentLikes(commentId) {
   return {
-    type:       ActionTypes.GET_COMMENT_LIKES,
-    apiRequest: Api.getCommentLikes,
-    payload:    { commentId },
+    type:           ActionTypes.GET_COMMENT_LIKES,
+    apiRequest:     Api.getCommentLikes,
+    nonAuthRequest: true,
+    payload:        { commentId },
   };
 }
 

--- a/test/unit/components/post-comments.js
+++ b/test/unit/components/post-comments.js
@@ -3,6 +3,7 @@ import unexpected from 'unexpected';
 import unexpectedReact from 'unexpected-react';
 
 import React from 'react';
+import { Link } from 'react-router';
 import flatten from 'lodash/flatten';
 
 import PostComments from '../../../src/components/post-comments';
@@ -144,7 +145,7 @@ describe('<PostComments>', () => {
   it('should render commenting section only if post is commented', () => {
     const post = { omittedComments: 1, isCommenting: false, createdBy: { username: '' }, user: {} };
     expect(
-      <PostComments comments={[]} post={post} />,
+      <PostComments comments={[]} post={post} user={{ id: '12345' }} />,
       'when rendered',
       'not to contain',
       <PostComment isEditing={true} />
@@ -152,10 +153,34 @@ describe('<PostComments>', () => {
 
     post.isCommenting = true;
     expect(
-      <PostComments comments={[]} post={post} />,
+      <PostComments comments={[]} post={post} user={{ id: '12345' }} />,
       'when rendered',
       'to contain',
       <PostComment isEditing={true} />
+    );
+  });
+
+  it('should render "Sign In" link if post is commented and user is anonymous', () => {
+    const post = { omittedComments: 1, isCommenting: false, createdBy: { username: '' }, user: {} };
+    expect(
+      <PostComments comments={[]} post={post} user={{}} />,
+      'when rendered',
+      'not to contain',
+      <PostComment isEditing={true} />
+    );
+    expect(
+      <PostComments comments={[]} post={post} user={{}} />,
+      'when rendered',
+      'not to contain',
+      <Link>Sign In</Link>
+    );
+
+    post.isCommenting = true;
+    expect(
+      <PostComments comments={[]} post={post} user={{}} />,
+      'when rendered',
+      'to contain',
+      <Link>Sign In</Link>
     );
   });
 });


### PR DESCRIPTION
Fixes for a few minor bugs in client:

1. Allow anonymous user to fetch comment likes list (it fixes #736);
2. Do not handle long click/tap on comment likes list (it allow user to scroll long list by dragging scrollbar);
3. Do not show comment textarea under the post in anonymous mode (show text “Sign In to add comment” instead).

![image](https://user-images.githubusercontent.com/132120/53951037-a19f4d80-40de-11e9-9abb-093cddc6c5c4.png)
