### PR TITLE
Add support for very long displaynames in usercard

### DIFF
--- a/styles/shared/user-name.scss
+++ b/styles/shared/user-name.scss
@@ -29,7 +29,7 @@
   }
 
   .user-card-info {
-    height: 97px; // 75px + 2px + 20px
+    min-height: 97px; // 75px + 2px + 20px
     padding: 10px;
     background-color: #fff;
     border-top-right-radius: 2px;
@@ -57,6 +57,8 @@
         color: #000088;
         font-weight: bold;
         word-break: break-word;
+        display: inline-block;
+        max-width: 170px;
       }
 
       .username {


### PR DESCRIPTION
Fixes #998

<img width="368" alt="Screenshot 2019-09-05 at 00 52 18" src="https://user-images.githubusercontent.com/632081/64275116-71464800-cf77-11e9-8bed-75e64c1a9f59.png">
