### PR TITLE
Use 'change' event instead of 'input' on file input

### DIFF
--- a/src/components/settings/forms/profile-picture.jsx
+++ b/src/components/settings/forms/profile-picture.jsx
@@ -22,7 +22,7 @@ export function PictureEditForm({ pictureURL, pictureStatus, onUpdate }) {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = 'image/jpeg, image/png, image/gif';
-    input.addEventListener('input', () => {
+    input.addEventListener('change', () => {
       onUpdate(input.files[0]);
       input.value = ''; // reset input state
     });


### PR DESCRIPTION
Safari does not fire 'input' event here