### PR TITLE
Gradually wrap up the elements of post footer on narrow screens

### DIFF
--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -594,20 +594,21 @@ class Post extends React.Component {
               </div>
               <div className="post-footer-content">
                 <span className="post-footer-block">
-                  {props.isDirect && (
-                    <Icon
-                      icon={faAngleDoubleRight}
-                      className="post-direct-icon"
-                      title="This is a direct message"
-                    />
-                  )}
-                  <Link to={canonicalPostURI} className="post-timestamp">
-                    <TimeDisplay
-                      timeStamp={+props.createdAt}
-                      showAbsTime={this.state.showTimestamps}
-                    />
-                  </Link>
-
+                  <span className="post-footer-item">
+                    {props.isDirect && (
+                      <Icon
+                        icon={faAngleDoubleRight}
+                        className="post-direct-icon"
+                        title="This is a direct message"
+                      />
+                    )}
+                    <Link to={canonicalPostURI} className="post-timestamp">
+                      <TimeDisplay
+                        timeStamp={+props.createdAt}
+                        showAbsTime={this.state.showTimestamps}
+                      />
+                    </Link>
+                  </span>
                   {props.commentsDisabled && (
                     <span className="post-footer-item">
                       <i>

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -136,19 +136,18 @@ $post-line-height: 20px;
 
 .post-footer-block {
   display: inline-block;
-  white-space: nowrap;
   margin-left: -1em;
   margin-right: 1em;
   max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-
-  &:first-child {
-    margin-left: 0;
-  }
 }
 
 .post-footer-item {
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+
   &:empty {
     display: none;
   }


### PR DESCRIPTION
Bug report: https://freefeed.net/ffdev/a4d12ded-4016-4196-bcd4-2890e377632f

Now all links will always be visible even on smart watches 🧠⌚

![image](https://user-images.githubusercontent.com/132120/71900478-f4b6b680-316e-11ea-9761-1cd402fa2003.png)
----
![image](https://user-images.githubusercontent.com/132120/71900497-fed8b500-316e-11ea-9a40-b1caabce0d35.png)
----
![image](https://user-images.githubusercontent.com/132120/71900522-07c98680-316f-11ea-890a-062e60dcb902.png)
----
![image](https://user-images.githubusercontent.com/132120/71900557-19129300-316f-11ea-8d24-c6f5cabca9d2.png)
----
![image](https://user-images.githubusercontent.com/132120/71900585-2596eb80-316f-11ea-8733-636e67606624.png)


