### PR TITLE
Remove the web worker part of Throbber component

### DIFF
--- a/src/components/throbber-worker.js
+++ b/src/components/throbber-worker.js
@@ -1,6 +1,0 @@
-import { startAnimation } from "./throbber-animation";
-
-
-self.onmessage = (e) => startAnimation(e.data);
-
-

--- a/src/components/throbber.jsx
+++ b/src/components/throbber.jsx
@@ -2,8 +2,6 @@ import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
 
-// eslint-disable-next-line import/no-unresolved
-import Worker from 'worker-loader?inline=true!./throbber-worker';
 import { startAnimation } from './throbber-animation';
 
 
@@ -65,12 +63,6 @@ const ThrobberOnCanvas = React.memo(function ThrobberOnCanvas({
       strokeWidth: (strokeWidth * 16) / size,
     };
 
-    if (canvasRef.current.transferControlToOffscreen) {
-      const canvas = canvasRef.current.transferControlToOffscreen();
-      const worker = new Worker();
-      worker.postMessage({ ...animationParams, canvas }, [canvas]);
-      return () => worker.terminate();
-    }
     return startAnimation({ ...animationParams, canvas: canvasRef.current });
   }, [dpr, duration, size, strokeWidth]);
 


### PR DESCRIPTION
This should fix the Chrome 77-78 crash (https://freefeed.net/saietor/bcd38558-9bab-4856-ad5e-3e5a1f201a26)

Webpack config still have WebWorkers support.