### PR TITLE
Add a general scroll compensating algorithm

### DIFF
--- a/src/components/link-preview/scroll-helpers/scroll-compensator.jsx
+++ b/src/components/link-preview/scroll-helpers/scroll-compensator.jsx
@@ -21,24 +21,6 @@ export default class ScrollCompensator extends React.Component {
       return;
     }
 
-    const halfScreen = Math.round(document.documentElement.clientHeight / 2);
-    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-
-    if (scrollTop > halfScreen / 2) {
-      // if user scrolled more than 1/4 screen from site top
-      const top = Math.round(this.root.getBoundingClientRect().top);
-      let scroll = 0;
-      if (top > halfScreen) {
-        // nope
-      } else if (top + this.prevHeight < halfScreen) {
-        scroll = newHeight - this.prevHeight;
-      } else {
-        // content in the center of the screen must not move
-        scroll = Math.round((newHeight * (halfScreen - top)) / this.prevHeight);
-      }
-      scrollBy(0, scroll);
-    }
-
     this.prevHeight = newHeight;
   };
 

--- a/src/components/post-comment.jsx
+++ b/src/components/post-comment.jsx
@@ -9,6 +9,7 @@ import { READMORE_STYLE_COMPACT, COMMENT_DELETED } from '../utils/frontend-prefe
 import { commentReadmoreConfig } from '../utils/readmore-config';
 import { defaultCommentState } from '../redux/reducers/comment-edit';
 
+import { safeScrollTo } from '../services/unscroll';
 import PieceOfText from './piece-of-text';
 import Expandable from './expandable';
 import UserName from './user-name';
@@ -34,7 +35,7 @@ class PostComment extends React.Component {
       const middleScreenPosition =
         window.pageYOffset + (rect.top + rect.bottom) / 2 - window.innerHeight / 2;
       if (rect.top < 0 || rect.bottom > window.innerHeight) {
-        window.scrollTo(0, middleScreenPosition);
+        safeScrollTo(0, middleScreenPosition);
       }
     }
   };

--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router';
 
 import { faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { preventDefault } from '../utils';
+import { safeScrollBy } from '../services/unscroll';
 import PostComment from './post-comment';
 import MoreCommentsWrapper from './more-comments-wrapper';
 import ErrorBoundary from './error-boundary';
@@ -131,7 +132,7 @@ export default class PostComments extends React.Component {
       const linkEl = this.rootEl.current.querySelector('.more-comments-wrapper');
       const top = linkEl.getBoundingClientRect().top - 8;
       if (top < 0) {
-        window.scrollBy(0, top);
+        safeScrollBy(0, top);
       }
     }
   }

--- a/src/components/post-hides-ui.jsx
+++ b/src/components/post-hides-ui.jsx
@@ -4,6 +4,7 @@ import { intersection } from 'lodash';
 import { faTimes, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { unhidePost, hideByName, removeRecentlyHiddenPost } from '../redux/action-creators';
 import { initialAsyncState } from '../redux/async-helpers';
+import { safeScrollBy } from '../services/unscroll';
 import { Icon } from './fontawesome-icons';
 import { Throbber } from './throbber';
 
@@ -23,7 +24,7 @@ export function PostRecentlyHidden({ id, initialTopOffset, isHidden, recipientNa
       return;
     }
     const firstLineOffset = firstLine.current.getBoundingClientRect().top;
-    window.scrollBy(0, firstLineOffset - initialTopOffset);
+    safeScrollBy(0, firstLineOffset - initialTopOffset);
   }, [initialTopOffset]);
 
   const oneHiddenName = intersection(recipientNames, hiddenUserNames).length === 1;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -40,6 +40,7 @@ if (store.getState().authenticated) {
 }
 
 import { bindRouteActions } from './redux/route-actions';
+import { initUnscroll, safeScrollTo } from './services/unscroll';
 
 // Set initial history state.
 // Without this, there can be problems with third-party
@@ -83,7 +84,7 @@ const enterStaticPage = (title) => () => {
   store.dispatch(ActionCreators.staticPage(title));
 };
 
-history.listen(() => scrollTo(0, 0));
+history.listen(() => safeScrollTo(0, 0));
 
 const generateRouteHooks = (callback) => ({
   onEnter: callback,
@@ -110,6 +111,8 @@ function InitialLayout({ children }) {
     </div>
   );
 }
+
+initUnscroll();
 
 function App() {
   const initialized = useSelector((state) => state.initialized);

--- a/src/redux/configure-store.js
+++ b/src/redux/configure-store.js
@@ -18,6 +18,7 @@ import {
   dataFixMiddleware,
   appearanceMiddleware,
   initialWhoamiMiddleware,
+  unscrollMiddleware,
 } from './middlewares';
 
 import * as reducers from './reducers';
@@ -25,6 +26,7 @@ import * as ActionCreators from './action-creators';
 
 //order matters — we need to stop unauthed async fetching before request, see authMiddleware
 const middleware = [
+  unscrollMiddleware,
   feedViewOptionsMiddleware,
   authMiddleware,
   apiMiddleware,

--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 
 import { getPost } from '../services/api';
 import { setToken } from '../services/auth';
-import { Connection, scrollCompensator } from '../services/realtime';
+import { Connection } from '../services/realtime';
 import { delay } from '../utils';
 import * as FeedOptions from '../utils/feed-options';
 
@@ -631,13 +631,7 @@ const bindHandlers = (store) => ({
 });
 
 export const realtimeMiddleware = (store) => {
-  const handlers = bindHandlers(store);
-
-  for (const key of Object.keys(handlers)) {
-    handlers[key] = scrollCompensator(handlers[key]);
-  }
-
-  return createRealtimeMiddleware(store, new Connection(), handlers);
+  return createRealtimeMiddleware(store, new Connection(), bindHandlers(store));
 };
 
 export const createRealtimeMiddleware = (store, conn, eventHandlers) => {

--- a/src/services/unscroll.js
+++ b/src/services/unscroll.js
@@ -25,12 +25,13 @@ export function initUnscroll() {
   window.addEventListener('touchstart', userInteraction.trigger);
   window.addEventListener('touchend', userInteraction.trigger);
 
-  new MutationObserver(unscroll).observe(document.getElementById('app'), {
-    subtree: true,
-    childList: true,
-    characterData: true,
-    attributes: true,
-  });
+  window.MutationObserver &&
+    new window.MutationObserver(unscroll).observe(document.getElementById('app'), {
+      subtree: true,
+      childList: true,
+      characterData: true,
+      attributes: true,
+    });
 }
 
 const pinnedSelectors = [

--- a/src/services/unscroll.js
+++ b/src/services/unscroll.js
@@ -1,0 +1,118 @@
+import createDebug from 'debug';
+import { EventsSequence, CombinedEventsSequences, FINISH, START } from '../utils/event-sequences';
+
+const unscrollDebug = createDebug('freefeed:react:unscroll');
+
+// TODO: reset scroll position on navigation events
+
+export const scrolling = new EventsSequence(200);
+const userInteraction = new EventsSequence(500);
+export const scrollingOrInteraction = new CombinedEventsSequences(scrolling, userInteraction);
+
+scrolling.on(START, () => unscrollDebug('Scrolling started'));
+scrolling.on(FINISH, () => unscrollDebug('Scrolling finished'));
+
+export function initUnscroll() {
+  window.addEventListener('scroll', scrolling.trigger);
+  window.addEventListener('resize', scrolling.trigger);
+  window.addEventListener('focusin', scrolling.trigger);
+  window.addEventListener('focusout', scrolling.trigger);
+
+  window.addEventListener('mousemove', userInteraction.trigger);
+  window.addEventListener('mousedown', userInteraction.trigger);
+  window.addEventListener('mouseup', userInteraction.trigger);
+  window.addEventListener('touchmove', userInteraction.trigger);
+  window.addEventListener('touchstart', userInteraction.trigger);
+  window.addEventListener('touchend', userInteraction.trigger);
+
+  new MutationObserver(unscroll).observe(document.getElementById('app'), {
+    subtree: true,
+    childList: true,
+    characterData: true,
+    attributes: true,
+  });
+}
+
+const pinnedSelectors = [
+  '.post-header',
+  '.post-text',
+  '.post-footer',
+  '.post-likes',
+  '.attachments',
+  '.link-preview',
+  '.comment',
+].join(',');
+
+const inputElements = ['INPUT', 'TEXTAREA', 'SELECT'];
+
+const maxPinDepth = 4;
+let pinnedElements = [];
+
+scrolling.on(START, () => (pinnedElements = []));
+scrolling.on(FINISH, () => {
+  pinnedElements = [];
+  const { activeElement } = document;
+  if (
+    activeElement !== document.body &&
+    inputElements.includes(activeElement.tagName) &&
+    isInViewport(activeElement)
+  ) {
+    const { top } = activeElement.getBoundingClientRect();
+    pinnedElements.push({ node: activeElement, top });
+    unscrollDebug('Pinned input:', activeElement);
+    return;
+  }
+
+  const nodes = document.querySelectorAll(pinnedSelectors);
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    const { top, bottom } = node.getBoundingClientRect();
+    if (bottom > 0) {
+      pinnedElements.push({ node, top });
+      unscrollDebug('Pinned element:', node);
+      let p = node.parentElement;
+      while (p && pinnedElements.length < maxPinDepth) {
+        const { top } = p.getBoundingClientRect();
+        pinnedElements.push({ node: p, top });
+        p = p.parentElement;
+      }
+      break;
+    }
+  }
+});
+
+export function safeScrollTo(x, y) {
+  scrolling.trigger();
+  window.scrollTo(x, y);
+}
+
+export function safeScrollBy(x, y) {
+  scrolling.trigger();
+  window.scrollBy(x, y);
+}
+
+export function unscroll() {
+  if (scrolling.active) {
+    return;
+  }
+  const pinned = pinnedElements.find((p) => p.node.isConnected);
+  if (!pinned) {
+    return;
+  }
+  const { top } = pinned.node.getBoundingClientRect();
+  if (top !== pinned.top) {
+    unscrollDebug(`⚡ Compensating by ${top - pinned.top}px`);
+    window.scrollBy(0, top - pinned.top);
+  }
+}
+
+function isInViewport(el) {
+  const rect = el.getBoundingClientRect();
+
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+  );
+}

--- a/src/utils/event-sequences.js
+++ b/src/utils/event-sequences.js
@@ -1,0 +1,54 @@
+import EventEmitter from 'events';
+
+export const START = Symbol('START');
+export const FINISH = Symbol('FINISH');
+
+/**
+ * Collects the sequence of events (triggered by trigger()) during the given
+ * interval and emits START and FINISH events before and after the sequence.
+ */
+export class EventsSequence extends EventEmitter {
+  active = false;
+
+  _interval = 0;
+  _timer = null;
+
+  constructor(interval) {
+    super();
+    this._interval = interval;
+  }
+
+  trigger = () => {
+    if (!this.active) {
+      this.emit(START);
+      this.active = true;
+    }
+    clearTimeout(this._timer);
+    this._timer = setTimeout(this._finish, this._interval);
+  };
+
+  _finish = () => {
+    this.active = false;
+    this.emit(FINISH);
+  };
+}
+
+export class CombinedEventsSequences extends EventEmitter {
+  sources;
+
+  constructor(...sources) {
+    super();
+    this.sources = sources;
+    for (const source of sources) {
+      source.on(FINISH, this._srcFinish);
+      source.on(START, this._srcStart);
+    }
+  }
+
+  get active() {
+    return this.sources.some((s) => s.active);
+  }
+
+  _srcFinish = () => this.active || this.emit(FINISH);
+  _srcStart = () => !this.active || this.emit(START);
+}


### PR DESCRIPTION
After any scroll/resize/focus event sequence the page remembers ('pins') the focused input node or the node at the top of the screen. On every page update (controlling by MutationObserver and by special middleware) the position of pinned node is checking and compensating in case of change.

The realtime events are delaying until scroll or user interaction is finished.