### PR TITLE
Add @ symbol to unsubscription confirmation

### DIFF
--- a/src/components/user-card.jsx
+++ b/src/components/user-card.jsx
@@ -35,7 +35,7 @@ class UserCard extends React.Component {
     }
 
     const { username } = this.props.user;
-    if (window.confirm(`Are you sure you want to unsubscribe from ${username}?`)) {
+    if (window.confirm(`Are you sure you want to unsubscribe from @${username}?`)) {
       this.props.unsubscribe({ username });
     }
   };

--- a/src/components/user-profile.jsx
+++ b/src/components/user-profile.jsx
@@ -40,7 +40,7 @@ export default class UserProfile extends React.Component {
 
     if (amIGroupAdmin) {
       this.setState({ isUnsubWarningDisplayed: true });
-    } else if (window.confirm(`Are you sure you want to unsubscribe from ${username}?`)) {
+    } else if (window.confirm(`Are you sure you want to unsubscribe from @${username}?`)) {
       unsubscribe({ username, id });
     }
   });


### PR DESCRIPTION
This PR adds a `@` symbol to unsubscription confirmation to make the username stand out more.

See https://freefeed.slack.com/archives/C0457L46F/p1568535046046600?thread_ts=1568521949.045700&cid=C0457L46F
