### PR TITLE
Open auth. popup synchronously to avoid being blocked by the browser

### DIFF
--- a/assets/ext-auth/auth-return.html
+++ b/assets/ext-auth/auth-return.html
@@ -1,12 +1,22 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script>
-      window.opener && window.opener.postMessage({ search: location.search }, location.origin);
-      window.close();
-    </script>
+    <meta charset="utf-8">
+    <title>Authorization window</title>
   </head>
   <body>
-    <p>Window is closing...</p>
+    <p id="message">Window is closing...</p>
+    <script>
+      var message = document.getElementById('message');
+      (function() {
+        if (!window.opener) {
+          message.textContent = 'Can\'t connect to the opener window. Please close this window and try again.';
+          return;
+        }
+
+        window.opener.postMessage({ search: location.search }, location.origin);
+        window.close();
+      })();
+    </script>
   </body>
 </html>

--- a/src/components/ext-auth-buttons.jsx
+++ b/src/components/ext-auth-buttons.jsx
@@ -1,16 +1,21 @@
 import React, { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { signInViaExternalProvider } from '../redux/action-creators';
+import { signInViaExternalProvider, connectToExtProvider } from '../redux/action-creators';
 import { providerTitle, useExtAuthProviders } from './ext-auth-helpers';
 
-export const ExtAuthButtons = React.memo(function ExtAuthButtons({ actionTitle = 'Sign in' }) {
+export const CONNECT = 'connect';
+export const SIGN_IN = 'sign-in';
+export const SIGN_UP = 'sign-up';
+
+export const ExtAuthButtons = React.memo(function ExtAuthButtons({ mode = SIGN_IN }) {
   const dispatch = useDispatch();
   const [providers] = useExtAuthProviders();
-  const signInStatus = useSelector((state) => state.extAuth.signInStatus);
+  const status = useSelector(statusSelector[mode]);
 
-  const doSignIn = useCallback((provider) => () => dispatch(signInViaExternalProvider(provider)), [
+  const onClick = useCallback((provider) => () => dispatch(actionCreator[mode](provider)), [
     dispatch,
+    mode,
   ]);
 
   if (providers.length === 0) {
@@ -21,28 +26,53 @@ export const ExtAuthButtons = React.memo(function ExtAuthButtons({ actionTitle =
   return (
     <>
       <p>
+        {commonLabel[mode]}
         {providers.map((p) => (
           <span key={p}>
-            <button
-              className="btn btn-default"
-              onClick={doSignIn(p)}
-              disabled={signInStatus.loading}
-            >
-              {actionTitle} via {providerTitle(p)}
+            <button className="btn btn-default" onClick={onClick(p)} disabled={status.loading}>
+              {btnLabel[mode]}
+              {providerTitle(p)}
             </button>{' '}
           </span>
         ))}
       </p>
-      {signInStatus.loading && (
+      {status.loading && (
         <p className="alert alert-info" role="alert">
-          Signing in...
+          {progressLabel[mode]}
         </p>
       )}
-      {signInStatus.error && (
+      {status.error && (
         <p className="alert alert-danger" role="alert">
-          {signInStatus.errorText}
+          {status.errorText}
         </p>
       )}
     </>
   );
 });
+
+const btnLabel = {
+  [SIGN_IN]: 'Sign in via ',
+  [SIGN_UP]: 'Sign up via ',
+};
+
+const commonLabel = {
+  [CONNECT]: 'Connect to ',
+};
+
+const progressLabel = {
+  [CONNECT]: 'Connecting...',
+  [SIGN_IN]: 'Signing in...',
+  [SIGN_UP]: 'Signing up...',
+};
+
+const actionCreator = {
+  [CONNECT]: connectToExtProvider,
+  [SIGN_IN]: signInViaExternalProvider,
+  [SIGN_UP]: signInViaExternalProvider,
+};
+
+const statusSelector = {
+  [CONNECT]: (state) => state.extAuth.connectStatus,
+  [SIGN_IN]: (state) => state.extAuth.signInStatus,
+  [SIGN_UP]: (state) => state.extAuth.signInStatus,
+};

--- a/src/components/ext-auth-buttons.jsx
+++ b/src/components/ext-auth-buttons.jsx
@@ -1,5 +1,6 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import cn from 'classnames';
 
 import { signInViaExternalProvider, connectToExtProvider } from '../redux/action-creators';
 import { extAuthPopup } from '../services/popup';
@@ -9,10 +10,22 @@ export const CONNECT = 'connect';
 export const SIGN_IN = 'sign-in';
 export const SIGN_UP = 'sign-up';
 
+/**
+ * [FBC]
+ * Facebook Container (https://addons.mozilla.org/ru/firefox/addon/facebook-container/) is a
+ * Firefox extension authored and promoted by Mozilla that isolates Facebook and all its domains
+ * in a separate container. Because of this extension it is not possible to sign in via Facebook
+ * unless the FreeFeed site is in the same container. The following code contains some hacks to
+ * indicate this situation to user.
+ */
+
 export const ExtAuthButtons = React.memo(function ExtAuthButtons({ mode = SIGN_IN }) {
   const dispatch = useDispatch();
   const [providers] = useExtAuthProviders();
   const status = useSelector(statusSelector[mode]);
+
+  // [FBC] Emulate click on page to activate the extension
+  useEffect(() => document.body.click(), []);
 
   const onClick = useCallback(
     (provider) => () => {
@@ -34,7 +47,14 @@ export const ExtAuthButtons = React.memo(function ExtAuthButtons({ mode = SIGN_I
         {commonLabel[mode]}
         {providers.map((p) => (
           <span key={p}>
-            <button className="btn btn-default" onClick={onClick(p)} disabled={status.loading}>
+            <button
+              className={cn('btn btn-default', {
+                // [FBC] This class tells FBC that this button is a Facebook login button
+                'fb-login-button': p === 'facebook',
+              })}
+              onClick={onClick(p)}
+              disabled={status.loading}
+            >
               {btnLabel[mode]}
               {providerTitle(p)}
             </button>{' '}

--- a/src/components/ext-auth-buttons.jsx
+++ b/src/components/ext-auth-buttons.jsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { signInViaExternalProvider, connectToExtProvider } from '../redux/action-creators';
+import { extAuthPopup } from '../services/popup';
 import { providerTitle, useExtAuthProviders } from './ext-auth-helpers';
 
 export const CONNECT = 'connect';
@@ -13,10 +14,14 @@ export const ExtAuthButtons = React.memo(function ExtAuthButtons({ mode = SIGN_I
   const [providers] = useExtAuthProviders();
   const status = useSelector(statusSelector[mode]);
 
-  const onClick = useCallback((provider) => () => dispatch(actionCreator[mode](provider)), [
-    dispatch,
-    mode,
-  ]);
+  const onClick = useCallback(
+    (provider) => () => {
+      // Popup must be opened synchronously to avoid being blocked by the browser
+      const popup = extAuthPopup();
+      dispatch(actionCreator[mode](provider, popup));
+    },
+    [dispatch, mode],
+  );
 
   if (providers.length === 0) {
     // No allowed providers so do not show anything

--- a/src/components/signup.jsx
+++ b/src/components/signup.jsx
@@ -7,7 +7,7 @@ import { signedIn } from '../redux/action-creators';
 import SignupForm from './signup-form';
 import { CookiesBanner } from './cookies-banner';
 import { useExtAuthProviders, providerTitle } from './ext-auth-helpers';
-import { ExtAuthButtons } from './ext-auth-buttons';
+import { ExtAuthButtons, SIGN_UP } from './ext-auth-buttons';
 
 export default React.memo(function Signup() {
   return (
@@ -49,7 +49,7 @@ const ExtAuthSignup = React.memo(function ExtAuthSignup() {
   return (
     <>
       <p>Or use external service profile to create FreeFeed account:</p>
-      <ExtAuthButtons actionTitle="Sign up" />
+      <ExtAuthButtons mode={SIGN_UP} />
       {result.status === 'signed-in' && (
         <div className="alert alert-success" role="alert">
           <p>

--- a/src/components/user-ext-auth-accounts-form.jsx
+++ b/src/components/user-ext-auth-accounts-form.jsx
@@ -3,16 +3,12 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import { faTimes, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import config from '../config';
-import {
-  getServerInfo,
-  getExtAuthProfiles,
-  connectToExtProvider,
-  unlinkExternalProfile,
-} from '../redux/action-creators';
+import { getServerInfo, getExtAuthProfiles, unlinkExternalProfile } from '../redux/action-creators';
 import { combineAsyncStates, initialAsyncState } from '../redux/async-helpers';
 import { Icon } from './fontawesome-icons';
 import { Throbber } from './throbber';
-import { useExtAuthProviders, providerTitle } from './ext-auth-helpers';
+import { providerTitle } from './ext-auth-helpers';
+import { ExtAuthButtons, CONNECT } from './ext-auth-buttons';
 
 export const UserExtAuthForm = React.memo(function UserExtAuthForm() {
   const dispatch = useDispatch();
@@ -68,7 +64,7 @@ export const UserExtAuthForm = React.memo(function UserExtAuthForm() {
           {existingProfiles.map((profile) => (
             <ConnectedProfile key={profile.id} profile={profile} />
           ))}
-          <ConnectButtons />
+          <ExtAuthButtons mode={CONNECT} />
         </>
       )}
       <hr />
@@ -107,52 +103,5 @@ const ConnectedProfile = React.memo(function ConnectedProfile({ profile }) {
         </>
       )}
     </p>
-  );
-});
-
-const ConnectButtons = React.memo(function ConnectButtons() {
-  const [providers, providersStatus] = useExtAuthProviders();
-  const connectStatus = useSelector((state) => state.extAuth.connectStatus);
-  const dispatch = useDispatch();
-
-  const doLink = useCallback((provider) => () => dispatch(connectToExtProvider(provider)), [
-    dispatch,
-  ]);
-
-  if (providersStatus.loading) {
-    return <p>Loading...</p>;
-  }
-
-  if (providers.length === 0) {
-    return <p>No supported identity providers.</p>;
-  }
-
-  return (
-    <>
-      <p>
-        Connect to{' '}
-        {providers.map((p) => (
-          <span key={p}>
-            <button
-              className="btn btn-default"
-              onClick={doLink(p)}
-              disabled={connectStatus.loading}
-            >
-              {providerTitle(p)}
-            </button>{' '}
-          </span>
-        ))}
-      </p>
-      {connectStatus.loading && (
-        <p className="alert alert-info" role="alert">
-          Connecting...
-        </p>
-      )}
-      {connectStatus.error && (
-        <p className="alert alert-danger" role="alert">
-          {connectStatus.errorText}
-        </p>
-      )}
-    </>
   );
 });

--- a/src/components/user-ext-auth-accounts-form.jsx
+++ b/src/components/user-ext-auth-accounts-form.jsx
@@ -2,17 +2,17 @@ import React, { useEffect, useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { faTimes, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
-import config from '../config';
 import { getServerInfo, getExtAuthProfiles, unlinkExternalProfile } from '../redux/action-creators';
 import { combineAsyncStates, initialAsyncState } from '../redux/async-helpers';
 import { Icon } from './fontawesome-icons';
 import { Throbber } from './throbber';
-import { providerTitle } from './ext-auth-helpers';
+import { providerTitle, useExtAuthProviders } from './ext-auth-helpers';
 import { ExtAuthButtons, CONNECT } from './ext-auth-buttons';
 
 export const UserExtAuthForm = React.memo(function UserExtAuthForm() {
   const dispatch = useDispatch();
 
+  const [providers] = useExtAuthProviders();
   const serverInfoStatus = useSelector((state) => state.serverInfoStatus);
   const existingProfilesStatus = useSelector((state) => state.extAuth.profilesStatus);
   const existingProfiles = useSelector(({ extAuth: { profiles, providers } }) =>
@@ -34,7 +34,7 @@ export const UserExtAuthForm = React.memo(function UserExtAuthForm() {
     existingProfilesStatus,
   ]);
 
-  if (config.auth.extAuthProviders.length === 0) {
+  if (providers.length === 0) {
     // External authentication is disabled so do not show anything
     return null;
   }

--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -937,11 +937,11 @@ export function getExtAuthProfiles() {
   };
 }
 
-export function connectToExtProvider(provider) {
+export function connectToExtProvider(provider, popup) {
   return {
     type: ActionTypes.CONNECT_TO_EXTERNAL_PROVIDER,
     asyncOperation: Api.performExtAuth,
-    payload: { provider, mode: 'connect' },
+    payload: { provider, popup, mode: 'connect' },
   };
 }
 
@@ -953,10 +953,10 @@ export function unlinkExternalProfile(profileId) {
   };
 }
 
-export function signInViaExternalProvider(provider) {
+export function signInViaExternalProvider(provider, popup) {
   return {
     type: ActionTypes.SIGN_IN_VIA_EXTERNAL_PROVIDER,
     asyncOperation: Api.performExtAuth,
-    payload: { provider, mode: 'sign-in' },
+    payload: { provider, popup, mode: 'sign-in' },
   };
 }

--- a/src/services/popup.js
+++ b/src/services/popup.js
@@ -46,3 +46,11 @@ export function popupAsPromise(popup, { origins = [location.origin] } = {}) {
     })();
   });
 }
+
+export function extAuthPopup() {
+  const popup = centeredPopup(`about:blank`);
+  popup.document.write('Loading...');
+  popup.document.close();
+  popup.document.title = 'Authorization window';
+  return popup;
+}


### PR DESCRIPTION
Also support the 'Facebook Container' Firefox extension to indicate that user can not sign in via Facebook with this extension:

![image](https://user-images.githubusercontent.com/132120/68482406-96db2080-024a-11ea-8e11-cf0571bdac83.png)
