### PR TITLE
Allow mobile users to insert soft return via space+Enter

### DIFF
--- a/src/components/comment-edit-form.jsx
+++ b/src/components/comment-edit-form.jsx
@@ -1,9 +1,9 @@
 import React, { useMemo, useCallback, useState, useRef, useEffect, forwardRef } from 'react';
 import Textarea from 'react-textarea-autosize';
-import { KEY_RETURN } from 'keycode-js';
 
 import { initialAsyncState } from '../redux/async-helpers';
 import { insertText } from '../utils/insert-text';
+import { submitByEnter } from '../utils/submit-by-enter';
 import { Throbber } from './throbber';
 import { useForwardedRef } from './hooks/forward-ref';
 import { PreventPageLeaving } from './prevent-page-leaving';
@@ -31,14 +31,8 @@ export const CommentEditForm = forwardRef(function CommentEditForm(
   const doSubmit = useCallback(() => canSubmit && onSubmit(text), [canSubmit, onSubmit, text]);
 
   const onKeyDown = useCallback(
-    (e) => {
-      if (e.keyCode === KEY_RETURN && !e.shiftKey) {
-        e.preventDefault();
-        // Need this line to update text that doSubmit can access
-        setText(text);
-        doSubmit();
-      }
-    },
+    // Need to setText to update text that doSubmit can access
+    submitByEnter(() => (setText(text), doSubmit())),
     [doSubmit, text],
   );
 

--- a/src/components/create-bookmarklet-post.jsx
+++ b/src/components/create-bookmarklet-post.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { faComment } from '@fortawesome/free-regular-svg-icons';
 import { preventDefault } from '../utils';
+import { submitByEnter } from '../utils/submit-by-enter';
 import { Throbber } from './throbber';
 import SendTo from './send-to';
 import { Icon } from './fontawesome-icons';
@@ -44,16 +45,9 @@ export default class CreateBookmarkletPost extends React.Component {
     this.setState({ isFormEmpty });
   };
 
-  checkSave = (e) => {
-    const isEnter = e.keyCode === 13;
-    const isShiftPressed = e.shiftKey;
-    if (isEnter && !isShiftPressed) {
-      e.preventDefault();
-      if (!this.state.isFormEmpty && !this.props.createPostViewState.isPending) {
-        this.submitForm();
-      }
-    }
-  };
+  checkSave = submitByEnter(
+    () => !this.state.isFormEmpty && !this.props.createPostViewState.isPending && this.submitForm(),
+  );
 
   submitForm = () => {
     // Get all the values

--- a/src/components/create-post.jsx
+++ b/src/components/create-post.jsx
@@ -5,6 +5,7 @@ import _ from 'lodash';
 
 import { faCloudUploadAlt } from '@fortawesome/free-solid-svg-icons';
 import { preventDefault } from '../utils';
+import { submitByEnter } from '../utils/submit-by-enter';
 import SendTo from './send-to';
 import Dropzone from './dropzone';
 import PostAttachments from './post-attachments';
@@ -119,14 +120,7 @@ export default class CreatePost extends React.Component {
   attLoadingStarted = () => this.setState({ attLoading: true });
   attLoadingCompleted = () => this.setState({ attLoading: false });
 
-  checkSave = (e) => {
-    const isEnter = e.keyCode === 13;
-    const isShiftPressed = e.shiftKey;
-    if (isEnter && !isShiftPressed) {
-      e.preventDefault();
-      this.canSubmitForm() && this.createPost();
-    }
-  };
+  checkSave = submitByEnter(() => this.canSubmitForm() && this.createPost());
 
   toggleMore = () => {
     this.setState({ isMoreOpen: !this.state.isMoreOpen });

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -19,6 +19,7 @@ import { READMORE_STYLE_COMPACT } from '../utils/frontend-preferences-options';
 import { postReadmoreConfig } from '../utils/readmore-config';
 import { savePost, hideByName, unhideNames } from '../redux/action-creators';
 import { initialAsyncState } from '../redux/async-helpers';
+import { submitByEnter } from '../utils/submit-by-enter';
 import { Throbber } from './throbber';
 
 import PostAttachments from './post-attachments';
@@ -191,15 +192,7 @@ class Post extends React.Component {
     props.saveEditingPost(props.id, reqBody);
   };
 
-  handleKeyDown = (event) => {
-    const isEnter = event.keyCode === 13;
-    const isShiftPressed = event.shiftKey;
-
-    if (isEnter && !isShiftPressed) {
-      event.preventDefault();
-      this.canSubmitForm() && this.saveEditingPost();
-    }
-  };
+  handleKeyDown = submitByEnter(() => this.canSubmitForm() && this.saveEditingPost());
 
   handleAttachmentResponse = (att) => {
     if (this.state.editingAttachments.length >= attachmentsMaxCount) {

--- a/src/utils/submit-by-enter.js
+++ b/src/utils/submit-by-enter.js
@@ -1,0 +1,29 @@
+import { KEY_RETURN } from 'keycode-js';
+
+/**
+ * Returns the keydown handler that handles submit by Enter in text fields.
+ *
+ * The Enter press acts as submit unless the Shift key is pressed or the text
+ * cursor is at the end of text and the text ends with space. The space+Enter
+ * pattern allows mobile users (that cannot use Shift) to insert soft returns to
+ * text.
+ *
+ * @param {Function} submitFn submit action function
+ */
+export function submitByEnter(submitFn) {
+  return function(event) {
+    if (event.keyCode !== KEY_RETURN || event.shiftKey) {
+      return;
+    }
+
+    const { target } = event;
+    if (target.selectionStart === target.value.length && / $/.test(target.value)) {
+      // Trim the extra spaces before new line
+      target.value = target.value.replace(/ +$/, '');
+      return;
+    }
+
+    event.preventDefault();
+    submitFn(event);
+  };
+}


### PR DESCRIPTION
Now the Enter press acts as submit unless the Shift key is pressed OR the text cursor is at the end of text and the text ends with space.

The space+Enter pattern allows mobile users (that cannot use Shift) to insert soft returns to text.