### PR TITLE
Prohibit additional zoom on iOS/Safari

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -2,7 +2,7 @@ doctype html
 html(lang='en')
   head
     meta(charset='utf-8')
-    meta(name='viewport', content='width=device-width,initial-scale=1')
+    meta(name='viewport', content='width=device-width,initial-scale=1,maximum-scale=1')
     //- Support for FB OpenGraph and Twitter
     <!--#if expr="${request_uri} = /^\/([a-zA-Z0-9]+)\/([a-fA-F0-9\-]{36})/" -->
     <!--#set var="post_id" value="$2" -->


### PR DESCRIPTION
iOS/Safari uses additional zoom if textarea with small font gets focus.
This patch doesn't allow it to go beyond 1 (which is our default)

see https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone