### PR TITLE
Fire the WHO_AM_I response before the INITIAL_WHO_AM_I processing

### DIFF
--- a/src/redux/action-helpers.js
+++ b/src/redux/action-helpers.js
@@ -25,7 +25,6 @@ import {
   TOGGLE_PINNED_GROUP,
   UPDATE_ACTUAL_USER_PREFERENCES,
   UPDATE_USER_NOTIFICATION_PREFERENCES,
-  INITIAL_WHO_AM_I,
 } from './action-types';
 import { request, response, fail, baseType } from './async-helpers';
 
@@ -70,7 +69,6 @@ const isUserFeedRequest = (action) => userFeedGeneratingActions.map(request).inc
 export const userChangeActions = [
   SIGN_UP,
   WHO_AM_I,
-  INITIAL_WHO_AM_I,
   SUBSCRIBE,
   UNSUBSCRIBE,
   UPDATE_USER,

--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -726,10 +726,11 @@ export const createRealtimeMiddleware = (store, conn, eventHandlers) => {
 };
 
 export const initialWhoamiMiddleware = (store) => (next) => (action) => {
-  next(action);
   if (action.type === response(ActionTypes.INITIAL_WHO_AM_I)) {
+    // Fire the WHO_AM_I response first to properly fill state by current user data
     store.dispatch({ ...action, type: response(ActionTypes.WHO_AM_I) });
   }
+  next(action);
 };
 
 // Fixing data structures coming from server

--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -682,7 +682,6 @@ export const createRealtimeMiddleware = (store, conn, eventHandlers) => {
     }
 
     if (
-      action.type === response(ActionTypes.INITIAL_WHO_AM_I) ||
       action.type === response(ActionTypes.WHO_AM_I) ||
       action.type === response(ActionTypes.SIGN_UP)
     ) {


### PR DESCRIPTION
The INITIAL_WHO_AM_I response starts the application. We should fire WHO_AM_I before that to properly fill state by user data.

It should fix the homefeed sort issue described in https://freefeed.net/support/3b530192-2c2c-4258-bdb5-4fc0842ccf1d