### PR TITLE
Realtime switch fixes

### DIFF
--- a/src/components/feed-options-switch.jsx
+++ b/src/components/feed-options-switch.jsx
@@ -27,8 +27,8 @@ class FeedOptionsSwitch extends React.PureComponent {
     const { homeFeedSort: defaultHomeFeedSort } = config.frontendPreferences.defaultValues;
 
     const toggle = defaultHomeFeedSort === feedSort.sort
-      ? <span className="glyphicon glyphicon-option-horizontal" onClick={this.toggleDropdown} />
-      : <span><span className="glyphicon glyphicon-time" />&nbsp;{!realtimeActive && <span>Paused,&nbsp;</span>}Most recent posts &#183;   <a href="#" onClick={preventDefault(this.switchSortToActivity)}>To default view</a>&nbsp;&nbsp;<span className="glyphicon glyphicon-option-horizontal" onClick={this.toggleDropdown} /></span>;
+      ? <span className="glyphicon glyphicon-option-horizontal dots-icon" onClick={this.toggleDropdown} />
+      : <span><span className="glyphicon glyphicon-time" />&nbsp;{!realtimeActive && <span>Paused,&nbsp;</span>}Most recent posts &#183;   <a href="#" onClick={preventDefault(this.switchSortToActivity)}>To default view</a>&nbsp;&nbsp;<span className="glyphicon glyphicon-option-horizontal dots-icon" onClick={this.toggleDropdown} /></span>;
 
     const menuOptions = {
       align:   'right',

--- a/src/components/feed-options-switch.jsx
+++ b/src/components/feed-options-switch.jsx
@@ -28,7 +28,7 @@ class FeedOptionsSwitch extends React.PureComponent {
     const { homeFeedSort: defaultHomeFeedSort } = config.frontendPreferences.defaultValues;
 
     const toggle = defaultHomeFeedSort === feedSort.sort
-      ? <span className="glyphicon glyphicon-option-horizontal dots-icon" onClick={this.toggleDropdown} />
+      ? <span>{!realtimeActive && isAuthenticated && <span>Paused&nbsp;</span>}<span className="glyphicon glyphicon-option-horizontal dots-icon" onClick={this.toggleDropdown} /></span>
       : <span><span className="glyphicon glyphicon-time" />&nbsp;{!realtimeActive && isAuthenticated && <span>Paused,&nbsp;</span>}<span className="widescreen-text">Most recent posts &#183;</span><span className="narrowscreen-text">Recent posts &#183;</span>   <a href="#" onClick={preventDefault(this.switchSortToActivity)}><span className="narrowscreen-text">Default</span><span className="widescreen-text">To default view</span></a>&nbsp;&nbsp;<span className="glyphicon glyphicon-option-horizontal dots-icon" onClick={this.toggleDropdown} /></span>;
 
     const menuOptions = {

--- a/src/components/feed-options-switch.jsx
+++ b/src/components/feed-options-switch.jsx
@@ -28,7 +28,7 @@ class FeedOptionsSwitch extends React.PureComponent {
 
     const toggle = defaultHomeFeedSort === feedSort.sort
       ? <span className="glyphicon glyphicon-option-horizontal dots-icon" onClick={this.toggleDropdown} />
-      : <span><span className="glyphicon glyphicon-time" />&nbsp;{!realtimeActive && <span>Paused,&nbsp;</span>}Most recent posts &#183;   <a href="#" onClick={preventDefault(this.switchSortToActivity)}>To default view</a>&nbsp;&nbsp;<span className="glyphicon glyphicon-option-horizontal dots-icon" onClick={this.toggleDropdown} /></span>;
+      : <span><span className="glyphicon glyphicon-time" />&nbsp;{!realtimeActive && <span>Paused,&nbsp;</span>}<span className="widescreen-text">Most recent posts &#183;</span><span className="narrowscreen-text">Recent posts &#183;</span>   <a href="#" onClick={preventDefault(this.switchSortToActivity)}><span className="narrowscreen-text">Default</span><span className="widescreen-text">To default view</span></a>&nbsp;&nbsp;<span className="glyphicon glyphicon-option-horizontal dots-icon" onClick={this.toggleDropdown} /></span>;
 
     const menuOptions = {
       align:   'right',

--- a/src/components/feed-options-switch.jsx
+++ b/src/components/feed-options-switch.jsx
@@ -23,12 +23,13 @@ class FeedOptionsSwitch extends React.PureComponent {
     const { props } = this;
     const { realtimeActive } = props.frontendPreferences;
     const { feedSort, showRealtime } = props;
+    const isAuthenticated = !!props.userId;
 
     const { homeFeedSort: defaultHomeFeedSort } = config.frontendPreferences.defaultValues;
 
     const toggle = defaultHomeFeedSort === feedSort.sort
       ? <span className="glyphicon glyphicon-option-horizontal dots-icon" onClick={this.toggleDropdown} />
-      : <span><span className="glyphicon glyphicon-time" />&nbsp;{!realtimeActive && <span>Paused,&nbsp;</span>}<span className="widescreen-text">Most recent posts &#183;</span><span className="narrowscreen-text">Recent posts &#183;</span>   <a href="#" onClick={preventDefault(this.switchSortToActivity)}><span className="narrowscreen-text">Default</span><span className="widescreen-text">To default view</span></a>&nbsp;&nbsp;<span className="glyphicon glyphicon-option-horizontal dots-icon" onClick={this.toggleDropdown} /></span>;
+      : <span><span className="glyphicon glyphicon-time" />&nbsp;{!realtimeActive && isAuthenticated && <span>Paused,&nbsp;</span>}<span className="widescreen-text">Most recent posts &#183;</span><span className="narrowscreen-text">Recent posts &#183;</span>   <a href="#" onClick={preventDefault(this.switchSortToActivity)}><span className="narrowscreen-text">Default</span><span className="widescreen-text">To default view</span></a>&nbsp;&nbsp;<span className="glyphicon glyphicon-option-horizontal dots-icon" onClick={this.toggleDropdown} /></span>;
 
     const menuOptions = {
       align:   'right',

--- a/styles/shared/feed-options-switch.scss
+++ b/styles/shared/feed-options-switch.scss
@@ -9,6 +9,19 @@
     top: 3px;
   }
 
+  .narrowscreen-text {
+    @media (min-width: 767px) {
+      display: none;
+    }
+  }
+
+  .widescreen-text {
+    display: none;
+    @media (min-width: 767px) {
+      display: inline;
+    }
+  }
+
   .dropdown {
     position: absolute;
     width: 180px;

--- a/styles/shared/feed-options-switch.scss
+++ b/styles/shared/feed-options-switch.scss
@@ -5,6 +5,10 @@
   position: relative;
   z-index: 1;
 
+  .dots-icon {
+    top: 3px;
+  }
+
   .dropdown {
     position: absolute;
     width: 180px;


### PR DESCRIPTION
This pull closes number of issues with realtime/feed sorting switch; namely:
1) Implements narrow-screen texts  (closes #885)
2) Shows 'paused' any time realtime updates are off (closes #884)
3) Aligns single an triple dots (closes #883)
4) Doesn't show 'paused' in anonymous mode (closes #881)