### PR TITLE
Fix incorrect layout on Best of page

### DIFF
--- a/src/components/summary.jsx
+++ b/src/components/summary.jsx
@@ -25,13 +25,15 @@ class Summary extends React.Component {
           </div>
         </div>
 
-        {props.isLoading || props.visibleEntries.length ? (
-          <Feed {...props} />
-        ) : (
-          <div className="summary-no-results">
-            <p>No entries here yet. You might want to subscribe for more users and groups.</p>
-          </div>
-        )}
+        <div className="box-body">
+          {props.isLoading || props.visibleEntries.length ? (
+            <Feed {...props} />
+          ) : (
+            <div className="summary-no-results">
+              <p>No entries here yet. You might want to subscribe for more users and groups.</p>
+            </div>
+          )}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
This PR adds a missing `<div className="box-body">` to "Best of" page, so that the left edge of the feed aligns with the left edge of the header.

Before:
<img width="754" alt="Screenshot 2019-09-15 at 12 14 08" src="https://user-images.githubusercontent.com/632081/64916595-be65bd80-d7b2-11e9-8844-ac77296b10e5.png">

After:
<img width="753" alt="Screenshot 2019-09-15 at 12 13 46" src="https://user-images.githubusercontent.com/632081/64916594-bdcd2700-d7b2-11e9-9cbd-1269671ee463.png">
