### PR TITLE
Properly clean auth cookie and localStorage key on log out

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,5 +1,5 @@
 /* global CONFIG */
-import { getCookie, setCookie, localStorage, userParser } from '../utils/';
+import { getCookie, setCookie, localStorage, userParser, deleteCookie } from '../utils/';
 
 const { userStorageKey, tokenPrefix } = CONFIG.auth;
 const NAME = `${tokenPrefix}authToken`;
@@ -39,6 +39,12 @@ export function getToken() {
 }
 
 export function setToken(token) {
+  if (!token) {
+    localStorageWorks() && localStorage.removeItem(NAME);
+    deleteCookie(NAME);
+    return;
+  }
+
   if (localStorageWorks()) {
     localStorage.setItem(NAME, token);
   } else {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -28,6 +28,10 @@ export function setCookie(name, value = '', expireDays, path) {
   return (document.cookie = cookie);
 }
 
+export function deleteCookie(name, path) {
+  return setCookie(name, '', -1, path);
+}
+
 const userDefaults = {
   profilePictureMediumUrl: defaultUserpicPath,
   profilePictureLargeUrl: defaultUserpicPath,


### PR DESCRIPTION
In previous version this code wrote 'undefined' as a string to localStorage. Also it didn't delete auth cookie (if it was present), so after reload the user remains logged in.

This version still displays 'User not found' just after log out from user's page (before the page reload), but it is unrelated to token storage.