### PR TITLE
Use candy.freefeed.net as development backend by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 ## Starting Development Server with Hot-Reload
 
-1. Start [freefeed-server](https://github.com/FreeFeed/freefeed-server)
-1. `npm start` or `dev-server.cmd` on Windows
+Run `npm start` (will use [staging backend](https://candy.freefeed.net)).
+
+Alternatively, install [freefeed-server](https://github.com/FreeFeed/freefeed-server) and run `npm run dev-server:local` if you need to work with local backend.
 
 Alternatively, instead of running a local backend, edit `src/config.js` and set `api.host` to `'https://candy.freefeed.net'` and `auth.cookieDomain` to `'candy.freefeed.net'` to use data from test backend.
 

--- a/package.json
+++ b/package.json
@@ -106,12 +106,13 @@
     "worker-loader": "~2.0.0"
   },
   "scripts": {
-    "start": "run-s dev-server",
+    "start": "run-s dev-server:candy",
     "test": "run-s \"test-just --recursive test/unit\"",
     "test-just": "cross-env NODE_ENV=development mochapack --webpack-config webpack.config.tests.babel.js",
     "lint": "eslint --ext .js --ext .jsx src test",
     "travis": "run-p --aggregate-output -c test lint",
-    "dev-server": "cross-env DEV=1 LIVERELOAD=1 webpack-dev-server --config webpack.config.babel.js --port 3333 --host 0.0.0.0 --output-public-path / --colors --hot",
+    "dev-server:local": "cross-env DEV=1 LIVERELOAD=1 webpack-dev-server --config webpack.config.babel.js --port 3333 --host 0.0.0.0 --output-public-path / --colors --hot --open",
+    "dev-server:candy": "cross-env DEV=1 LIVERELOAD=1 CANDY=1 webpack-dev-server --config webpack.config.babel.js --port 3333 --host 0.0.0.0 --output-public-path / --colors --hot --open",
     "clean": "rimraf ./_dist",
     "build-prod": "cross-env UGLIFY=1 HASH=1 DEV=0 run-s clean _webpack _cp-assets",
     "build-dev": "cross-env UGLIFY=0 HASH=0 DEV=1 run-s clean _webpack _cp-assets",

--- a/src/config.js
+++ b/src/config.js
@@ -1,14 +1,19 @@
+/* global WEBPACK_SAYS_USE_CANDY */
 import * as FrontendPrefsOptions from './utils/frontend-preferences-options';
 import * as FeedOptions from './utils/feed-options';
 
 
+const shouldUseCandy = typeof WEBPACK_SAYS_USE_CANDY !== 'undefined' && WEBPACK_SAYS_USE_CANDY;
+const HOST = shouldUseCandy ? 'https://candy.freefeed.net' : 'http://localhost:3000';
+const COOKIE_DOMAIN = shouldUseCandy ? 'candy.freefeed.net' : 'localhost';
+
 const config = {
   api: {
-    host:     'http://localhost:3000',
+    host:     HOST,
     sentinel: null // keep always last
   },
   auth: {
-    cookieDomain:   'localhost',
+    cookieDomain:   COOKIE_DOMAIN,
     tokenPrefix:    'freefeed_',
     userStorageKey: 'USER_KEY',
     sentinel:       null // keep always last

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -3,6 +3,7 @@ import OptiCSS from "optimize-css-assets-webpack-plugin";
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import Uglify from "terser-webpack-plugin";
 import CopyPlugin from "copy-webpack-plugin";
+import webpack from 'webpack';
 
 import { baseConfig, opts, rules } from "./webpack/base";
 import { skipFalsy } from './webpack/utils';
@@ -47,6 +48,7 @@ const config = {
       { from: 'assets/images/favicon.ico', to: 'assets/images/' },
       { from: 'assets/images/ios/*.png', to: '' },
     ]),
+    new webpack.DefinePlugin({ WEBPACK_SAYS_USE_CANDY: Boolean(process.env.CANDY) })
   ]),
   optimization: {
     splitChunks: {


### PR DESCRIPTION
This PR changes default development server from localhost to candy.freefeed.net, so that it is easier for a newcomer to start developing without having to deal with configuration or installation of freefeed-server.

This works by setting `CANDY=1` environment variable, using `webpack.DefinePlugin` to make it a global variable, and then checking for it in config file to set either candy or localhost as backend.