### PR TITLE
Redirect to canonical URI on user pages

### DIFF
--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -44,7 +44,7 @@ export function title(state = '', action) {
       return `Search - FreeFeed`;
     }
     case response(ActionTypes.GET_USER_FEED): {
-      const [user] = (action.payload.users || []).filter((user) => user.username === action.request.username);
+      const user = action.payload.users.find((user) => user.id === action.payload.timelines.user);
       const author = user.screenName + (user.username !== user.screenName ? ` (${user.username})` : '');
       return `${author} - FreeFeed`;
     }


### PR DESCRIPTION
For example /uSErNAme/likes?offset=30 → /username/likes?offset=30

Bug report: https://freefeed.net/support/a7ea40dc-8a83-4df6-ac8a-3cd3cd75f268

This change is not fixed all possible variants of this issue (it not fixes subscriptions/subscribers pages for example).