### PR TITLE
Normalize display of relative time

### DIFF
--- a/src/components/time-display.jsx
+++ b/src/components/time-display.jsx
@@ -7,7 +7,6 @@ import parseISO from 'date-fns/parseISO';
 import toDate from 'date-fns/toDate';
 import format from 'date-fns/format';
 import addMilliseconds from 'date-fns/addMilliseconds';
-import differenceInMilliseconds from 'date-fns/differenceInMilliseconds';
 import formatDistance from 'date-fns/formatDistance';
 import { useBool } from './hooks/bool';
 import { withListener } from './hooks/sub-unsub';
@@ -42,10 +41,10 @@ const TimeDisplay = memo(function TimeDisplay({
 
   const time = typeof timeStamp === 'number' ? toDate(timeStamp) : parseISO(timeStamp);
   const serverNow = addMilliseconds(new Date(), serverTimeAhead);
-  const timeAgo =
-    Math.abs(differenceInMilliseconds(serverNow, time)) < 1000
-      ? 'just now'
-      : `${formatDistance(time, serverNow)} ago`;
+  let timeAgo = `${formatDistance(time, serverNow)} ago`;
+  if (timeAgo === 'less than a minute ago') {
+    timeAgo = 'just now';
+  }
   const timeAbs = format(time, showDateOnly ? dateOnlyFormat : datetimeFormat);
   const timeISO = time.toISOString();
 


### PR DESCRIPTION
Before this we had the following relative time strings (https://date-fns.org/v2.9.0/docs/formatDistance):
0-1s - just now
1s-30s - less than a minute ago
30s-90s - 1 minute ago
...

The second, long, option was shown right after post creation and causes the suddenly change of page layout (https://freefeed.net/support/80cf8d61-72f2-45f1-abb8-9f7d3eb8a22d).

Now the sequence will be:
0-30s - just now
30s-90s - 1 minute ago
...