### PR TITLE
Always render post comments as a single array

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "react-router-redux": "4.0.x",
     "react-select": "~1.2.1",
     "react-sortablejs": "~1.5.1",
-    "react-sticky": "~6.0.3",
     "react-textarea-autosize": "~7.1.2",
     "redux": "~4.0.5",
     "snarkdown": "~1.2.2",

--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -162,21 +162,22 @@ export default class PostComments extends React.Component {
           .map((c, i) => this.renderComment(withBackwardNumber(c, totalComments - i - 1)));
 
     if (showExpand) {
-      return (
+      return [
         <MoreCommentsWrapper
+          key={`${post.id}:more-comments`}
           omittedComments={foldedCount}
           showMoreComments={this.showMoreComments}
           entryUrl={entryUrl}
           omittedCommentLikes={post.omittedCommentLikes}
           omittedOwnCommentLikes={post.omittedOwnCommentLikes}
           isLoading={post.isLoadingComments}
-        />
-      );
+        />,
+      ];
     }
 
     if (showFold) {
-      return (
-        <StickyContainer>
+      return [
+        <StickyContainer key={`${post.id}:sticky-container`}>
           <Sticky>
             {({ style, isSticky }) => (
               <div
@@ -189,8 +190,8 @@ export default class PostComments extends React.Component {
             )}
           </Sticky>
           {middleComments}
-        </StickyContainer>
-      );
+        </StickyContainer>,
+      ];
     }
 
     return middleComments;
@@ -228,9 +229,11 @@ export default class PostComments extends React.Component {
     return (
       <div className="comments" ref={this.rootEl}>
         <ErrorBoundary>
-          {first ? this.renderComment(first) : false}
-          {this.renderMiddle()}
-          {last ? this.renderComment(last) : false}
+          {[
+            first && this.renderComment(first),
+            ...this.renderMiddle(),
+            last && this.renderComment(last),
+          ]}
           {this.renderAddComment()}
         </ErrorBoundary>
       </div>

--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
-import { StickyContainer, Sticky } from 'react-sticky';
 import _ from 'lodash';
-import cn from 'classnames';
 
 import { faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { preventDefault } from '../utils';
@@ -11,6 +9,7 @@ import MoreCommentsWrapper from './more-comments-wrapper';
 import ErrorBoundary from './error-boundary';
 import { Icon } from './fontawesome-icons';
 import { faCommentPlus } from './fontawesome-custom-icons';
+import { Sticky } from './sticky';
 
 const minCommentsToFold = 12;
 
@@ -177,20 +176,16 @@ export default class PostComments extends React.Component {
 
     if (showFold) {
       return [
-        <StickyContainer key={`${post.id}:sticky-container`}>
-          <Sticky>
-            {({ style, isSticky }) => (
-              <div
-                style={style}
-                className={cn('fold-comments', { 'fold-comments-sticky': isSticky })}
-              >
-                <Icon icon={faChevronUp} className="chevron" />
-                <a onClick={this.fold}>Fold comments</a>
-              </div>
-            )}
-          </Sticky>
-          {middleComments}
-        </StickyContainer>,
+        <Sticky
+          key={`${post.id}:fold-link`}
+          className="fold-comments"
+          stickyClassName="fold-comments-sticky"
+          stickUntil={middleComments.length}
+        >
+          <Icon icon={faChevronUp} className="chevron" />
+          <a onClick={this.fold}>Fold comments</a>
+        </Sticky>,
+        ...middleComments,
       ];
     }
 

--- a/src/components/sticky.jsx
+++ b/src/components/sticky.jsx
@@ -1,0 +1,62 @@
+import React, { useRef, useState, useEffect, memo, useCallback } from 'react';
+
+const events = ['resize', 'scroll', 'touchstart', 'touchmove', 'touchend', 'pageshow', 'load'];
+
+// The lightweight Sticky component that doesn't require a wrapper around the sticky area
+export const Sticky = memo(function Sticky({
+  // The Sticky element can be scrolled over the next stickUntil DOM siblings.
+  // It will stick to the bottom of stickUntil-th element.
+  stickUntil = 0,
+  // Class that this element always has
+  className = '',
+  // Class to add when the element is in sticky mode
+  stickyClassName = '',
+  children,
+}) {
+  const ref = useRef(null);
+  const rafHandle = useRef(0);
+  const [top, setTop] = useState(0);
+
+  const update = useCallback(() => {
+    rafHandle.current = 0;
+    const el = ref.current;
+    const { top, bottom } = el.getBoundingClientRect();
+    let newTop = top < 0 ? -top : 0;
+    if (newTop > 0 && stickUntil > 0) {
+      let sbl = el;
+      for (let i = 0; i < stickUntil && sbl; i++) {
+        sbl = sbl.nextElementSibling;
+      }
+      if (sbl) {
+        const { bottom: sblBottom } = sbl.getBoundingClientRect();
+        newTop = Math.min(newTop, sblBottom - bottom);
+      }
+    }
+    setTop(newTop);
+  }, [stickUntil]);
+
+  useEffect(() => {
+    const handler = () => {
+      if (rafHandle.current === 0) {
+        rafHandle.current = requestAnimationFrame(update);
+      }
+    };
+    handler();
+    events.forEach((e) => window.addEventListener(e, handler));
+    return () => {
+      events.forEach((e) => window.removeEventListener(e, handler));
+      cancelAnimationFrame(rafHandle.current);
+    };
+  }, [stickUntil, update]);
+
+  return (
+    <div ref={ref}>
+      <div
+        className={className + (top > 0 ? ` ${stickyClassName}` : '')}
+        style={{ top, position: 'relative' }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+});

--- a/styles/shared/comments.scss
+++ b/styles/shared/comments.scss
@@ -124,7 +124,8 @@
 
 .fold-comments {
   font-style: italic;
-  padding: 8px 0 0 19px;
+  padding: 8px 0 0 59px;
+  margin-left: -40px;
   .chevron {
     display: none;
   }
@@ -137,7 +138,7 @@
   .chevron {
     display: block;
     position: absolute;
-    left: 0px;
+    left: 40px;
     top: 9px;
     opacity: 0.3;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8005,13 +8005,6 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-raf@^3.3.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
-  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
-  dependencies:
-    performance-now "^2.1.0"
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -8222,14 +8215,6 @@ react-sortablejs@~1.5.1:
   integrity sha512-bKIc1UVhjZt55Nb6WZFxZ8Jwyngg8CTt+w+iG1pA5k9LQsg1J0X6nLppHatSSDZDECtRZKp2z47tmmhPRJNj4g==
   dependencies:
     prop-types ">=15.0.0"
-
-react-sticky@~6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/react-sticky/-/react-sticky-6.0.3.tgz#7a18b643e1863da113d7f7036118d2a75d9ecde4"
-  integrity sha512-LNH4UJlRatOqo29/VHxDZOf6fwbgfgcHO4mkEFvrie5FuaZCSTGtug5R8NGqJ0kSnX8gHw8qZN37FcvnFBJpTQ==
-  dependencies:
-    prop-types "^15.5.8"
-    raf "^3.3.0"
 
 react-test-renderer@~16.12.0:
   version "16.12.0"


### PR DESCRIPTION
It fixes #899. This bug was caused by the fact that the first and last comments were mounted separately from the others (which were included in StickyContainer). When the last comment becomes the penultimate one, it was re-mounted and reset the current editing status.

The new custom Sticky component does not require a container around the scrolling area and allows comments to be placed in a single list. This eliminates the need for re-mounting.

By the way, the [react-sticky](https://github.com/captivationsoftware/react-sticky) is not supported anymore.