### PR TITLE
Use escaped character code in CSS instead of unicode symbol

### DIFF
--- a/styles/helvetica/boxes.scss
+++ b/styles/helvetica/boxes.scss
@@ -142,7 +142,7 @@
         color: #000;
         font-size: 13px;
         &:after {
-          content: '•';
+          content: '\2022'; // Bullet symbol
           display: inline-block;
           width: 7px;
           text-align: center;


### PR DESCRIPTION
Explicit Unicode in CSS in some cases leads to incorrect results: https://freefeed.net/support/8dd019f6-80fd-4285-a3fd-ce9fd1a24395