### PR TITLE
Add a `return_url` parameter of magic link

### DIFF
--- a/src/components/settings/app-tokens/create-link.jsx
+++ b/src/components/settings/app-tokens/create-link.jsx
@@ -1,6 +1,6 @@
 import { stringify } from 'querystring';
 
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Link } from 'react-router';
 import { trim } from 'lodash';
 
@@ -12,6 +12,9 @@ import { withLayout } from './layout';
 
 export default withLayout('Create a magic link', function CreateLink() {
   const [form, setForm] = useState(initialFormData);
+  const [returnURL, setReturnURL] = useState('');
+
+  const onReturnURLChange = useCallback((e) => setReturnURL(e.target.value), []);
 
   const linkParams = {};
   if (trim(form.title) !== '') {
@@ -25,6 +28,9 @@ export default withLayout('Create a magic link', function CreateLink() {
   }
   if (trim(form.origins)) {
     linkParams.origins = trim(form.origins);
+  }
+  if (/^https?:\/\//i.test(trim(returnURL))) {
+    linkParams.return_url = trim(returnURL);
   }
 
   const query = stringify(linkParams);
@@ -45,6 +51,20 @@ export default withLayout('Create a magic link', function CreateLink() {
       </p>
 
       <TokenForm onChange={setForm} />
+
+      <div className="form-group">
+        <p>After creating a token, show this return link to user:</p>
+        <input
+          type="text"
+          name="title"
+          className="form-control"
+          id="return-url"
+          maxLength="500"
+          value={returnURL}
+          onChange={onReturnURLChange}
+          placeholder="https://…"
+        />
+      </div>
 
       <div className="alert alert-info">
         <p>Share this link with your application users:</p>

--- a/src/components/settings/app-tokens/create-token.jsx
+++ b/src/components/settings/app-tokens/create-token.jsx
@@ -34,10 +34,10 @@ export default withLayout('Generate new token', function CreateToken() {
 
   const [form, setForm] = useState(initialData);
 
-  const canSubmit = useMemo(
-    () => !status.loading && trim(form.title) !== '' && form.scopes.length > 0,
-    [form, status.loading],
-  );
+  const canSubmit = useMemo(() => !status.loading && trim(form.title) !== '', [
+    form,
+    status.loading,
+  ]);
 
   const onSubmit = useCallback(
     (e) => {

--- a/src/components/settings/app-tokens/token-form-fields.jsx
+++ b/src/components/settings/app-tokens/token-form-fields.jsx
@@ -67,6 +67,12 @@ export default function TokenForm({ initialData = initialFormData, onChange }) {
       </div>
       <div className="form-group">
         <label htmlFor="title-input">Allow token to</label>
+        <div className="checkbox">
+          <label>
+            <input type="checkbox" name="scope" value="" checked disabled /> Read my public profile{' '}
+            <em>(always available)</em>
+          </label>
+        </div>
         {scopes.map((scope) => (
           <div key={scope.name} className="checkbox">
             <label>


### PR DESCRIPTION
After creating a token, site shows this link to user. Feature request: https://freefeed.net/n1313/50a7bc12-1c6a-4376-8dfb-6324527d277d

Also added client-side support of freefeed/freefeed-server#412

![2020-01-01_22-58-39](https://user-images.githubusercontent.com/132120/71645583-8cd61b00-2ceb-11ea-8319-09239f59b178.png)

![2020-01-01_22-54-58 (2)](https://user-images.githubusercontent.com/132120/71645585-93649280-2ceb-11ea-8db3-ded0d00e4be0.png)

![2020-01-01_22-56-28](https://user-images.githubusercontent.com/132120/71645589-98c1dd00-2ceb-11ea-9802-1017a61e29f0.png)
