### PR TITLE
Add an endOfLine = auto Prettier rule

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,5 +7,6 @@
   "useTabs": false,
   "bracketSpacing": true,
   "jsxBracketSameLine": false,
-  "arrowParens": "always"
+  "arrowParens": "always",
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
We already use the configurable EOL type checking with Eslint. The Prettier has the "LF" default since 2.0 and it overrides the Eslint rule on Windows.