### PR TITLE
Add GitHub link to site footer

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -5,6 +5,6 @@ import { Link } from 'react-router';
 export default () => (
   <footer className="footer">
     &copy; FreeFeed 1.68.2 (Sep, 6, 2019)<br />
-    <Link to="/about">About</Link> | <Link to="/freefeed">News</Link> | <a href="https://dev.freefeed.net/w/faq" target="_blank">FAQ</a> | <Link to="/about/terms">Terms</Link> | <Link to="/about/privacy">Privacy</Link> | <a href="https://status.freefeed.net/" target="_blank">Status</a> | <Link to="/about/stats">Stats</Link> | <Link to="/invite">Invite</Link>
+    <Link to="/about">About</Link> | <Link to="/about/terms">Terms</Link> | <Link to="/about/privacy">Privacy</Link> | <Link to="/about/stats">Stats</Link> | <a href="https://status.freefeed.net/" target="_blank">Status</a> | <a href="https://github.com/FreeFeed" target="_blank">GitHub</a>
   </footer>
 );


### PR DESCRIPTION
This PR adds a link to FreeFeed repo on GitHub to site footer. Hopefully, this will make it more obvious for users that this is an open-source project and bring in more contributors.
