### PR TITLE
Remove mentions of dev.freefeed.net from all pages

### DIFF
--- a/src/components/about.jsx
+++ b/src/components/about.jsx
@@ -51,7 +51,7 @@ const About = ({ authenticated }) => (
 
       <p>
         FreeFeed{' '}
-        <a href="https://dev.freefeed.net/w/faq" target="_blank">
+        <a href="https://freefeed.net/welcome/7c70927a-4e51-49e7-bfe1-33bc4c1c0618" target="_blank">
           frequently asked questions page
         </a>
         .

--- a/src/components/dev.jsx
+++ b/src/components/dev.jsx
@@ -13,7 +13,7 @@ export default () => (
 
       <p>
         We{' '}
-        <a href="https://dev.freefeed.net" target="_blank">
+        <a href="https://freefeed.net/ffdev/" target="_blank">
           need help
         </a>{' '}
         with both development and testing.
@@ -44,7 +44,7 @@ export default () => (
 
       <p>
         <b>
-          <a href="https://dev.freefeed.net" target="_blank">
+          <a href="https://freefeed.net/ffdev/" target="_blank">
             Join
           </a>
         </b>{' '}

--- a/src/components/sidebar.jsx
+++ b/src/components/sidebar.jsx
@@ -109,7 +109,10 @@ const SideBarFreeFeed = () => (
         </li>
         <li>
           <Link to="/support">Support</Link> /{' '}
-          <a href="https://dev.freefeed.net/w/faq/" target="_blank">
+          <a
+            href="https://freefeed.net/welcome/7c70927a-4e51-49e7-bfe1-33bc4c1c0618"
+            target="_blank"
+          >
             FAQ
           </a>
         </li>


### PR DESCRIPTION
This PR removes all mentions of dev.freefeed.net from all pages (well, one exception is archive restoration FAQ which is not duplicated anywhere else) and replaces them with more appropriate links. The reason is that dev.freefeed.net is _very_ inactive and having a page with tickets from 2016 featured in the sidebar is not improving our image. 

See also https://freefeed.net/ffdev/d72616bd-e8df-4051-ac09-b285ca4205a1