### PR TITLE
Scroll-compensation debugging and fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "classnames": "2.2.x",
     "custom-event": "1.0.x",
     "date-fns": "~2.9.0",
+    "debug": "~4.1.1",
     "filesize": "~6.0.1",
     "final-form": "~4.18.7",
     "highcharts": "~7.2.1",

--- a/src/services/realtime.js
+++ b/src/services/realtime.js
@@ -38,17 +38,17 @@ export const scrollCompensator = (dispatchAction) => (...actionParams) => {
         scrollBy(0, heightOffset);
       }
     });
-  }
+  } else {
+    const topAfter = nearestTop.getBoundingClientRect().top;
+    const heightAfter = document.body.offsetHeight;
 
-  const topAfter = nearestTop.getBoundingClientRect().top;
-  const heightAfter = document.body.offsetHeight;
-
-  if (topAfter !== topBefore) {
-    const heightOffset = heightAfter - heightBefore;
-    scrollDebug('Action changed height. Compensating', {
-      offset: heightOffset,
-    });
-    scrollBy(0, heightOffset);
+    if (topAfter !== topBefore) {
+      const heightOffset = heightAfter - heightBefore;
+      scrollDebug('Action changed height. Compensating', {
+        offset: heightOffset,
+      });
+      scrollBy(0, heightOffset);
+    }
   }
 
   return res;

--- a/src/services/realtime.js
+++ b/src/services/realtime.js
@@ -1,12 +1,14 @@
 /* global CONFIG */
+import createDebug from 'debug';
 import io from 'socket.io-client';
 
 import { getToken } from './auth';
 
 const dummyPost = { getBoundingClientRect: () => ({ top: 0 }) };
 
+const scrollDebug = createDebug('freefeed:react:realtime:scrollCompensator');
 export const scrollCompensator = (dispatchAction) => (...actionParams) => {
-  //we hope that markup will remain the same — best tradeoff between this and code all over components
+  // we hope that markup will remain the same — best tradeoff between this and code all over components
   const postCommentNodes = [...document.querySelectorAll('.post, .comment')];
 
   const [firstVisible] = postCommentNodes.filter(
@@ -20,7 +22,7 @@ export const scrollCompensator = (dispatchAction) => (...actionParams) => {
   const topBefore = nearestTop.getBoundingClientRect().top;
   const heightBefore = document.body.offsetHeight;
 
-  //here we're dispatching, so render is called internally and after call we have new page
+  // here we're dispatching, so render is called internally and after call we have new page
   const res = dispatchAction(...actionParams);
 
   if (res.then) {
@@ -29,7 +31,11 @@ export const scrollCompensator = (dispatchAction) => (...actionParams) => {
       const heightAfter = document.body.offsetHeight;
 
       if (topAfter !== topBefore) {
-        scrollBy(0, heightAfter - heightBefore);
+        const heightOffset = heightAfter - heightBefore;
+        scrollDebug('Asynchronous action changed height. Compensating', {
+          offset: heightOffset,
+        });
+        scrollBy(0, heightOffset);
       }
     });
   }
@@ -38,8 +44,13 @@ export const scrollCompensator = (dispatchAction) => (...actionParams) => {
   const heightAfter = document.body.offsetHeight;
 
   if (topAfter !== topBefore) {
-    scrollBy(0, heightAfter - heightBefore);
+    const heightOffset = heightAfter - heightBefore;
+    scrollDebug('Action changed height. Compensating', {
+      offset: heightOffset,
+    });
+    scrollBy(0, heightOffset);
   }
+
   return res;
 };
 

--- a/src/services/realtime.js
+++ b/src/services/realtime.js
@@ -56,13 +56,15 @@ export const scrollCompensator = (dispatchAction) => (...actionParams) => {
   return res;
 };
 
+const socketDebug = createDebug('freefeed:react:realtime:socket');
 const bindSocketLog = (socket) => (eventName) =>
-  socket.on(eventName, (data) => console.log(`socket ${eventName}`, data)); // eslint-disable-line no-console
+  socket.on(eventName, (data) => socketDebug(`got event: ${eventName}`, data));
 
 const bindSocketActionsLog = (socket) => (events) => events.forEach(bindSocketLog(socket));
 
 const eventsToLog = ['connect', 'error', 'disconnect', 'reconnect'];
 
+const subscriptionDebug = createDebug('freefeed:react:realtime:subscriptions');
 export class Connection {
   socket;
 
@@ -87,14 +89,14 @@ export class Connection {
 
   async subscribeTo(...rooms) {
     if (this.socket.connected && rooms.length > 0) {
-      console.log('subscribing to', rooms); // eslint-disable-line no-console
+      subscriptionDebug('subscribing to', rooms);
       await this.socket.emitAsync('subscribe', roomsToHash(rooms));
     }
   }
 
   async unsubscribeFrom(...rooms) {
     if (this.socket.connected && rooms.length > 0) {
-      console.log('unsubscribing from', rooms); // eslint-disable-line no-console
+      subscriptionDebug('unsubscribing from', rooms);
       await this.socket.emitAsync('unsubscribe', roomsToHash(rooms));
     }
   }

--- a/src/services/realtime.js
+++ b/src/services/realtime.js
@@ -23,10 +23,10 @@ export const scrollCompensator = (dispatchAction) => (...actionParams) => {
   const heightBefore = document.body.offsetHeight;
 
   // here we're dispatching, so render is called internally and after call we have new page
-  const res = dispatchAction(...actionParams);
+  let res = dispatchAction(...actionParams);
 
   if (res.then) {
-    res.then(() => {
+    res = res.then((actionResult) => {
       const topAfter = nearestTop.getBoundingClientRect().top;
       const heightAfter = document.body.offsetHeight;
 
@@ -37,6 +37,8 @@ export const scrollCompensator = (dispatchAction) => (...actionParams) => {
         });
         scrollBy(0, heightOffset);
       }
+
+      return actionResult;
     });
   } else {
     const topAfter = nearestTop.getBoundingClientRect().top;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2971,7 +2971,7 @@ debug@3.2.6, debug@^3.0.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0, debug@~4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==


### PR DESCRIPTION
Added simple debug-logging of scroll-compensation actions and a fix for a problem I saw after that:

We have 2 scroll-compensation actions. One regular and one for asynchronous actions. The problem is, that "regular" compensation was used for async actions too