### PR TITLE
Suppress success-message when changing feed-mode

### DIFF
--- a/src/components/feed-options-switch.jsx
+++ b/src/components/feed-options-switch.jsx
@@ -81,7 +81,7 @@ const mapDispatchToProps = (dispatch) => {
     toggleRealtime: (userId, frontendPreferences) => {
       const { realtimeActive } = frontendPreferences;
       //send a request to change flag
-      dispatch(updateUserPreferences(userId, { ...frontendPreferences, realtimeActive: !realtimeActive }));
+      dispatch(updateUserPreferences(userId, { ...frontendPreferences, realtimeActive: !realtimeActive }, {}, true));
       //set a flag to show
       dispatch(toggleRealtime());
       if (!realtimeActive) {

--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -434,11 +434,12 @@ export function userSettingsChange(payload) {
   };
 }
 
-export function updateUserPreferences(userId, frontendPrefs = {}, backendPrefs = {}) {
+export function updateUserPreferences(userId, frontendPrefs = {}, backendPrefs = {}, suppressStatus = false) {
   return {
     type:       ActionTypes.UPDATE_USER_PREFERENCES,
     apiRequest: Api.updateUserPreferences,
     payload:    { userId, frontendPrefs, backendPrefs },
+    extra:      { suppressStatus },
   };
 }
 

--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -37,7 +37,7 @@ export const feedSortMiddleware = (store) => (next) => (action) => {
       const { user, feedSort } = store.getState();
       const { id, frontendPreferences } = user;
       const { sort: homeFeedSort } = feedSort;
-      return store.dispatch(ActionCreators.updateUserPreferences(id, { ...frontendPreferences, homeFeedSort }));
+      return store.dispatch(ActionCreators.updateUserPreferences(id, { ...frontendPreferences, homeFeedSort }, {}, true));
     }
   }
   if (action.type === response(ActionTypes.WHO_AM_I)) {
@@ -83,7 +83,8 @@ export const apiMiddleware = (store) => (next) => async (action) => {
           adjustTime(store.dispatch, serverTime - Date.now());
         }
       }
-      return store.dispatch({ payload: obj, type: response(action.type), request: action.payload });
+      const extra = action.extra || {};
+      return store.dispatch({ payload: obj, type: response(action.type), request: action.payload, extra });
     }
 
     if (apiResponse.status === 401) {

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -1713,12 +1713,21 @@ export function frontendPreferencesForm(state = {}, action) {
       return { ...state, ...action.payload.users.frontendPreferences[frontendPrefsConfig.clientId] };
     }
     case request(ActionTypes.UPDATE_USER_PREFERENCES): {
+      if (typeof action.extra !== 'undefined' && action.extra.suppressStatus) {
+        return state;
+      }
       return { ...state, status: 'loading' };
     }
     case response(ActionTypes.UPDATE_USER_PREFERENCES): {
+      if (typeof action.extra !== 'undefined' && action.extra.suppressStatus) {
+        return state;
+      }
       return { ...state, status: 'success' };
     }
     case fail(ActionTypes.UPDATE_USER_PREFERENCES): {
+      if (typeof action.extra !== 'undefined' && action.extra.suppressStatus) {
+        return state;
+      }
       return { ...state, status: 'error', errorMessage: (action.payload || {}).err };
     }
     case ActionTypes.RESET_SETTINGS_FORMS: {


### PR DESCRIPTION
Ensure, that whenever user changes feed's sort-mode or enables realtime
she would not get "success" message on the settings page