### PR TITLE
Remove npm from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ## Starting Development Server with Hot-Reload
 
-Run `npm start` (will use [staging backend](https://candy.freefeed.net)).
+Run `yarn start` (will use [staging backend](https://candy.freefeed.net)).
 
-Alternatively, install [freefeed-server](https://github.com/FreeFeed/freefeed-server) and run `npm run dev-server:local` if you need to work with local backend.
+Alternatively, install [freefeed-server](https://github.com/FreeFeed/freefeed-server) and run `yarn dev-server:local` if you need to work with local backend.
 
 ## Sanity checks
 
-1. `npm test` will build test-suite and run the tests
-1. `npm run lint` will check if sourcecode complies to the coding guidelines
+1. `yarn test` will build test-suite and run the tests
+1. `yarn lint` will check if sourcecode complies to the coding guidelines
 
 ## To deploy run
 


### PR DESCRIPTION
This PR replaces npm with yarn in installation instructions

Fixes #1005 
