### PR TITLE
Rethink how RT events await user inactivity

### DIFF
--- a/src/services/unscroll.js
+++ b/src/services/unscroll.js
@@ -3,8 +3,6 @@ import { EventsSequence, CombinedEventsSequences, FINISH, START } from '../utils
 
 const unscrollDebug = createDebug('freefeed:react:unscroll');
 
-// TODO: reset scroll position on navigation events
-
 export const scrolling = new EventsSequence(200);
 const userInteraction = new EventsSequence(500);
 export const scrollingOrInteraction = new CombinedEventsSequences(scrolling, userInteraction);

--- a/src/utils/event-sequences.js
+++ b/src/utils/event-sequences.js
@@ -49,6 +49,17 @@ export class CombinedEventsSequences extends EventEmitter {
     return this.sources.some((s) => s.active);
   }
 
-  _srcFinish = () => this.active || this.emit(FINISH);
-  _srcStart = () => !this.active || this.emit(START);
+  _srcFinish = () => !this.active && this.emit(FINISH);
+  _srcStart = () => !this.active && this.emit(START);
+}
+
+/**
+ * Returns promise that resolves when the EventSequence became inactive
+ *
+ * @return {Promise<void>}
+ */
+export function inactivityOf(eventsSequence) {
+  return eventsSequence.active
+    ? new Promise((resolve) => eventsSequence.once(FINISH, resolve))
+    : Promise.resolve();
 }


### PR DESCRIPTION
The previous algorithm could sometimes cause infinity loop.

Bug report: https://freefeed.net/support/655cab4a-d129-4d82-b5ed-8235f9b3468f
