### PR TITLE
Fix "Public groups" link label

### DIFF
--- a/src/components/sidebar.jsx
+++ b/src/components/sidebar.jsx
@@ -104,7 +104,7 @@ const SideBarFreeFeed = () => (
         </li>
         <li>
           <a href="https://davidmz.me/frfrfr/all-groups/" target="_blank">
-            Public Groups
+            Public groups
           </a>
         </li>
         <li>


### PR DESCRIPTION
For consistency with other sidebar items
