### PR TITLE
Check if post is in sore on REALTIME_LIKE_REMOVE processing

### DIFF
--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -140,7 +140,7 @@ export const likesLogicMiddleware = (store) => (next) => (action) => {
       const { postId, userId } = action;
       const post = store.getState().posts[postId];
       // it is necessary for proper update postsViewState
-      action.isLikeVisible = _.includes(post.likes, userId);
+      action.isLikeVisible = post ? post.likes.includes(userId) : false;
       return next(action);
     }
   }

--- a/test/unit/redux/middlewares/likes-logic.js
+++ b/test/unit/redux/middlewares/likes-logic.js
@@ -1,0 +1,56 @@
+import { describe, it, beforeEach } from 'mocha';
+import unexpected from 'unexpected';
+import unexpectedSinon from 'unexpected-sinon';
+import sinon from 'sinon';
+
+import { likesLogicMiddleware } from '../../../../src/redux/middlewares';
+import { REALTIME_LIKE_REMOVE } from '../../../../src/redux/action-types';
+
+
+const expect = unexpected.clone();
+expect.use(unexpectedSinon);
+
+describe('likesLogicMiddleware middleware', () => {
+  describe('on REALTIME_LIKE_REMOVE', () => {
+    const store = {
+      posts: {},
+      getState() { return this; },
+    };
+    const next = sinon.spy();
+    let action;
+
+    beforeEach(() => {
+      store.posts = {};
+      action = {
+        type:   REALTIME_LIKE_REMOVE,
+        postId: '111',
+        userId: '222',
+      };
+      next.resetHistory();
+    });
+
+    it('should add isLikeVisible: false if post not in store', () => {
+      store.posts = {};
+      const nextAction = { ...action, isLikeVisible: false };
+
+      likesLogicMiddleware(store)(next)(action);
+      expect(next, 'to have a call satisfying', { args: [nextAction] });
+    });
+
+    it('should add isLikeVisible: false if user was not like post', () => {
+      store.posts = { '111': { likes: ['333'] } } ;
+      const nextAction = { ...action, isLikeVisible: false };
+
+      likesLogicMiddleware(store)(next)(action);
+      expect(next, 'to have a call satisfying', { args: [nextAction] });
+    });
+
+    it('should add isLikeVisible: true if user was like post', () => {
+      store.posts = { '111': { likes: ['333', '222'] } } ;
+      const nextAction = { ...action, isLikeVisible: true };
+
+      likesLogicMiddleware(store)(next)(action);
+      expect(next, 'to have a call satisfying', { args: [nextAction] });
+    });
+  });
+});


### PR DESCRIPTION
It fixes "Cannot read property 'likes' of undefined" error when unliked post is not in the current redux store.