### PR TITLE
Add ErrorBoundary wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .module-cache
 .history
 /yarn-error.log
+.DS_Store

--- a/src/components/discussions.jsx
+++ b/src/components/discussions.jsx
@@ -8,6 +8,7 @@ import CreatePost from './create-post';
 import Feed from './feed';
 import PaginatedView from './paginated-view';
 import FeedOptionsSwitch from './feed-options-switch';
+import ErrorBoundary from './error-boundary';
 
 
 const FeedHandler = (props) => {
@@ -32,16 +33,18 @@ const FeedHandler = (props) => {
 
   return (
     <div className="box">
-      <div className="box-header-timeline">
-        {props.boxHeader}
-        <div className="pull-right">
-          <FeedOptionsSwitch />
+      <ErrorBoundary>
+        <div className="box-header-timeline">
+          {props.boxHeader}
+          <div className="pull-right">
+            <FeedOptionsSwitch />
+          </div>
         </div>
-      </div>
-      <PaginatedView firstPageHead={props.isSaves || createPostComponent} {...props}>
-        <Feed {...props} emptyFeedMessage={emptyFeedMessage} />
-      </PaginatedView>
-      <div className="box-footer" />
+        <PaginatedView firstPageHead={props.isSaves || createPostComponent} {...props}>
+          <Feed {...props} emptyFeedMessage={emptyFeedMessage} />
+        </PaginatedView>
+        <div className="box-footer" />
+      </ErrorBoundary>
     </div>);
 };
 

--- a/src/components/error-boundary.jsx
+++ b/src/components/error-boundary.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch() {
+    // You can also log the error to an error reporting service
+    // See https://reactjs.org/docs/error-boundaries.html
+  }
+
+  render() {
+    if (this.state.hasError) {
+      const errorMessage = this.state.error ? `${this.state.error.name}: ${this.state.error.message}` : 'Unexpected error';
+      return (
+        <div className="error-boundary">
+          <div className="error-boundary-header">Oops! Something went wrong :(</div>
+          <div className="error-boundary-details">{errorMessage}</div>
+        </div>);
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/expandable.jsx
+++ b/src/components/expandable.jsx
@@ -4,6 +4,8 @@ import classnames from "classnames";
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import { Icon } from "./fontawesome-icons";
 
+import ErrorBoundary from './error-boundary';
+
 
 const DEFAULT_MAX_LINES = 8;
 const DEFAULT_ABOVE_FOLD_LINES = 5;
@@ -36,12 +38,14 @@ export default class Expandable extends React.Component {
     const style = { maxHeight: expanded ? "" : `${this.state.maxHeight}px` };
     return (
       <div className={cn} style={style}>
-        {this.props.children}
-        {!expanded && (
-          <div className="expand-panel">
-            <div className="expand-button"><i onClick={this.userExpand}><Icon icon={faChevronDown} className="expand-icon" /> Read more</i> {this.props.bonusInfo}</div>
-          </div>
-        )}
+        <ErrorBoundary>
+          {this.props.children}
+          {!expanded && (
+            <div className="expand-panel">
+              <div className="expand-button"><i onClick={this.userExpand}><Icon icon={faChevronDown} className="expand-icon" /> Read more</i> {this.props.bonusInfo}</div>
+            </div>
+          )}
+        </ErrorBoundary>
       </div>
     );
   }

--- a/src/components/feed.jsx
+++ b/src/components/feed.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import ErrorBoundary from './error-boundary';
 import Post from './post';
 
 
@@ -64,30 +65,33 @@ function Feed(props) {
 
   return (
     <div className="posts">
+      <ErrorBoundary>
 
-      {visibleEntries}
+        {visibleEntries}
 
-      {hiddenEntries.length > 0 ? (
-        <div>
-          <HiddenEntriesToggle
-            count={hiddenEntries.length}
-            isOpen={props.isHiddenRevealed}
-            toggle={props.toggleHiddenPosts}
-          />
+        {hiddenEntries.length > 0 ? (
+          <div>
+            <HiddenEntriesToggle
+              count={hiddenEntries.length}
+              isOpen={props.isHiddenRevealed}
+              toggle={props.toggleHiddenPosts}
+            />
 
-          {props.isHiddenRevealed ? hiddenEntries : false}
-        </div>
-      ) : false}
+            {props.isHiddenRevealed ? hiddenEntries : false}
+          </div>
+        ) : false}
 
-      {emptyFeed && props.loading && <p>Loading feed...</p>}
-      {emptyFeed && !props.loading && (
-        <>
-          <p>
-            There are no posts in this feed.
-          </p>
-          {props.emptyFeedMessage}
-        </>
-      )}
+        {emptyFeed && props.loading && <p>Loading feed...</p>}
+        {emptyFeed && !props.loading && (
+          <>
+            <p>
+              There are no posts in this feed.
+            </p>
+            {props.emptyFeedMessage}
+          </>
+        )}
+
+      </ErrorBoundary>
     </div>
   );
 }

--- a/src/components/friends.jsx
+++ b/src/components/friends.jsx
@@ -9,6 +9,7 @@ import {
   revokeSentRequest
 } from '../redux/action-creators';
 import { tileUserListFactory, PLAIN, WITH_REQUEST_HANDLES, WITH_REVOKE_SENT_REQUEST } from './tile-user-list';
+import ErrorBoundary from './error-boundary';
 
 
 const TileList = tileUserListFactory({ type: PLAIN, displayQuantity: true });
@@ -21,29 +22,31 @@ const FriendsHandler = (props) => {
 
   return (
     <div className="box">
-      <div className="box-header-timeline">
-        Friends
-      </div>
-      <div className="box-body">
-        <TileListWithAcceptAndReject
-          header={feedRequestsHeader}
-          users={props.feedRequests}
-          acceptRequest={props.acceptUserRequest}
-          rejectRequest={props.rejectUserRequest}
-        />
+      <ErrorBoundary>
+        <div className="box-header-timeline">
+          Friends
+        </div>
+        <div className="box-body">
+          <TileListWithAcceptAndReject
+            header={feedRequestsHeader}
+            users={props.feedRequests}
+            acceptRequest={props.acceptUserRequest}
+            rejectRequest={props.rejectUserRequest}
+          />
 
 
-        <TileList {...props.mutual} />
-        <TileList {...props.subscriptions} />
-        <TileList {...props.blockedByMe} />
+          <TileList {...props.mutual} />
+          <TileList {...props.subscriptions} />
+          <TileList {...props.blockedByMe} />
 
-        <TileListWithRevoke
-          header={sentRequestsHeader}
-          users={props.sentRequests}
-          revokeSentRequest={props.revokeSentRequest}
-        />
-      </div>
-      <div className="box-footer" />
+          <TileListWithRevoke
+            header={sentRequestsHeader}
+            users={props.sentRequests}
+            revokeSentRequest={props.revokeSentRequest}
+          />
+        </div>
+        <div className="box-footer" />
+      </ErrorBoundary>
     </div>
   );
 };

--- a/src/components/group-create.jsx
+++ b/src/components/group-create.jsx
@@ -3,20 +3,23 @@ import { connect } from 'react-redux';
 
 import { createGroup, resetGroupCreateForm } from '../redux/action-creators';
 import GroupCreateForm from './group-create-form';
+import ErrorBoundary from './error-boundary';
 
 
 const GroupCreate = (props) => (
   <div className="box">
-    <div className="box-header-timeline">
-      Create a group
-    </div>
-    <div className="box-body">
-      <GroupCreateForm
-        createGroup={props.createGroup}
-        resetGroupCreateForm={props.resetGroupCreateForm}
-        {...props.groupCreateForm}
-      />
-    </div>
+    <ErrorBoundary>
+      <div className="box-header-timeline">
+        Create a group
+      </div>
+      <div className="box-body">
+        <GroupCreateForm
+          createGroup={props.createGroup}
+          resetGroupCreateForm={props.resetGroupCreateForm}
+          {...props.groupCreateForm}
+        />
+      </div>
+    </ErrorBoundary>
   </div>
 );
 

--- a/src/components/groups.jsx
+++ b/src/components/groups.jsx
@@ -7,6 +7,7 @@ import { pluralForm } from '../utils';
 
 import { acceptGroupRequest, rejectGroupRequest } from '../redux/action-creators';
 import { tileUserListFactory, WITH_REQUEST_HANDLES, PLAIN } from './tile-user-list';
+import ErrorBoundary from './error-boundary';
 
 
 const TileListWithAcceptAndReject = tileUserListFactory({ type: WITH_REQUEST_HANDLES, displayQuantity: true });
@@ -49,29 +50,31 @@ const GroupsHandler = (props) => {
 
   return (
     <div className="box">
-      <div className="box-header-timeline">
-        Groups
-      </div>
-      <div className="box-body">
-        <div className="row">
-          <div className="col-md-8">
-            All the groups you are subscribed to
-          </div>
-          <div className="col-md-4 text-right">
-            <Link to="/groups/create">Create a group</Link>
-          </div>
+      <ErrorBoundary>
+        <div className="box-header-timeline">
+          Groups
         </div>
-
-        {groupRequests ? (
-          <div>
-            {groupRequests}
+        <div className="box-body">
+          <div className="row">
+            <div className="col-md-8">
+              All the groups you are subscribed to
+            </div>
+            <div className="col-md-4 text-right">
+              <Link to="/groups/create">Create a group</Link>
+            </div>
           </div>
-        ) : false}
 
-        <TileList {...props.myGroups} />
-        <TileList {...props.groupsIAmIn} />
-      </div>
-      <div className="box-footer" />
+          {groupRequests ? (
+            <div>
+              {groupRequests}
+            </div>
+          ) : false}
+
+          <TileList {...props.myGroups} />
+          <TileList {...props.groupsIAmIn} />
+        </div>
+        <div className="box-footer" />
+      </ErrorBoundary>
     </div>
   );
 };

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -10,6 +10,7 @@ import Feed from './feed';
 import PaginatedView from './paginated-view';
 import FeedOptionsSwitch from './feed-options-switch';
 import Welcome from './welcome';
+import ErrorBoundary from './error-boundary';
 
 
 const FeedHandler = (props) => {
@@ -34,34 +35,36 @@ const FeedHandler = (props) => {
 
   return (
     <div className="box">
-      <div className="box-header-timeline">
-        {props.boxHeader}
-        <div className="pull-right">
-          {props.authenticated && <FeedOptionsSwitch />}
+      <ErrorBoundary>
+        <div className="box-header-timeline">
+          {props.boxHeader}
+          <div className="pull-right">
+            {props.authenticated && <FeedOptionsSwitch />}
+          </div>
         </div>
-      </div>
 
-      {props.authenticated && totalRequestsCount > 0 ? (
-        <div className="box-message alert alert-info">
-          <span className="message">
-            {totalRequestsCount > 0 ? (
-              <span>
-                <span>You have </span>
-                {userRequestsCount > 0 ? (<Link to="/friends">{userRequestsText}</Link>) : false}
-                {bothRequestsDisplayed ? (<span> and </span>) : false}
-                {groupRequestsCount > 0 ? (<Link to="/groups">{groupRequestsText}</Link>) : false}
-              </span>
-            ) : false}
-          </span>
-        </div>
-      ) : false}
+        {props.authenticated && totalRequestsCount > 0 ? (
+          <div className="box-message alert alert-info">
+            <span className="message">
+              {totalRequestsCount > 0 ? (
+                <span>
+                  <span>You have </span>
+                  {userRequestsCount > 0 ? (<Link to="/friends">{userRequestsText}</Link>) : false}
+                  {bothRequestsDisplayed ? (<span> and </span>) : false}
+                  {groupRequestsCount > 0 ? (<Link to="/groups">{groupRequestsText}</Link>) : false}
+                </span>
+              ) : false}
+            </span>
+          </div>
+        ) : false}
 
-      {props.authenticated ? (
-        <PaginatedView firstPageHead={createPostComponent} {...props}>
-          <Feed {...props} isInHomeFeed={!props.feedIsLoading} />
-        </PaginatedView>
-      ) : (<Welcome />)}
-      <div className="box-footer" />
+        {props.authenticated ? (
+          <PaginatedView firstPageHead={createPostComponent} {...props}>
+            <Feed {...props} isInHomeFeed={!props.feedIsLoading} />
+          </PaginatedView>
+        ) : (<Welcome />)}
+        <div className="box-footer" />
+      </ErrorBoundary>
     </div>);
 };
 

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -10,6 +10,7 @@ import Footer from './footer';
 import Sidebar from './sidebar';
 import LoaderContainer from './loader-container';
 import SearchForm from './search-form';
+import ErrorBoundary from './error-boundary';
 import { ColorSchemeSetter } from './color-theme-setter';
 import { SVGSymbolDeclarations } from './fontawesome-icons';
 
@@ -129,51 +130,53 @@ class Layout extends React.Component {
 
     return (
       <div className={layoutClassNames}>
-        <Helmet title={props.title} />
-        <ColorSchemeSetter />
-        <SVGSymbolDeclarations />
+        <ErrorBoundary>
+          <Helmet title={props.title} />
+          <ColorSchemeSetter />
+          <SVGSymbolDeclarations />
 
-        <header className="row">
-          <div className="col-xs-9 col-sm-4 col-md-4">
-            <h1 className="site-logo">
-              <IndexLink className="site-logo-link" to="/" onClick={logoHandler(props.routeName, props.home)}>FreeFeed</IndexLink>
-            </h1>
-          </div>
-
-          {props.authenticated ? (
-            <div className="col-xs-12 col-sm-8 hidden-md hidden-lg">
-              <div className="mobile-shortcuts">
-                <Link className="mobile-shortcut-link" to="/filter/discussions">Discussions</Link>
-                <Link className="mobile-shortcut-link" to="/filter/notifications">Notifications{(props.user.unreadNotificationsNumber > 0 && !props.user.frontendPreferences.hideUnreadNotifications) && ` (${props.user.unreadNotificationsNumber})`}</Link>
-                <Link className="mobile-shortcut-link" to="/filter/direct">Directs{props.user.unreadDirectsNumber > 0 && ` (${props.user.unreadDirectsNumber})`}</Link>
-                <Link className="mobile-shortcut-link" to={`/${props.user.username}`}>My feed</Link>
-              </div>
+          <header className="row">
+            <div className="col-xs-9 col-sm-4 col-md-4">
+              <h1 className="site-logo">
+                <IndexLink className="site-logo-link" to="/" onClick={logoHandler(props.routeName, props.home)}>FreeFeed</IndexLink>
+              </h1>
             </div>
-          ) : (
-            <div className="col-xs-3 col-sm-6 col-md-3 text-right">
-              <div className="signin-link">
-                <Link to="/signin">Sign In</Link>
+
+            {props.authenticated ? (
+              <div className="col-xs-12 col-sm-8 hidden-md hidden-lg">
+                <div className="mobile-shortcuts">
+                  <Link className="mobile-shortcut-link" to="/filter/discussions">Discussions</Link>
+                  <Link className="mobile-shortcut-link" to="/filter/notifications">Notifications{(props.user.unreadNotificationsNumber > 0 && !props.user.frontendPreferences.hideUnreadNotifications) && ` (${props.user.unreadNotificationsNumber})`}</Link>
+                  <Link className="mobile-shortcut-link" to="/filter/direct">Directs{props.user.unreadDirectsNumber > 0 && ` (${props.user.unreadDirectsNumber})`}</Link>
+                  <Link className="mobile-shortcut-link" to={`/${props.user.username}`}>My feed</Link>
+                </div>
               </div>
+            ) : (
+              <div className="col-xs-3 col-sm-6 col-md-3 text-right">
+                <div className="signin-link">
+                  <Link to="/signin">Sign In</Link>
+                </div>
+              </div>
+            )}
+
+            <div className="col-xs-12 col-sm-12 col-md-5">
+              <SearchForm />
             </div>
-          )}
+          </header>
 
-          <div className="col-xs-12 col-sm-12 col-md-5">
-            <SearchForm />
-          </div>
-        </header>
+          <LoaderContainer loading={props.loadingView} fullPage={true}>
+            <div className="row">
+              <InternalLayout {...props} />
+              {props.authenticated ? <Sidebar {...props} /> : false}
+            </div>
+          </LoaderContainer>
 
-        <LoaderContainer loading={props.loadingView} fullPage={true}>
           <div className="row">
-            <InternalLayout {...props} />
-            {props.authenticated ? <Sidebar {...props} /> : false}
+            <div className="col-md-12">
+              <Footer />
+            </div>
           </div>
-        </LoaderContainer>
-
-        <div className="row">
-          <div className="col-md-12">
-            <Footer />
-          </div>
-        </div>
+        </ErrorBoundary>
       </div>
     );
   }

--- a/src/components/linkify.jsx
+++ b/src/components/linkify.jsx
@@ -7,6 +7,7 @@ import { parseText } from '../utils/parse-text';
 import { highlightString } from '../utils/search-highlighter';
 import { FRIENDFEED_POST } from '../utils/link-types';
 import UserName from './user-name';
+import ErrorBoundary from './error-boundary';
 
 
 const MAX_URL_LENGTH = 50;
@@ -106,10 +107,10 @@ export default class Linkify extends React.Component {
     const hl = this.props.highlightTerms;
     const parsed = this.processStrings(this.props.children, this.parseString, ['a', 'button', UserName]);
     if (!hl || hl.length === 0) {
-      return <span className="Linkify" dir="auto">{parsed}</span>;
+      return <span className="Linkify" dir="auto"><ErrorBoundary>{parsed}</ErrorBoundary></span>;
     }
     const highlighted = this.processStrings(parsed, (str) => highlightString(str, hl), ['button']);
-    return <span className="Linkify" dir="auto">{highlighted}</span>;
+    return <span className="Linkify" dir="auto"><ErrorBoundary>{highlighted}</ErrorBoundary></span>;
   }
 }
 

--- a/src/components/more-comments-wrapper.jsx
+++ b/src/components/more-comments-wrapper.jsx
@@ -2,22 +2,25 @@ import React from 'react';
 
 import { preventDefault } from '../utils';
 import { Throbber } from './throbber';
+import ErrorBoundary from './error-boundary';
 
 
 const MoreCommentsWrapper = (props) => (
   <div className="comment more-comments-wrapper">
-    <span className="more-comments-throbber">
-      {props.isLoading ? (
-        <Throbber />
-      ) : false}
-    </span>
-    <a
-      className="more-comments-link"
-      href={props.entryUrl}
-      onClick={preventDefault(() => props.showMoreComments())}
-    >
-      {getText(props)}
-    </a>
+    <ErrorBoundary>
+      <span className="more-comments-throbber">
+        {props.isLoading ? (
+          <Throbber />
+        ) : false}
+      </span>
+      <a
+        className="more-comments-link"
+        href={props.entryUrl}
+        onClick={preventDefault(() => props.showMoreComments())}
+      >
+        {getText(props)}
+      </a>
+    </ErrorBoundary>
   </div>
 );
 

--- a/src/components/notifications.jsx
+++ b/src/components/notifications.jsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { connect } from "react-redux";
 import { Link } from "react-router";
+
 import { Throbber } from './throbber';
 import Linkify from "./linkify";
 import TimeDisplay from "./time-display";
 import PaginatedView from "./paginated-view";
+import ErrorBoundary from './error-boundary';
 
 
 const getAuthorName = ({ postAuthor, createdUser, group }) => {
@@ -133,40 +135,42 @@ const isFilterActive = (filterName, filter) => filter && filter.indexOf(filterNa
 
 const Notifications = (props) => (
   <div className="box notifications">
-    <div className="box-header-timeline">
-      Notifications
-      {props.isLoading && (
-        <span className="notifications-throbber">
-          <Throbber />
-        </span>
-      )}
-    </div>
-    <div className="filter">
-      <div>Show: </div>
-      <Link className={!props.location.query.filter ? "active" : ""} to={{ pathname: props.location.pathname, query: {} }}>Everything</Link>
-      <Link className={isFilterActive("mentions", props.location.query.filter) ? "active" : ""} to={{ pathname: props.location.pathname, query: { filter: "mentions" } }}>Mentions</Link>
-      <Link className={isFilterActive("subscriptions", props.location.query.filter) ? "active" : ""} to={{ pathname: props.location.pathname, query: { filter: "subscriptions" } }}>Subscriptions</Link>
-      <Link className={isFilterActive("groups", props.location.query.filter) ? "active" : ""} to={{ pathname: props.location.pathname, query: { filter: "groups" } }}>Groups</Link>
-      <Link className={isFilterActive("directs", props.location.query.filter) ? "active" : ""} to={{ pathname: props.location.pathname, query: { filter: "directs" } }}>Direct messages</Link>
-      <Link className={isFilterActive("bans", props.location.query.filter) ? "active" : ""} to={{ pathname: props.location.pathname, query: { filter: "bans" } }}>Bans</Link>
-    </div>
-    {props.authenticated
-      ? (
-        <PaginatedView routes={props.routes} location={props.location}>
-          <div className="notification-list">
-            {props.loading
-              ? "Loading"
-              : props.events.length > 0 ? props.events.map(Notification) : "No notifications yet"
-            }
+    <ErrorBoundary>
+      <div className="box-header-timeline">
+        Notifications
+        {props.isLoading && (
+          <span className="notifications-throbber">
+            <Throbber />
+          </span>
+        )}
+      </div>
+      <div className="filter">
+        <div>Show: </div>
+        <Link className={!props.location.query.filter ? "active" : ""} to={{ pathname: props.location.pathname, query: {} }}>Everything</Link>
+        <Link className={isFilterActive("mentions", props.location.query.filter) ? "active" : ""} to={{ pathname: props.location.pathname, query: { filter: "mentions" } }}>Mentions</Link>
+        <Link className={isFilterActive("subscriptions", props.location.query.filter) ? "active" : ""} to={{ pathname: props.location.pathname, query: { filter: "subscriptions" } }}>Subscriptions</Link>
+        <Link className={isFilterActive("groups", props.location.query.filter) ? "active" : ""} to={{ pathname: props.location.pathname, query: { filter: "groups" } }}>Groups</Link>
+        <Link className={isFilterActive("directs", props.location.query.filter) ? "active" : ""} to={{ pathname: props.location.pathname, query: { filter: "directs" } }}>Direct messages</Link>
+        <Link className={isFilterActive("bans", props.location.query.filter) ? "active" : ""} to={{ pathname: props.location.pathname, query: { filter: "bans" } }}>Bans</Link>
+      </div>
+      {props.authenticated
+        ? (
+          <PaginatedView routes={props.routes} location={props.location}>
+            <div className="notification-list">
+              {props.loading
+                ? "Loading"
+                : props.events.length > 0 ? props.events.map(Notification) : "No notifications yet"
+              }
+            </div>
+          </PaginatedView>
+        )
+        : (
+          <div className="alert alert-danger" role="alert">
+            You must <Link to="/signin">sign in</Link> or <Link to="/signup">sign up</Link> before visiting this page.
           </div>
-        </PaginatedView>
-      )
-      : (
-        <div className="alert alert-danger" role="alert">
-          You must <Link to="/signin">sign in</Link> or <Link to="/signup">sign up</Link> before visiting this page.
-        </div>
-      )
-    }
+        )
+      }
+    </ErrorBoundary>
   </div>
 );
 

--- a/src/components/paginated-view.jsx
+++ b/src/components/paginated-view.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { bindRouteActions } from '../redux/route-actions';
 import { getCurrentRouteName } from '../utils';
 import PaginationLinks from './pagination-links';
+import ErrorBoundary from './error-boundary';
 
 
 const PaginatedView = (props) => {
@@ -12,25 +13,27 @@ const PaginatedView = (props) => {
 
   return (
     <div className="box-body">
-      {props.showSummaryHeader ? (
-        <h4 className="user-subheader">
-          {props.boxHeader.title}
-          <div className="user-subheader-sidelinks">
-            {'View best of: '}
-            {summaryDays === 1 ? <b>day</b> : <Link to={`/${props.viewUser.username}/summary/1`}>day</Link>}
-            {' - '}
-            {summaryDays === 7 ? <b>week</b> : <Link to={`/${props.viewUser.username}/summary/7`}>week</Link>}
-            {' - '}
-            {summaryDays === 30 ? <b>month</b> : <Link to={`/${props.viewUser.username}/summary/30`}>month</Link>}
-          </div>
-        </h4>
-      ) : props.offset > 0
-        ? props.children
-          ? <PaginationLinks location={props.location} offset={props.offset} isLastPage={props.isLastPage} />
-          : false
-        : props.firstPageHead}
-      {props.children}
-      <PaginationLinks location={props.location} offset={props.offset} isLastPage={props.isLastPage} />
+      <ErrorBoundary>
+        {props.showSummaryHeader ? (
+          <h4 className="user-subheader">
+            {props.boxHeader.title}
+            <div className="user-subheader-sidelinks">
+              {'View best of: '}
+              {summaryDays === 1 ? <b>day</b> : <Link to={`/${props.viewUser.username}/summary/1`}>day</Link>}
+              {' - '}
+              {summaryDays === 7 ? <b>week</b> : <Link to={`/${props.viewUser.username}/summary/7`}>week</Link>}
+              {' - '}
+              {summaryDays === 30 ? <b>month</b> : <Link to={`/${props.viewUser.username}/summary/30`}>month</Link>}
+            </div>
+          </h4>
+        ) : props.offset > 0
+          ? props.children
+            ? <PaginationLinks location={props.location} offset={props.offset} isLastPage={props.isLastPage} />
+            : false
+          : props.firstPageHead}
+        {props.children}
+        <PaginationLinks location={props.location} offset={props.offset} isLastPage={props.isLastPage} />
+      </ErrorBoundary>
     </div>
   );
 };

--- a/src/components/plain-feed.jsx
+++ b/src/components/plain-feed.jsx
@@ -5,23 +5,26 @@ import { joinPostData, postActions } from './select-utils';
 import Feed from './feed';
 import PaginatedView from './paginated-view';
 import FeedOptionsSwitch from './feed-options-switch';
+import ErrorBoundary from './error-boundary';
 
 
 const FeedHandler = (props) => (
   <div className="box">
-    <div className="box-header-timeline">
-      {props.boxHeader}
-      {props.route.name === 'everything' && (
-        <div className="pull-right">
-          <FeedOptionsSwitch />
-        </div>
-      )}
-    </div>
-    <PaginatedView {...props}>
-      {props.visibleEntries.length === 0 && 'No posts here'}
-      <Feed {...props} />
-    </PaginatedView>
-    <div className="box-footer" />
+    <ErrorBoundary>
+      <div className="box-header-timeline">
+        {props.boxHeader}
+        {props.route.name === 'everything' && (
+          <div className="pull-right">
+            <FeedOptionsSwitch />
+          </div>
+        )}
+      </div>
+      <PaginatedView {...props}>
+        {props.visibleEntries.length === 0 && 'No posts here'}
+        <Feed {...props} />
+      </PaginatedView>
+      <div className="box-footer" />
+    </ErrorBoundary>
   </div>
 );
 

--- a/src/components/post-attachments.jsx
+++ b/src/components/post-attachments.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ImageAttachmentsContainer from './post-attachment-image-container';
 import AudioAttachment from './post-attachment-audio';
 import GeneralAttachment from './post-attachment-general';
+import ErrorBoundary from './error-boundary';
 
 
 export default (props) => {
@@ -51,9 +52,11 @@ export default (props) => {
 
   return (attachments.length > 0 ? (
     <div className="attachments">
-      {imageAttachmentsContainer}
-      {audioAttachmentsContainer}
-      {generalAttachmentsContainer}
+      <ErrorBoundary>
+        {imageAttachmentsContainer}
+        {audioAttachmentsContainer}
+        {generalAttachmentsContainer}
+      </ErrorBoundary>
     </div>
   ) : false);
 };

--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -8,6 +8,7 @@ import { faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { preventDefault } from '../utils';
 import PostComment from './post-comment';
 import MoreCommentsWrapper from './more-comments-wrapper';
+import ErrorBoundary from './error-boundary';
 import { Icon } from './fontawesome-icons';
 import { faCommentPlus } from './fontawesome-custom-icons';
 
@@ -227,10 +228,12 @@ export default class PostComments extends React.Component {
 
     return (
       <div className="comments" ref={this.registerRootEl}>
-        {first ? this.renderComment(first) : false}
-        {this.renderMiddle()}
-        {last ? this.renderComment(last) : false}
-        {this.renderAddComment()}
+        <ErrorBoundary>
+          {first ? this.renderComment(first) : false}
+          {this.renderMiddle()}
+          {last ? this.renderComment(last) : false}
+          {this.renderAddComment()}
+        </ErrorBoundary>
       </div>
     );
   }

--- a/src/components/post-likes.jsx
+++ b/src/components/post-likes.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { faHeart } from '@fortawesome/free-solid-svg-icons';
 import { preventDefault } from '../utils';
 import UserName from './user-name';
+import ErrorBoundary from './error-boundary';
 import { Icon } from './fontawesome-icons';
 
 
@@ -44,8 +45,10 @@ export default ({ likes, showMoreLikes, post }) => {
 
   return (
     <div className="post-likes">
-      <Icon icon={faHeart} className="icon" />
-      <ul className="post-likes-list">{renderedLikes}</ul>
+      <ErrorBoundary>
+        <Icon icon={faHeart} className="icon" />
+        <ul className="post-likes-list">{renderedLikes}</ul>
+      </ErrorBoundary>
     </div>
   );
 };

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -25,6 +25,7 @@ import PostMoreMenu from './post-more-menu';
 import TimeDisplay from './time-display';
 import LinkPreview from './link-preview/preview';
 import SendTo from './send-to';
+import ErrorBoundary from './error-boundary';
 import { destinationsPrivacy } from './select-utils';
 import { makeJpegIfNeeded } from './create-post';
 import { Icon } from './fontawesome-icons';
@@ -407,162 +408,164 @@ class Post extends React.Component {
       </div>
     ) : (
       <div className={postClass} data-author={props.createdBy.username}>
-        <Expandable
-          expanded={props.isEditing || props.isSinglePost || props.readMoreStyle === READMORE_STYLE_COMPACT}
-          config={postReadmoreConfig}
-        >
-          <div className="post-userpic">
-            <Link to={`/${props.createdBy.username}`}>
-              <img className="post-userpic-img" src={profilePicture} width={profilePictureSize} height={profilePictureSize} />
-            </Link>
-          </div>
-          <div className="post-body">
-            {props.isEditing ? (
-              <div>
-                <SendTo
-                  ref={this.registerSelectFeeds}
-                  defaultFeed={props.recipients.map((r) => r.username)}
-                  isDirects={props.isDirect}
-                  isEditing={true}
-                  disableAutoFocus={true}
-                  user={props.createdBy}
-                  onChange={this.onDestsChange}
-                />
-                <div className="post-privacy-warning">{this.state.privacyWarning}</div>
-              </div>
-            ) : (
-              <div className="post-header">
-                <UserName className="post-author" user={props.createdBy} />
-                {recipients.length > 0 ? ' to ' : false}
-                {recipients}
-                {this.props.isInHomeFeed ? <PostVia post={this.props} me={this.props.user} /> : false}
-              </div>
-            )}
-            {props.isEditing ? (
-              <div className="post-editor">
-                <Dropzone
-                  onInit={this.handleDropzoneInit}
-                  addAttachmentResponse={this.handleAttachmentResponse}
-                  onSending={this.attLoadingStarted}
-                  onQueueComplete={this.attLoadingCompleted}
-                />
-
+        <ErrorBoundary>
+          <Expandable
+            expanded={props.isEditing || props.isSinglePost || props.readMoreStyle === READMORE_STYLE_COMPACT}
+            config={postReadmoreConfig}
+          >
+            <div className="post-userpic">
+              <Link to={`/${props.createdBy.username}`}>
+                <img className="post-userpic-img" src={profilePicture} width={profilePictureSize} height={profilePictureSize} />
+              </Link>
+            </div>
+            <div className="post-body">
+              {props.isEditing ? (
                 <div>
-                  <Textarea
-                    className="post-textarea"
-                    value={this.state.editingText}
-                    onKeyDown={this.handleKeyDown}
-                    onChange={this.handlePostTextChange}
-                    onPaste={this.handlePaste}
-                    autoFocus={true}
-                    minRows={2}
-                    maxRows={10}
-                    maxLength="1500"
+                  <SendTo
+                    ref={this.registerSelectFeeds}
+                    defaultFeed={props.recipients.map((r) => r.username)}
+                    isDirects={props.isDirect}
+                    isEditing={true}
+                    disableAutoFocus={true}
+                    user={props.createdBy}
+                    onChange={this.onDestsChange}
+                  />
+                  <div className="post-privacy-warning">{this.state.privacyWarning}</div>
+                </div>
+              ) : (
+                <div className="post-header">
+                  <UserName className="post-author" user={props.createdBy} />
+                  {recipients.length > 0 ? ' to ' : false}
+                  {recipients}
+                  {this.props.isInHomeFeed ? <PostVia post={this.props} me={this.props.user} /> : false}
+                </div>
+              )}
+              {props.isEditing ? (
+                <div className="post-editor">
+                  <Dropzone
+                    onInit={this.handleDropzoneInit}
+                    addAttachmentResponse={this.handleAttachmentResponse}
+                    onSending={this.attLoadingStarted}
+                    onQueueComplete={this.attLoadingCompleted}
+                  />
+
+                  <div>
+                    <Textarea
+                      className="post-textarea"
+                      value={this.state.editingText}
+                      onKeyDown={this.handleKeyDown}
+                      onChange={this.handlePostTextChange}
+                      onPaste={this.handlePaste}
+                      autoFocus={true}
+                      minRows={2}
+                      maxRows={10}
+                      maxLength="1500"
+                    />
+                  </div>
+
+                  <div className="post-edit-options">
+                    <span className="post-edit-attachments dropzone-trigger" disabled={this.state.dropzoneDisabled}>
+                      <Icon icon={faCloudUploadAlt} className="upload-icon" />
+                      {' '}
+                      Add photos or files
+                    </span>
+                  </div>
+
+                  <div className="post-edit-actions">
+                    {props.isSaving ? (
+                      <span className="post-edit-throbber">
+                        <Throbber />
+                      </span>
+                    ) : false}
+                    <a className="post-cancel" onClick={this.cancelEditingPost}>Cancel</a>
+                    <button
+                      className="btn btn-default btn-xs"
+                      onClick={this.saveEditingPost}
+                      disabled={!this.canSubmitForm()}
+                    >
+                      Update
+                    </button>
+                  </div>
+                  {this.state.dropzoneDisabled && (
+                    <div className="alert alert-warning">
+                      The maximum number of attached files ({config.attachments.maxCount}) has been reached
+                    </div>
+                  )}
+                  {props.isError ? <div className="post-error alert alert-danger">{props.errorString}</div> : false}
+                </div>
+              ) : (
+                <div className="post-text">
+                  <PieceOfText
+                    text={props.body}
+                    readMoreStyle={props.readMoreStyle}
+                    highlightTerms={props.highlightTerms}
                   />
                 </div>
-
-                <div className="post-edit-options">
-                  <span className="post-edit-attachments dropzone-trigger" disabled={this.state.dropzoneDisabled}>
-                    <Icon icon={faCloudUploadAlt} className="upload-icon" />
-                    {' '}
-                    Add photos or files
-                  </span>
-                </div>
-
-                <div className="post-edit-actions">
-                  {props.isSaving ? (
-                    <span className="post-edit-throbber">
-                      <Throbber />
-                    </span>
-                  ) : false}
-                  <a className="post-cancel" onClick={this.cancelEditingPost}>Cancel</a>
-                  <button
-                    className="btn btn-default btn-xs"
-                    onClick={this.saveEditingPost}
-                    disabled={!this.canSubmitForm()}
-                  >
-                    Update
-                  </button>
-                </div>
-                {this.state.dropzoneDisabled && (
-                  <div className="alert alert-warning">
-                    The maximum number of attached files ({config.attachments.maxCount}) has been reached
-                  </div>
-                )}
-                {props.isError ? <div className="post-error alert alert-danger">{props.errorString}</div> : false}
-              </div>
-            ) : (
-              <div className="post-text">
-                <PieceOfText
-                  text={props.body}
-                  readMoreStyle={props.readMoreStyle}
-                  highlightTerms={props.highlightTerms}
-                />
-              </div>
-            )}
-          </div>
-        </Expandable>
-
-        <div className="post-body">
-          <PostAttachments
-            postId={props.id}
-            attachments={this.attachments}
-            isEditing={props.isEditing}
-            isSinglePost={props.isSinglePost}
-            removeAttachment={this.removeAttachment}
-            reorderImageAttachments={this.reorderImageAttachments}
-          />
-
-          {noImageAttachments && linkToEmbed ? (
-            <div className="link-preview"><LinkPreview url={linkToEmbed} allowEmbedly={props.allowLinksPreview} /></div>
-          ) : false}
-
-          <div className="dropzone-previews" />
-
-          <div className="post-footer">
-            <span className="post-timestamps-toggle" onClick={this.toggleTimestamps}>
-              {isPrivate ? (
-                <Icon icon={faLock} className="post-lock-icon post-private-icon" title="This entry is private" />
-              ) : isProtected ? (
-                <Icon icon={faUserFriends} className="post-lock-icon post-protected-icon" title="This entry is only visible to FreeFeed users" />
-              ) : (
-                <Icon icon={faGlobeAmericas} className="post-lock-icon post-public-icon" title="This entry is public" />
               )}
-            </span>
-            {props.isDirect && <Icon icon={faAngleDoubleRight} className="post-direct-icon" title="This is a direct message" />}
-            <Link to={canonicalPostURI} className="post-timestamp">
-              <TimeDisplay timeStamp={+props.createdAt} showAbsTime={this.state.showTimestamps} />
-            </Link>
-            {commentLink}
-            {likeLink}
-            {saveLink}
-            {hideLink}
-            {moreLink}
+            </div>
+          </Expandable>
+
+          <div className="post-body">
+            <PostAttachments
+              postId={props.id}
+              attachments={this.attachments}
+              isEditing={props.isEditing}
+              isSinglePost={props.isSinglePost}
+              removeAttachment={this.removeAttachment}
+              reorderImageAttachments={this.reorderImageAttachments}
+            />
+
+            {noImageAttachments && linkToEmbed ? (
+              <div className="link-preview"><LinkPreview url={linkToEmbed} allowEmbedly={props.allowLinksPreview} /></div>
+            ) : false}
+
+            <div className="dropzone-previews" />
+
+            <div className="post-footer">
+              <span className="post-timestamps-toggle" onClick={this.toggleTimestamps}>
+                {isPrivate ? (
+                  <Icon icon={faLock} className="post-lock-icon post-private-icon" title="This entry is private" />
+                ) : isProtected ? (
+                  <Icon icon={faUserFriends} className="post-lock-icon post-protected-icon" title="This entry is only visible to FreeFeed users" />
+                ) : (
+                  <Icon icon={faGlobeAmericas} className="post-lock-icon post-public-icon" title="This entry is public" />
+                )}
+              </span>
+              {props.isDirect && <Icon icon={faAngleDoubleRight} className="post-direct-icon" title="This is a direct message" />}
+              <Link to={canonicalPostURI} className="post-timestamp">
+                <TimeDisplay timeStamp={+props.createdAt} showAbsTime={this.state.showTimestamps} />
+              </Link>
+              {commentLink}
+              {likeLink}
+              {saveLink}
+              {hideLink}
+              {moreLink}
+            </div>
+
+            <PostLikes
+              post={props}
+              likes={props.usersLikedPost}
+              showMoreLikes={props.showMoreLikes}
+            />
+
+            <PostComments
+              post={props}
+              comments={props.comments}
+              creatingNewComment={props.isCommenting}
+              updateCommentingText={props.updateCommentingText}
+              addComment={props.addComment}
+              toggleCommenting={props.toggleCommenting}
+              showMoreComments={props.showMoreComments}
+              commentEdit={props.commentEdit}
+              readMoreStyle={props.readMoreStyle}
+              entryUrl={canonicalPostURI}
+              highlightTerms={props.highlightTerms}
+              isSinglePost={props.isSinglePost}
+              showTimestamps={this.state.showTimestamps}
+              user={props.user}
+            />
           </div>
-
-          <PostLikes
-            post={props}
-            likes={props.usersLikedPost}
-            showMoreLikes={props.showMoreLikes}
-          />
-
-          <PostComments
-            post={props}
-            comments={props.comments}
-            creatingNewComment={props.isCommenting}
-            updateCommentingText={props.updateCommentingText}
-            addComment={props.addComment}
-            toggleCommenting={props.toggleCommenting}
-            showMoreComments={props.showMoreComments}
-            commentEdit={props.commentEdit}
-            readMoreStyle={props.readMoreStyle}
-            entryUrl={canonicalPostURI}
-            highlightTerms={props.highlightTerms}
-            isSinglePost={props.isSinglePost}
-            showTimestamps={this.state.showTimestamps}
-            user={props.user}
-          />
-        </div>
+        </ErrorBoundary>
       </div>
     ));
   }

--- a/src/components/sidebar.jsx
+++ b/src/components/sidebar.jsx
@@ -8,6 +8,7 @@ import { setUserColorScheme } from '../redux/action-creators';
 import { SCHEME_DARK, SCHEME_SYSTEM, SCHEME_LIGHT, systemColorSchemeSupported } from '../services/appearance';
 import UserName from './user-name';
 import RecentGroups from './recent-groups';
+import ErrorBoundary from './error-boundary';
 import { InvisibleSelect } from './invisibe-select';
 
 
@@ -263,15 +264,17 @@ const SideBarAppearance = connect(
 const SideBar = ({ user, signOut, recentGroups }) => {
   return (
     <div className="col-md-3 sidebar">
-      <LoggedInBlock user={user} signOut={signOut} />
-      <SideBarFriends user={user} />
-      <SideBarArchive user={user} />
-      <SideBarFreeFeed />
-      <SideBarGroups recentGroups={recentGroups} />
-      <SideBarBookmarklet />
-      <SideBarMemories />
-      <SideBarCoinJar />
-      <SideBarAppearance />
+      <ErrorBoundary>
+        <LoggedInBlock user={user} signOut={signOut} />
+        <SideBarFriends user={user} />
+        <SideBarArchive user={user} />
+        <SideBarFreeFeed />
+        <SideBarGroups recentGroups={recentGroups} />
+        <SideBarBookmarklet />
+        <SideBarMemories />
+        <SideBarCoinJar />
+        <SideBarAppearance />
+      </ErrorBoundary>
     </div>
   );
 };

--- a/src/components/signin.jsx
+++ b/src/components/signin.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { signInChange, signIn, signInEmpty } from '../redux/action-creators';
 import { preventDefault } from '../utils';
 import LoaderContainer from './loader-container';
+import ErrorBoundary from './error-boundary';
 
 
 function mapStateToProps(state) {
@@ -42,59 +43,61 @@ class Signin extends React.PureComponent {
 
     return (
       <div className="box">
-        <div className="box-header-timeline">
-          Hello
-        </div>
-        <div className="box-body">
-          <div className="col-md-12">
-            <h2 className="p-signin-header">Sign in</h2>
-            {props.error && (
-              <div className="alert alert-danger p-signin-error" role="alert">
-                <span id="error-message">{props.error}</span>
-              </div>
-            )}
-            {props.requireAuth && (
-              <div className="alert alert-danger p-signin-error" role="alert">
-                <span id="error-message">Please sign in or <Link to="/signup">sign up</Link> before visiting this page.</span>
-              </div>
-            )}
-            <div className="row">
-              <div className="col-md-6">
-                <LoaderContainer loading={props.loading}>
-                  <form onSubmit={this.handleFormSubmit} className="p-signin">
-                    <div className="form-group">
-                      <label htmlFor="username">Username or e-mail address</label>
-                      <input
-                        id="username"
-                        name="username"
-                        className="ember-view ember-text-field form-control"
-                        type="text"
-                        onChange={this.handleUsernameChange}
-                        autoFocus="true"
-                      />
-                    </div>
-                    <div className="form-group">
-                      <label htmlFor="password">Password</label>
-                      <input
-                        id="password"
-                        name="password"
-                        className="ember-view ember-text-field form-control"
-                        type="password"
-                        onChange={this.handlePasswordChange}
-                      />
-                    </div>
-                    <div className="form-group">
-                      <button className="btn btn-default p-singin-action" type="submit">Sign in</button>
-                    </div>
-                  </form>
-                </LoaderContainer>
-                <p>New to freefeed? <Link to="/signup">Create an account »</Link></p>
-                <p>Forgot your password? <Link to="/restore">Request password reset instructions »</Link></p>
+        <ErrorBoundary>
+          <div className="box-header-timeline">
+            Hello
+          </div>
+          <div className="box-body">
+            <div className="col-md-12">
+              <h2 className="p-signin-header">Sign in</h2>
+              {props.error && (
+                <div className="alert alert-danger p-signin-error" role="alert">
+                  <span id="error-message">{props.error}</span>
+                </div>
+              )}
+              {props.requireAuth && (
+                <div className="alert alert-danger p-signin-error" role="alert">
+                  <span id="error-message">Please sign in or <Link to="/signup">sign up</Link> before visiting this page.</span>
+                </div>
+              )}
+              <div className="row">
+                <div className="col-md-6">
+                  <LoaderContainer loading={props.loading}>
+                    <form onSubmit={this.handleFormSubmit} className="p-signin">
+                      <div className="form-group">
+                        <label htmlFor="username">Username or e-mail address</label>
+                        <input
+                          id="username"
+                          name="username"
+                          className="ember-view ember-text-field form-control"
+                          type="text"
+                          onChange={this.handleUsernameChange}
+                          autoFocus="true"
+                        />
+                      </div>
+                      <div className="form-group">
+                        <label htmlFor="password">Password</label>
+                        <input
+                          id="password"
+                          name="password"
+                          className="ember-view ember-text-field form-control"
+                          type="password"
+                          onChange={this.handlePasswordChange}
+                        />
+                      </div>
+                      <div className="form-group">
+                        <button className="btn btn-default p-singin-action" type="submit">Sign in</button>
+                      </div>
+                    </form>
+                  </LoaderContainer>
+                  <p>New to freefeed? <Link to="/signup">Create an account »</Link></p>
+                  <p>Forgot your password? <Link to="/restore">Request password reset instructions »</Link></p>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div className="box-footer" />
+          <div className="box-footer" />
+        </ErrorBoundary>
       </div>
     );
   }

--- a/src/components/signup-form.jsx
+++ b/src/components/signup-form.jsx
@@ -7,6 +7,7 @@ import config from '../config';
 import { signUpChange, signUp, signUpEmpty } from '../redux/action-creators';
 import { preventDefault } from '../utils';
 import LoaderContainer from './loader-container';
+import ErrorBoundary from './error-boundary';
 
 
 const captchaConfig = config.captcha;
@@ -127,62 +128,64 @@ class Signup extends React.Component {
     const { loading, invitationId, lang = 'en' } = this.props;
 
     return (
-      <LoaderContainer loading={loading}>
-        <form onSubmit={preventDefault(() => signUpFunc(this.state, this.props))} className="p-signin">
-          <div className="form-group">
-            <label htmlFor="username">{LABELS[lang].username}</label>
-            <input
-              id="username"
-              className="ember-view ember-text-field form-control"
-              type="text"
-              onChange={this.handleUsernameChange}
-            />
-          </div>
-
-          <div className="form-group">
-            <label htmlFor="email">{LABELS[lang].email}</label>
-            <input
-              id="email"
-              className="ember-view ember-text-field form-control"
-              type="text"
-              onChange={this.handleEmailChange}
-            />
-          </div>
-
-          <div className="form-group">
-            <label htmlFor="password">{LABELS[lang].password}</label>
-            <input
-              id="password"
-              className="ember-view ember-text-field form-control"
-              type="password"
-              onChange={this.handlePasswordChange}
-            />
-          </div>
-
-          {captchaConfig.siteKey &&
+      <ErrorBoundary>
+        <LoaderContainer loading={loading}>
+          <form onSubmit={preventDefault(() => signUpFunc(this.state, this.props))} className="p-signin">
             <div className="form-group">
-              <Recaptcha
-                sitekey={captchaConfig.siteKey}
-                theme="light" type="image"
-                onChange={this.handleRecaptchaChange}
-                onExpired={this.handleRecaptchaExpiration}
+              <label htmlFor="username">{LABELS[lang].username}</label>
+              <input
+                id="username"
+                className="ember-view ember-text-field form-control"
+                type="text"
+                onChange={this.handleUsernameChange}
               />
             </div>
-          }
 
-          {invitationId &&
-            <div className="form-group checkbox">
-              <label>
-                <input type="checkbox" name="subscribe-groups" value="0" checked={this.state.subscribe} onChange={this.toggleSubscribe} />
-                {LABELS[lang].subscribe}
-              </label>
-            </div>}
+            <div className="form-group">
+              <label htmlFor="email">{LABELS[lang].email}</label>
+              <input
+                id="email"
+                className="ember-view ember-text-field form-control"
+                type="text"
+                onChange={this.handleEmailChange}
+              />
+            </div>
 
-          <div className="form-group">
-            <button className="btn btn-default p-signin-action" type="submit">{LABELS[lang].signup}</button>
-          </div>
-        </form>
-      </LoaderContainer>
+            <div className="form-group">
+              <label htmlFor="password">{LABELS[lang].password}</label>
+              <input
+                id="password"
+                className="ember-view ember-text-field form-control"
+                type="password"
+                onChange={this.handlePasswordChange}
+              />
+            </div>
+
+            {captchaConfig.siteKey &&
+              <div className="form-group">
+                <Recaptcha
+                  sitekey={captchaConfig.siteKey}
+                  theme="light" type="image"
+                  onChange={this.handleRecaptchaChange}
+                  onExpired={this.handleRecaptchaExpiration}
+                />
+              </div>
+            }
+
+            {invitationId &&
+              <div className="form-group checkbox">
+                <label>
+                  <input type="checkbox" name="subscribe-groups" value="0" checked={this.state.subscribe} onChange={this.toggleSubscribe} />
+                  {LABELS[lang].subscribe}
+                </label>
+              </div>}
+
+            <div className="form-group">
+              <button className="btn btn-default p-signin-action" type="submit">{LABELS[lang].signup}</button>
+            </div>
+          </form>
+        </LoaderContainer>
+      </ErrorBoundary>
     );
   }
 }

--- a/src/components/user-card.jsx
+++ b/src/components/user-card.jsx
@@ -7,6 +7,7 @@ import { getUserInfo, updateUserPreferences } from '../redux/action-creators';
 import { Throbber } from './throbber';
 import UserFeedStatus from './user-feed-status';
 import UserRelationshipStatus from './user-relationships-status';
+import ErrorBoundary from './error-boundary';
 import { userActions, canAcceptDirects } from './select-utils';
 
 
@@ -88,67 +89,69 @@ class UserCard extends React.Component {
 
     return (
       <div className="user-card" style={style}>
-        <div className="user-card-info">
-          <Link to={`/${props.user.username}`} className="userpic">
-            <img src={props.user.profilePictureLargeUrl} width="75" height="75" />
-          </Link>
+        <ErrorBoundary>
+          <div className="user-card-info">
+            <Link to={`/${props.user.username}`} className="userpic">
+              <img src={props.user.profilePictureLargeUrl} width="75" height="75" />
+            </Link>
 
-          <div className="names">
-            <Link to={`/${props.user.username}`} className="display-name" dir="auto">{props.user.screenName}</Link><br />
+            <div className="names">
+              <Link to={`/${props.user.username}`} className="display-name" dir="auto">{props.user.screenName}</Link><br />
 
-            {props.user.screenName !== props.user.username ? (
-              <span className="username">@{props.user.username}</span>
-            ) : false}
-          </div>
-
-          {!props.isItMe && (
-            <div className="feed-status">
-              <UserFeedStatus {...props.user} />
+              {props.user.screenName !== props.user.username ? (
+                <span className="username">@{props.user.username}</span>
+              ) : false}
             </div>
-          )}
-          <div className="relationship-status">
-            {props.isItMe ? 'It\'s you!' : <UserRelationshipStatus type={props.user.type} {...props} />}
-          </div>
-        </div>
 
-        {props.blocked ? (
-          <div className="user-card-actions">
-            <span>Blocked user - </span>
-            <a onClick={this.handleUnblockClick}>Un-block</a>
-          </div>
-        ) : !props.isItMe ? (
-          <div className="user-card-actions">
-            {props.canAcceptDirects ? (
-              <span>
-                <Link to={`/filter/direct?to=${props.user.username}`}>Direct message</Link>
-                <span> - </span>
-              </span>
-            ) : false
-            }
-            {props.user.isPrivate === '1' && !props.subscribed ? (
-              props.hasRequestBeenSent ? (
-                <span>Subscription request sent</span>
-              ) : (
-                <a onClick={this.handleRequestSubscriptionClick}>Request a subscription</a>
-              )
-            ) : (
-              props.subscribed ? (
-                <a onClick={this.handleUnsubscribeClick}>Unsubscribe</a>
-              ) : (
-                <a onClick={this.handleSubscribeClick}>Subscribe</a>
-              )
+            {!props.isItMe && (
+              <div className="feed-status">
+                <UserFeedStatus {...props.user} />
+              </div>
             )}
-
-            {props.user.type !== 'group' && !props.subscribed ? (
-              <span> - <a onClick={this.handleBlockClick}>Block</a></span>
-            ) : props.amIGroupAdmin ? (
-              <span> - <Link to={`/${props.user.username}/settings`}>Settings</Link></span>
-            ) : false}
-
-            <span> - <a onClick={this.handleShowOrHideClick}>{props.hidden ? 'Show' : 'Hide'} posts</a></span>
-
+            <div className="relationship-status">
+              {props.isItMe ? 'It\'s you!' : <UserRelationshipStatus type={props.user.type} {...props} />}
+            </div>
           </div>
-        ) : false}
+
+          {props.blocked ? (
+            <div className="user-card-actions">
+              <span>Blocked user - </span>
+              <a onClick={this.handleUnblockClick}>Un-block</a>
+            </div>
+          ) : !props.isItMe ? (
+            <div className="user-card-actions">
+              {props.canAcceptDirects ? (
+                <span>
+                  <Link to={`/filter/direct?to=${props.user.username}`}>Direct message</Link>
+                  <span> - </span>
+                </span>
+              ) : false
+              }
+              {props.user.isPrivate === '1' && !props.subscribed ? (
+                props.hasRequestBeenSent ? (
+                  <span>Subscription request sent</span>
+                ) : (
+                  <a onClick={this.handleRequestSubscriptionClick}>Request a subscription</a>
+                )
+              ) : (
+                props.subscribed ? (
+                  <a onClick={this.handleUnsubscribeClick}>Unsubscribe</a>
+                ) : (
+                  <a onClick={this.handleSubscribeClick}>Subscribe</a>
+                )
+              )}
+
+              {props.user.type !== 'group' && !props.subscribed ? (
+                <span> - <a onClick={this.handleBlockClick}>Block</a></span>
+              ) : props.amIGroupAdmin ? (
+                <span> - <Link to={`/${props.user.username}/settings`}>Settings</Link></span>
+              ) : false}
+
+              <span> - <a onClick={this.handleShowOrHideClick}>{props.hidden ? 'Show' : 'Hide'} posts</a></span>
+
+            </div>
+          ) : false}
+        </ErrorBoundary>
       </div>);
   }
 }

--- a/src/components/user-name.jsx
+++ b/src/components/user-name.jsx
@@ -6,6 +6,7 @@ import { Portal } from 'react-portal';
 
 import * as FrontendPrefsOptions from '../utils/frontend-preferences-options';
 import UserCard from './user-card';
+import ErrorBoundary from './error-boundary';
 
 
 const DisplayOption = ({ user, me, preferences }) => {
@@ -84,33 +85,35 @@ class UserName extends React.Component {
         onMouseEnter={this.enterUserName}
         onMouseLeave={this.leaveUserName}
       >
+        <ErrorBoundary>
 
-        <Link to={`/${this.props.user.username}`} className={this.props.className}>
-          {this.props.children ? (
-            <span dir="ltr">{this.props.children}</span>
-          ) : (
-            <DisplayOption
-              user={this.props.user}
-              me={this.props.me}
-              preferences={this.props.frontendPreferences.displayNames}
-            />
-          )}
-        </Link>
-
-        {this.state.isCardOpen ? (
-          <Portal isOpened={true}>
-            <div
-              onMouseEnter={this.enterUserName}
-              onMouseLeave={this.leaveUserName}
-            >
-              <UserCard
-                username={this.props.user.username}
-                top={bottom}
-                left={left}
+          <Link to={`/${this.props.user.username}`} className={this.props.className}>
+            {this.props.children ? (
+              <span dir="ltr">{this.props.children}</span>
+            ) : (
+              <DisplayOption
+                user={this.props.user}
+                me={this.props.me}
+                preferences={this.props.frontendPreferences.displayNames}
               />
-            </div>
-          </Portal>
-        ) : false}
+            )}
+          </Link>
+
+          {this.state.isCardOpen ? (
+            <Portal isOpened={true}>
+              <div
+                onMouseEnter={this.enterUserName}
+                onMouseLeave={this.leaveUserName}
+              >
+                <UserCard
+                  username={this.props.user.username}
+                  top={bottom}
+                  left={left}
+                />
+              </div>
+            </Portal>
+          ) : false}
+        </ErrorBoundary>
       </span>
     );
   }

--- a/src/components/user-profile.jsx
+++ b/src/components/user-profile.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router';
 import { preventDefault, pluralForm } from '../utils';
 import CreatePost from './create-post';
 import PieceOfText from './piece-of-text';
+import ErrorBoundary from './error-boundary';
 import { Throbber } from './throbber';
 
 
@@ -55,133 +56,135 @@ export default class UserProfile extends React.Component {
 
     return (
       <div>
-        {!props.isLoading && !props.isUserFound ? (
-          <h2>404 Not Found</h2>
-        ) : (
-          <div className="profile">
-            <div className="row">
-              <div className="col-sm-9 col-xs-12">
-                <div className="avatar">
-                  <img src={props.profilePictureLargeUrl} width="75" height="75" />
+        <ErrorBoundary>
+          {!props.isLoading && !props.isUserFound ? (
+            <h2>404 Not Found</h2>
+          ) : (
+            <div className="profile">
+              <div className="row">
+                <div className="col-sm-9 col-xs-12">
+                  <div className="avatar">
+                    <img src={props.profilePictureLargeUrl} width="75" height="75" />
+                  </div>
+                  <div className="description">
+                    <div className="name" dir="auto">{props.screenName}</div>
+                    <PieceOfText text={props.description} isExpanded={true} />
+                  </div>
                 </div>
-                <div className="description">
-                  <div className="name" dir="auto">{props.screenName}</div>
-                  <PieceOfText text={props.description} isExpanded={true} />
+                {props.statistics && !props.blocked ? (
+                  <div className="col-sm-3 col-xs-12">
+                    <div className="profile-stats">
+                      {props.type !== 'group' && props.statistics.subscriptions >= 0 ? (
+                        <div className="profile-stats-item">
+                          {props.canISeeSubsList ? (
+                            <Link to={`/${props.username}/subscriptions`}>{pluralForm(props.statistics.subscriptions, 'subscription')}</Link>
+                          ) : (
+                            pluralForm(props.statistics.subscriptions, 'subscription')
+                          )}
+                        </div>
+                      ) : false}
+                      {' '}
+                      {props.statistics.subscribers >= 0 ? (
+                        <div className="profile-stats-item">
+                          {props.canISeeSubsList ? (
+                            <Link to={`/${props.username}/subscribers`}>{pluralForm(props.statistics.subscribers, 'subscriber')}</Link>
+                          ) : (
+                            pluralForm(props.statistics.subscribers, 'subscriber')
+                          )}
+                        </div>
+                      ) : false}
+                      {' '}
+                      {props.type !== 'group' && props.statistics.comments >= 0 ? (
+                        <div className="profile-stats-item">
+                          <Link to={`/${props.username}/comments`}>{pluralForm(props.statistics.comments, 'comment')}</Link>
+                        </div>
+                      ) : false}
+                      {' '}
+                      {props.type !== 'group' && props.statistics.likes >= 0 ? (
+                        <div className="profile-stats-item">
+                          <Link to={`/${props.username}/likes`}>{pluralForm(props.statistics.likes, 'like')}</Link>
+                        </div>
+                      ) : false}
+                    </div>
+                  </div>
+                ) : false}
+              </div>
+            </div>
+          )}
+
+          {props.authenticated && props.isUserFound && !props.isItMe && !props.blocked ? (
+            <div className="profile-controls">
+              <div className="row">
+                <div className="col-xs-7 col-sm-7 subscribe-controls">
+                  {props.isPrivate === '1' && !props.subscribed ? (
+                    props.hasRequestBeenSent ? (
+                      <span><b>{props.screenName}</b> has been sent your subscription request.</span>
+                    ) : (
+                      <a onClick={this.handleRequestSubscriptionClick}>Request a subscription</a>
+                    )
+                  ) : (
+                    props.subscribed ? (
+                      <a onClick={this.handleUnsubscribeClick}>Unsubscribe</a>
+                    ) : (
+                      <a onClick={this.handleSubscribeClick}>Subscribe</a>
+                    )
+                  )}
+
+                  {props.userView.isSubscribing ? (
+                    <span className="profile-controls-throbber">
+                      <Throbber />
+                    </span>
+                  ) : false}
+                </div>
+                <div className="col-xs-5 col-sm-5 text-right">
+                  <ul className="profile-actions">
+                    {props.canAcceptDirects ? (
+                      <li><Link to={`/filter/direct?to=${props.username}`}>Direct message</Link></li>
+                    ) : false}
+                    {props.type === 'group' && props.subscribed && (
+                      <li>
+                        <Link to={`/filter/direct?invite=${props.username}`}>Invite</Link>
+                      </li>
+                    )}
+                    {props.type !== 'group' && !props.subscribed ? (
+                      <li><a onClick={this.handleBlockUserClick}>Block this user</a></li>
+                    ) : props.amIGroupAdmin ? (
+                      <li><Link to={`/${props.username}/settings`}>Settings</Link></li>
+                    ) : false}
+                  </ul>
                 </div>
               </div>
-              {props.statistics && !props.blocked ? (
-                <div className="col-sm-3 col-xs-12">
-                  <div className="profile-stats">
-                    {props.type !== 'group' && props.statistics.subscriptions >= 0 ? (
-                      <div className="profile-stats-item">
-                        {props.canISeeSubsList ? (
-                          <Link to={`/${props.username}/subscriptions`}>{pluralForm(props.statistics.subscriptions, 'subscription')}</Link>
-                        ) : (
-                          pluralForm(props.statistics.subscriptions, 'subscription')
-                        )}
-                      </div>
-                    ) : false}
-                    {' '}
-                    {props.statistics.subscribers >= 0 ? (
-                      <div className="profile-stats-item">
-                        {props.canISeeSubsList ? (
-                          <Link to={`/${props.username}/subscribers`}>{pluralForm(props.statistics.subscribers, 'subscriber')}</Link>
-                        ) : (
-                          pluralForm(props.statistics.subscribers, 'subscriber')
-                        )}
-                      </div>
-                    ) : false}
-                    {' '}
-                    {props.type !== 'group' && props.statistics.comments >= 0 ? (
-                      <div className="profile-stats-item">
-                        <Link to={`/${props.username}/comments`}>{pluralForm(props.statistics.comments, 'comment')}</Link>
-                      </div>
-                    ) : false}
-                    {' '}
-                    {props.type !== 'group' && props.statistics.likes >= 0 ? (
-                      <div className="profile-stats-item">
-                        <Link to={`/${props.username}/likes`}>{pluralForm(props.statistics.likes, 'like')}</Link>
-                      </div>
-                    ) : false}
+              {this.state.isUnsubWarningDisplayed ? (
+                <div className="row">
+                  <div className="col-xs-12">
+                    <p className="group-warning">
+                      You are the Admin for this group. If you want to unsubscribe please drop administrative privileges first
+                      at <Link to={`/${props.username}/manage-subscribers`}>manage subscribers</Link> page
+                    </p>
                   </div>
                 </div>
               ) : false}
             </div>
-          </div>
-        )}
+          ) : false}
 
-        {props.authenticated && props.isUserFound && !props.isItMe && !props.blocked ? (
-          <div className="profile-controls">
-            <div className="row">
-              <div className="col-xs-7 col-sm-7 subscribe-controls">
-                {props.isPrivate === '1' && !props.subscribed ? (
-                  props.hasRequestBeenSent ? (
-                    <span><b>{props.screenName}</b> has been sent your subscription request.</span>
-                  ) : (
-                    <a onClick={this.handleRequestSubscriptionClick}>Request a subscription</a>
-                  )
-                ) : (
-                  props.subscribed ? (
-                    <a onClick={this.handleUnsubscribeClick}>Unsubscribe</a>
-                  ) : (
-                    <a onClick={this.handleSubscribeClick}>Subscribe</a>
-                  )
-                )}
+          {props.canIPostHere ? (
+            <CreatePost
+              createPostViewState={props.createPostViewState}
+              sendTo={props.sendTo}
+              user={props.user}
+              createPost={props.createPost}
+              resetPostCreateForm={props.resetPostCreateForm}
+              expandSendTo={props.expandSendTo}
+              addAttachmentResponse={props.addAttachmentResponse}
+            />
+          ) : false}
 
-                {props.userView.isSubscribing ? (
-                  <span className="profile-controls-throbber">
-                    <Throbber />
-                  </span>
-                ) : false}
-              </div>
-              <div className="col-xs-5 col-sm-5 text-right">
-                <ul className="profile-actions">
-                  {props.canAcceptDirects ? (
-                    <li><Link to={`/filter/direct?to=${props.username}`}>Direct message</Link></li>
-                  ) : false}
-                  {props.type === 'group' && props.subscribed && (
-                    <li>
-                      <Link to={`/filter/direct?invite=${props.username}`}>Invite</Link>
-                    </li>
-                  )}
-                  {props.type !== 'group' && !props.subscribed ? (
-                    <li><a onClick={this.handleBlockUserClick}>Block this user</a></li>
-                  ) : props.amIGroupAdmin ? (
-                    <li><Link to={`/${props.username}/settings`}>Settings</Link></li>
-                  ) : false}
-                </ul>
-              </div>
+          {!props.canIPostHere && props.isRestricted === '1' ? (
+            <div className="create-post create-post-restricted">
+              Only administrators can post to this group.
             </div>
-            {this.state.isUnsubWarningDisplayed ? (
-              <div className="row">
-                <div className="col-xs-12">
-                  <p className="group-warning">
-                    You are the Admin for this group. If you want to unsubscribe please drop administrative privileges first
-                    at <Link to={`/${props.username}/manage-subscribers`}>manage subscribers</Link> page
-                  </p>
-                </div>
-              </div>
-            ) : false}
-          </div>
-        ) : false}
-
-        {props.canIPostHere ? (
-          <CreatePost
-            createPostViewState={props.createPostViewState}
-            sendTo={props.sendTo}
-            user={props.user}
-            createPost={props.createPost}
-            resetPostCreateForm={props.resetPostCreateForm}
-            expandSendTo={props.expandSendTo}
-            addAttachmentResponse={props.addAttachmentResponse}
-          />
-        ) : false}
-
-        {!props.canIPostHere && props.isRestricted === '1' ? (
-          <div className="create-post create-post-restricted">
-            Only administrators can post to this group.
-          </div>
-        ) : false}
+          ) : false}
+        </ErrorBoundary>
       </div>
     );
   }

--- a/src/components/user-settings-form.jsx
+++ b/src/components/user-settings-form.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 import { preventDefault } from '../utils';
 import { Throbber } from './throbber';
+import ErrorBoundary from './error-boundary';
 
 
 const
@@ -75,90 +76,92 @@ export default class UserSettingsForm extends React.Component {
 
     return (
       <form onSubmit={preventDefault(this.updateUser)}>
-        <div className={className}>
-          {
-            this.props.screenName ? (
-              <span className="help-block displayName-input-hint">{this.props.screenName.length} of 25</span>
-            ) : false
-          }
-          <label htmlFor="displayName-input">Display name:</label>
-          <input id="displayName-input" className="form-control" name="screenName" type="text" defaultValue={this.props.user.screenName} onChange={this.updateSetting('screenName')} maxLength="100" />
-        </div>
-        <div className="form-group">
-          <label htmlFor="email-input">Email:</label>
-          <input id="email-input" className="form-control" name="email" type="text" defaultValue={this.props.user.email} onChange={this.updateSetting('email')} />
-        </div>
-        <div className="form-group">
-          <label htmlFor="description-textarea">Description:</label>
-          <textarea id="description-textarea" className="form-control" name="description" defaultValue={this.props.user.description} onChange={this.updateSetting('description')} maxLength="1500" />
-        </div>
-        <div className="form-group">
+        <ErrorBoundary>
+          <div className={className}>
+            {
+              this.props.screenName ? (
+                <span className="help-block displayName-input-hint">{this.props.screenName.length} of 25</span>
+              ) : false
+            }
+            <label htmlFor="displayName-input">Display name:</label>
+            <input id="displayName-input" className="form-control" name="screenName" type="text" defaultValue={this.props.user.screenName} onChange={this.updateSetting('screenName')} maxLength="100" />
+          </div>
+          <div className="form-group">
+            <label htmlFor="email-input">Email:</label>
+            <input id="email-input" className="form-control" name="email" type="text" defaultValue={this.props.user.email} onChange={this.updateSetting('email')} />
+          </div>
+          <div className="form-group">
+            <label htmlFor="description-textarea">Description:</label>
+            <textarea id="description-textarea" className="form-control" name="description" defaultValue={this.props.user.description} onChange={this.updateSetting('description')} maxLength="1500" />
+          </div>
+          <div className="form-group">
+            <p>
+            Your feed is:
+            </p>
+            <div className="radio">
+              <label>
+                <input
+                  type="radio"
+                  name="privacy"
+                  value={PUBLIC_FEED}
+                  checked={feedPrivacy === PUBLIC_FEED}
+                  onChange={this.updatePrivacy}
+                />
+                Public &mdash; anyone can see your posts
+              </label>
+            </div>
+            <div className="radio">
+              <label>
+                <input
+                  type="radio"
+                  name="privacy"
+                  value={PROTECTED_FEED}
+                  checked={feedPrivacy === PROTECTED_FEED}
+                  onChange={this.updatePrivacy}
+                />
+                Protected &mdash; anonymous users and search engines cannot see your posts
+              </label>
+            </div>
+            <div className="radio">
+              <label>
+                <input
+                  type="radio"
+                  name="privacy"
+                  value={PRIVATE_FEED}
+                  checked={feedPrivacy === PRIVATE_FEED}
+                  onChange={this.updatePrivacy}
+                />
+                Private &mdash; only people you approve can see your posts
+              </label>
+            </div>
+          </div>
+          <div className="form-group">
+            <div className="checkbox">
+              <label>
+                <input
+                  type="checkbox"
+                  name="directsFromAll"
+                  checked={this.props.directsFromAll || false}
+                  onChange={this.updateSetting('directsFromAll')}
+                />
+                Accept direct messages from all users
+              </label>
+            </div>
+          </div>
           <p>
-          Your feed is:
+            <button className="btn btn-default" type="submit">Update</button>
+            {this.props.isSaving ? (
+              <span className="settings-throbber">
+                <Throbber />
+              </span>
+            ) : false}
           </p>
-          <div className="radio">
-            <label>
-              <input
-                type="radio"
-                name="privacy"
-                value={PUBLIC_FEED}
-                checked={feedPrivacy === PUBLIC_FEED}
-                onChange={this.updatePrivacy}
-              />
-              Public &mdash; anyone can see your posts
-            </label>
-          </div>
-          <div className="radio">
-            <label>
-              <input
-                type="radio"
-                name="privacy"
-                value={PROTECTED_FEED}
-                checked={feedPrivacy === PROTECTED_FEED}
-                onChange={this.updatePrivacy}
-              />
-              Protected &mdash; anonymous users and search engines cannot see your posts
-            </label>
-          </div>
-          <div className="radio">
-            <label>
-              <input
-                type="radio"
-                name="privacy"
-                value={PRIVATE_FEED}
-                checked={feedPrivacy === PRIVATE_FEED}
-                onChange={this.updatePrivacy}
-              />
-              Private &mdash; only people you approve can see your posts
-            </label>
-          </div>
-        </div>
-        <div className="form-group">
-          <div className="checkbox">
-            <label>
-              <input
-                type="checkbox"
-                name="directsFromAll"
-                checked={this.props.directsFromAll || false}
-                onChange={this.updateSetting('directsFromAll')}
-              />
-              Accept direct messages from all users
-            </label>
-          </div>
-        </div>
-        <p>
-          <button className="btn btn-default" type="submit">Update</button>
-          {this.props.isSaving ? (
-            <span className="settings-throbber">
-              <Throbber />
-            </span>
+          {this.props.success ? (
+            <div className="alert alert-info" role="alert">Updated!</div>
+          ) : this.props.error ? (
+            <div className="alert alert-danger" role="alert">{this.props.errorMessage}</div>
           ) : false}
-        </p>
-        {this.props.success ? (
-          <div className="alert alert-info" role="alert">Updated!</div>
-        ) : this.props.error ? (
-          <div className="alert alert-danger" role="alert">{this.props.errorMessage}</div>
-        ) : false}
+        </ErrorBoundary>
       </form>
     );
   }

--- a/src/components/user.jsx
+++ b/src/components/user.jsx
@@ -10,6 +10,7 @@ import config from '../config';
 import { joinPostData, postActions, userActions, canAcceptDirects } from './select-utils';
 import FeedOptionsSwitch from './feed-options-switch';
 import Breadcrumbs from './breadcrumbs';
+import ErrorBoundary from './error-boundary';
 import UserProfile from './user-profile';
 import UserFeed from './user-feed';
 
@@ -32,42 +33,44 @@ const UserHandler = (props) => {
 
   return (
     <div className="box">
-      {props.viewUser.id && (
-        <Helmet>
-          <link
-            rel="alternate"
-            type="application/rss+xml"
-            title={props.viewUser.type === 'user' ? `Posts of ${props.viewUser.username}` : `Posts in group ${props.viewUser.username}`}
-            href={`${config.api.host}/v2/timelines-rss/${props.viewUser.username}`}
-          />
-        </Helmet>
-      )}
+      <ErrorBoundary>
+        {props.viewUser.id && (
+          <Helmet>
+            <link
+              rel="alternate"
+              type="application/rss+xml"
+              title={props.viewUser.type === 'user' ? `Posts of ${props.viewUser.username}` : `Posts in group ${props.viewUser.username}`}
+              href={`${config.api.host}/v2/timelines-rss/${props.viewUser.username}`}
+            />
+          </Helmet>
+        )}
 
-      <div className="box-header-timeline">
-        {props.boxHeader}
-        <div className="pull-right">
-          <FeedOptionsSwitch />
+        <div className="box-header-timeline">
+          {props.boxHeader}
+          <div className="pull-right">
+            <FeedOptionsSwitch />
+          </div>
         </div>
-      </div>
 
-      <div className="box-body">
-        {props.breadcrumbs.shouldShowBreadcrumbs ? <Breadcrumbs {...props.breadcrumbs} /> : false}
+        <div className="box-body">
+          {props.breadcrumbs.shouldShowBreadcrumbs ? <Breadcrumbs {...props.breadcrumbs} /> : false}
 
-        <UserProfile
-          {...props.viewUser}
-          {...props.userActions}
-          user={props.user}
-          sendTo={props.sendTo}
-          expandSendTo={props.expandSendTo}
-          createPostViewState={props.createPostViewState}
-          createPost={props.createPost}
-          resetPostCreateForm={props.resetPostCreateForm}
-          addAttachmentResponse={props.addAttachmentResponse}
-          getUserInfo={props.getUserInfo}
-        />
-      </div>
+          <UserProfile
+            {...props.viewUser}
+            {...props.userActions}
+            user={props.user}
+            sendTo={props.sendTo}
+            expandSendTo={props.expandSendTo}
+            createPostViewState={props.createPostViewState}
+            createPost={props.createPost}
+            resetPostCreateForm={props.resetPostCreateForm}
+            addAttachmentResponse={props.addAttachmentResponse}
+            getUserInfo={props.getUserInfo}
+          />
+        </div>
 
-      <UserFeed {...props} />
+        <UserFeed {...props} />
+      </ErrorBoundary>
     </div>
   );
 };

--- a/styles/helvetica/app.scss
+++ b/styles/helvetica/app.scss
@@ -27,6 +27,7 @@
 @import "../shared/comment-likes";
 @import "../shared/signup-by-invitation";
 @import "../shared/bookmarklet";
+@import "../shared/error-boundary";
 @import "player";
 @import "react-select";
 @import "legal";

--- a/styles/shared/error-boundary.scss
+++ b/styles/shared/error-boundary.scss
@@ -1,0 +1,16 @@
+.error-boundary {
+  display: block;
+  padding: 10px;
+  color: #000;
+  border: 2px solid #a00;
+}
+
+.error-boundary-header {
+  font-size: 14px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.error-boundary-details {
+  font-size: 12px;
+}

--- a/styles/shared/error-boundary.scss
+++ b/styles/shared/error-boundary.scss
@@ -3,14 +3,16 @@
   padding: 10px;
   color: #000;
   border: 2px solid #a00;
+  text-align: left;
+  line-height: 16px;
 }
 
 .error-boundary-header {
   font-size: 14px;
   font-weight: bold;
-  margin-bottom: 10px;
 }
 
 .error-boundary-details {
   font-size: 12px;
+  margin-top: 10px;
 }

--- a/test/unit/components/post-comments.js
+++ b/test/unit/components/post-comments.js
@@ -8,6 +8,7 @@ import flatten from 'lodash/flatten';
 
 import PostComments from '../../../src/components/post-comments';
 import PostComment from '../../../src/components/post-comment';
+import ErrorBoundary from '../../../src/components/error-boundary';
 import MoreCommentsWrapper from '../../../src/components/more-comments-wrapper';
 
 
@@ -65,7 +66,7 @@ describe('<PostComments>', () => {
       <PostComments comments={[]} post={post} />,
       'when rendered',
       'to have rendered with all children',
-      <div />
+      <div className="comments"><ErrorBoundary /></div>
     );
 
     expect(
@@ -83,7 +84,8 @@ describe('<PostComments>', () => {
       'queried for',
       <div className="comments" />
     );
-    const comments = flatten(root.props.children).filter((tag) => tag.type === PostComment);
+    const errorBoundary = root.props.children;
+    const comments = flatten(errorBoundary.props.children).filter((tag) => tag.type === PostComment);
     expect(comments, 'to have length', 4);
   });
 

--- a/test/unit/components/post-likes.js
+++ b/test/unit/components/post-likes.js
@@ -21,7 +21,8 @@ describe('<PostLikes>', () => {
       const renderer = new ShallowRenderer();
       renderer.render(<PostLikes {...{ likes, post }} />);
 
-      expect(renderer.getRenderOutput().props.children[1].props.children, 'to have length', i);
+      const errorBoundary = renderer.getRenderOutput().props.children;
+      expect(errorBoundary.props.children[1].props.children, 'to have length', i);
     });
   }
 
@@ -32,7 +33,8 @@ describe('<PostLikes>', () => {
     const renderer = new ShallowRenderer();
     renderer.render(<PostLikes {...{ likes, post }} />);
 
-    const likeList = renderer.getRenderOutput().props.children[1].props.children;
+    const errorBoundary = renderer.getRenderOutput().props.children;
+    const likeList = errorBoundary.props.children[1].props.children;
     const lastLike = likeList[likeList.length - 1];
     const [ommitedLikesNode] = lastLike.props.children;
     const [ommitedLikesNumber] = ommitedLikesNode.props.children;


### PR DESCRIPTION
This PR adds ErrorBoundary wrapper component, and uses it around important components such as post or comments. ErrorBoundary acts like a try-catch block for js errors inside wrapped components, and displays a user-friendly message in place of a crashed component instead of letting the error destroy the whole app and show the user a blank page.

Read more: https://reactjs.org/docs/error-boundaries.html

Example of a simulated error in user-card.js caught by an ErrorBoundary (previously this error would result in a blank page):

<img width="761" alt="Screenshot 2019-09-08 at 12 57 05" src="https://user-images.githubusercontent.com/632081/64483856-91f2f400-d23c-11e9-86da-6e5664bcd3c6.png">

Note that the rest of the page is still working and interactive. Error message with full stack trace is still logged to the console.