### PR TITLE
Add a warning message and email collection form if signup is suspended

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -12,5 +12,8 @@
   },
   "sentry": {
     "publicDSN": "FRF_SENTRY_DSN"
+  },
+  "registrationsLimit": {
+    "emailFormIframeSrc": "FRF_REG_LIMIT_FORM_IFRAME_SRC"
   }
 }

--- a/config/default.js
+++ b/config/default.js
@@ -69,6 +69,10 @@ module.exports = {
 
   appearance: { colorSchemeStorageKey: 'color-scheme' },
 
+  registrationsLimit: {
+    emailFormIframeSrc: null,
+  },
+
   eslint: {
     // By default the eslint-linebreak-style directive requires "windows" linebreaks
     // on Windows platform and "unix" linebreaks otherwise.

--- a/src/components/hooks/server-info.js
+++ b/src/components/hooks/server-info.js
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { getServerInfo } from '../../redux/action-creators';
+
+export function useServerInfo() {
+  const dispatch = useDispatch();
+  const serverInfo = useSelector((state) => state.serverInfo);
+  const status = useSelector((state) => state.serverInfoStatus);
+
+  useEffect(() => void (status.initial && dispatch(getServerInfo())), [dispatch, status]);
+  return [serverInfo, status];
+}

--- a/src/components/signup.jsx
+++ b/src/components/signup.jsx
@@ -1,3 +1,4 @@
+/* global CONFIG */
 import { encode as qsEncode } from 'querystring';
 import React, { useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -8,17 +9,55 @@ import SignupForm from './signup-form';
 import { CookiesBanner } from './cookies-banner';
 import { useExtAuthProviders, providerTitle } from './ext-auth-helpers';
 import { ExtAuthButtons, SIGN_UP } from './ext-auth-buttons';
+import { useServerInfo } from './hooks/server-info';
 
 export default React.memo(function Signup() {
+  const [serverInfo, serverInfoStatus] = useServerInfo();
+  const registrationOpen = !serverInfoStatus.success || serverInfo.registrationOpen;
+  const withForm = !!CONFIG.registrationsLimit.emailFormIframeSrc;
+
   return (
     <div className="box">
       <div className="box-header-timeline">Hello</div>
       <div className="box-body">
         <div className="col-md-12">
           <h2 className="p-signin-header">Sign up</h2>
-          <CookiesBanner />
-          <SignupForm />
-          <ExtAuthSignup />
+          {registrationOpen ? (
+            <>
+              <CookiesBanner />
+              <SignupForm />
+              <ExtAuthSignup />
+            </>
+          ) : (
+            <>
+              <div className="alert alert-warning" role="alert">
+                <p>
+                  Unfortunately we are not accepting new user registrations at this time, but we
+                  plan to be open for registration shortly.
+                </p>
+                {withForm && (
+                  <p>
+                    Please provide your email address to be notified when FreeFeed is open for
+                    registration.
+                  </p>
+                )}
+              </div>
+              {withForm && (
+                <p>
+                  <iframe
+                    src={CONFIG.registrationsLimit.emailFormIframeSrc}
+                    width="100%"
+                    height="550"
+                    frameBorder="0"
+                    marginHeight="0"
+                    marginWidth="0"
+                  >
+                    Loading…
+                  </iframe>
+                </p>
+              )}
+            </>
+          )}
         </div>
       </div>
       <div className="box-footer" />


### PR DESCRIPTION
This feature requires setting the `registrationsLimit.emailFormIframeSrc` field in a config or `FRF_REG_LIMIT_FORM_IFRAME_SRC` environment variable to show form.