### PR TITLE
Add unsubscription confirmation

### DIFF
--- a/src/components/user-card.jsx
+++ b/src/components/user-card.jsx
@@ -35,7 +35,9 @@ class UserCard extends React.Component {
     }
 
     const { username } = this.props.user;
-    this.props.unsubscribe({ username });
+    if (window.confirm(`Are you sure you want to unsubscribe from ${username}?`)) {
+      this.props.unsubscribe({ username });
+    }
   };
 
   handleRequestSubscriptionClick = () => {

--- a/src/components/user-profile.jsx
+++ b/src/components/user-profile.jsx
@@ -40,7 +40,7 @@ export default class UserProfile extends React.Component {
 
     if (amIGroupAdmin) {
       this.setState({ isUnsubWarningDisplayed: true });
-    } else {
+    } else if (window.confirm(`Are you sure you want to unsubscribe from ${username}?`)) {
       unsubscribe({ username, id });
     }
   });


### PR DESCRIPTION
This PR adds a confirmation dialog for unsubscribe actions in user-card and user-profile:

<img width="330" alt="Screenshot 2019-09-15 at 12 30 15" src="https://user-images.githubusercontent.com/632081/64916699-d63e4100-d7b4-11e9-9e03-e5883e2d7173.png">

Fixes #986
