### PR TITLE
Update all user data in the UserSettingsForm with the single API call

### DIFF
--- a/src/components/settings.jsx
+++ b/src/components/settings.jsx
@@ -48,7 +48,6 @@ class Settings extends React.Component {
             <UserSettingsForm
               user={props.user}
               updateUser={props.updateUser}
-              updateUserPreferences={props.updateUserPreferences}
               userSettingsChange={props.userSettingsChange}
               {...props.userSettingsForm}
             />

--- a/src/components/user-settings-form.jsx
+++ b/src/components/user-settings-form.jsx
@@ -40,17 +40,20 @@ export default class UserSettingsForm extends React.Component {
   };
 
   updateUser = () => {
-    if (!this.props.isSaving) {
-      this.props.updateUser(
-        this.props.user.id,
-        this.props.screenName,
-        this.props.email,
-        this.props.isPrivate,
-        this.props.isProtected,
-        this.props.description,
-      );
-      this.props.updateUserPreferences(this.props.user.id, this.props.user.frontendPreferences, { acceptDirectsFrom: this.props.directsFromAll ? 'all' : 'friends' });
+    if (this.props.isSaving) {
+      return;
     }
+
+    this.props.updateUser(
+      this.props.user.id,
+      this.props.screenName,
+      this.props.email,
+      this.props.isPrivate,
+      this.props.isProtected,
+      this.props.description,
+      undefined, // frontendPreferences will not updates
+      { acceptDirectsFrom: this.props.directsFromAll ? 'all' : 'friends' },
+    );
   };
 
   render() {

--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -419,11 +419,20 @@ export function signUpEmpty(errorMessage) {
   };
 }
 
-export function updateUser(id, screenName, email, isPrivate, isProtected, description) {
+export function updateUser(
+  id,
+  screenName,
+  email,
+  isPrivate,
+  isProtected,
+  description,
+  frontendPrefs = undefined,
+  backendPrefs = undefined,
+) {
   return {
     type:       ActionTypes.UPDATE_USER,
     apiRequest: Api.updateUser,
-    payload:    { id, screenName, email, isPrivate, isProtected, description },
+    payload:    { id, screenName, email, isPrivate, isProtected, description, frontendPrefs, backendPrefs },
   };
 }
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -342,7 +342,23 @@ export function markAllNotificationsAsRead() {
   });
 }
 
-export function updateUser({ id, screenName, email, isPrivate, isProtected, description }) {
+export function updateUser({
+  id,
+  screenName,
+  email,
+  isPrivate,
+  isProtected,
+  description,
+  frontendPrefs = undefined,
+  backendPrefs = undefined,
+}) {
+  const user = { screenName, email, isPrivate, isProtected, description };
+  if (frontendPrefs) {
+    user.frontendPreferences = { [frontendPrefsConfig.clientId]: frontendPrefs };
+  }
+  if (backendPrefs) {
+    user.preferences = backendPrefs;
+  }
   return fetch(`${apiConfig.host}/v1/users/${id}`, {
     'method':  'PUT',
     'headers': {
@@ -350,7 +366,7 @@ export function updateUser({ id, screenName, email, isPrivate, isProtected, desc
       'Content-Type':           'application/json',
       'X-Authentication-Token': getToken()
     },
-    'body': JSON.stringify({ user: { screenName, email, isPrivate, isProtected, description } })
+    'body': JSON.stringify({ user })
   });
 }
 


### PR DESCRIPTION
Previously the results of two parallel calls (one for data update and one for prefs) can interfere with each other.