### PR TITLE
Added inline video playing for attached .mp4 and .webm videofiles

### DIFF
--- a/src/components/post-attachment-video-container.jsx
+++ b/src/components/post-attachment-video-container.jsx
@@ -1,0 +1,71 @@
+import React, { useState, useCallback } from 'react';
+import classnames from 'classnames';
+import Loadable from 'react-loadable';
+import { faChevronCircleRight } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from './fontawesome-icons';
+import PostAttachmentVideo from './post-attachment-video';
+
+const Sortable = Loadable({
+  loading: ({ error }) => {
+    if (error) {
+      return <div>Cannot load Sortable component</div>;
+    }
+    return <div>Loading component...</div>;
+  },
+  loader: () => import('react-sortablejs'),
+  delay: 500,
+});
+
+function VideoAttachmentsContainer(props) {
+  const { attachments, isEditing, isSinglePost, removeAttachment, reorderImageAttachments } = props;
+  const [isFolded, setIsFolded] = useState(true);
+  const shouldFold = attachments.length > 1 && !isEditing && !isSinglePost;
+  const withSortable = isEditing && attachments.length > 1;
+
+  const toggleFolding = useCallback(
+    (e) => {
+      e.preventDefault();
+      setIsFolded(!isFolded);
+    },
+    [isFolded],
+  );
+
+  const onSortChange = useCallback((order) => reorderImageAttachments(order), [
+    reorderImageAttachments,
+  ]);
+
+  const className = classnames({
+    'video-attachments': true,
+    'is-folded': isFolded,
+    'needs-folding': true,
+    'sortable-images': withSortable,
+  });
+
+  const videos = attachments.map((video, i) => (
+    <PostAttachmentVideo
+      key={video.id}
+      isHidden={shouldFold && isFolded && i}
+      isEditing={isEditing}
+      removeAttachment={removeAttachment}
+      {...video}
+    />
+  ));
+
+  return (
+    <div className={className}>
+      {withSortable ? <Sortable onChange={onSortChange}>{videos}</Sortable> : videos}
+      {shouldFold && (
+        <div className="show-more">
+          <Icon
+            icon={faChevronCircleRight}
+            className="show-more-icon"
+            onClick={toggleFolding}
+            title={isFolded ? `Show more (${attachments.length - 1})` : 'Show less'}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default VideoAttachmentsContainer;

--- a/src/components/post-attachment-video.jsx
+++ b/src/components/post-attachment-video.jsx
@@ -1,0 +1,28 @@
+import React, { useCallback } from 'react';
+import classnames from 'classnames';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from './fontawesome-icons';
+
+function PostAttachmentVideo(props) {
+  const { isEditing, isHidden, removeAttachment, id, url } = props;
+
+  const handleRemoveImage = useCallback(() => {
+    removeAttachment(id);
+  }, [removeAttachment, id]);
+
+  return (
+    <div className={classnames({ attachment: true, hidden: isHidden })} data-id={id}>
+      <video className="video-preview" src={url} controls={1} />
+      {isEditing && (
+        <Icon
+          icon={faTimes}
+          className="remove-attachment"
+          title="Remove image"
+          onClick={handleRemoveImage}
+        />
+      )}
+    </div>
+  );
+}
+
+export default PostAttachmentVideo;

--- a/src/components/post-attachments.jsx
+++ b/src/components/post-attachments.jsx
@@ -3,6 +3,7 @@ import ImageAttachmentsContainer from './post-attachment-image-container';
 import AudioAttachment from './post-attachment-audio';
 import GeneralAttachment from './post-attachment-general';
 import ErrorBoundary from './error-boundary';
+import VideoAttachmentsContainer from './post-attachment-video-container';
 
 export default (props) => {
   const attachments = props.attachments || [];
@@ -36,7 +37,24 @@ export default (props) => {
     false
   );
 
-  const generalAttachments = attachments.filter((attachment) => attachment.mediaType === 'general');
+  const isVideo = (attachment) => attachment.fileName.match(/\.(mp4|webm)$/i);
+  const videoAttachments = attachments.filter((attachment) => isVideo(attachment));
+  const videoAttachmentNodes = videoAttachments.length ? (
+    <VideoAttachmentsContainer
+      isEditing={props.isEditing}
+      isSinglePost={props.isSinglePost}
+      removeAttachment={props.removeAttachment}
+      reorderImageAttachments={props.reorderImageAttachments}
+      attachments={videoAttachments}
+      postId={props.postId}
+    />
+  ) : (
+    false
+  );
+
+  const generalAttachments = attachments.filter(
+    (attachment) => attachment.mediaType === 'general' && !isVideo(attachment),
+  );
   const generalAttachmentsNodes = generalAttachments.map((attachment) => (
     <GeneralAttachment
       key={attachment.id}
@@ -56,6 +74,7 @@ export default (props) => {
       <ErrorBoundary>
         {imageAttachmentsContainer}
         {audioAttachmentsContainer}
+        {videoAttachmentNodes}
         {generalAttachmentsContainer}
       </ErrorBoundary>
     </div>

--- a/styles/shared/attachments-edit.scss
+++ b/styles/shared/attachments-edit.scss
@@ -1,6 +1,6 @@
 // Editing entries
 
-.image-attachments {
+.image-attachments, .video-attachments {
   .attachment .remove-attachment {
     display: block;
     position: absolute;
@@ -96,5 +96,22 @@
 
   .attachment.added {
     background-color: #bfb;
+  }
+}
+
+@media (max-width: 560px) {
+  .video-attachments {
+    .show-more {
+      width: 100%;
+      text-align: center;
+
+      .show-more-icon {
+        transform: rotate(270deg);
+      }
+    }
+
+    &.is-folded .show-more .show-more-icon {
+      transform: rotate(90deg);
+    }
   }
 }

--- a/styles/shared/attachments.scss
+++ b/styles/shared/attachments.scss
@@ -123,3 +123,27 @@
     }
   }
 }
+
+
+.video-attachments {
+  .attachment {
+    position: relative;
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 8px 8px 0;
+    box-sizing: content-box;
+    text-align: center;
+    max-width: 90%;
+    line-height: 0;
+
+    @media (max-width: 560px) {
+      max-width: 100%;
+      margin-right: 0;
+    }
+
+    video {
+      max-height: 400px;
+      max-width: 100%;
+    }
+  }
+}


### PR DESCRIPTION
I miss the opportunity to share short videofragments, since they are attached as links and are not easily viewable - most of the time i just have to convert them into gif, losing quality and gaining extra file size. This allows inline playing for two most popular web video formats. Like image collections video collections are foldable and sortable.