### PR TITLE
Repeat attempts to load chunks up to 5 times

### DIFF
--- a/src/components/lazy-component.jsx
+++ b/src/components/lazy-component.jsx
@@ -1,10 +1,11 @@
 import React, { Suspense, useState, useEffect, useMemo } from 'react';
+import { lazyRetry } from '../utils/retry-promise';
 import ErrorBoundary from './error-boundary';
 
 export const lazyComponent = (loader, { fallback, errorMessage, delay }) => (props) => {
   // No deps: loader can depends only on the initial props
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const Lazy = useMemo(() => React.lazy(() => loader(props)), []);
+  const Lazy = useMemo(() => lazyRetry(() => loader(props)), []);
   return (
     <ErrorBoundary message={errorMessage}>
       <Suspense fallback={<Delayed>{fallback}</Delayed>} delay={delay}>

--- a/src/components/settings/app-tokens/routes.jsx
+++ b/src/components/settings/app-tokens/routes.jsx
@@ -1,10 +1,11 @@
-import React, { lazy } from 'react';
+import React from 'react';
 import { Route, IndexRoute } from 'react-router';
+import { lazyRetry } from '../../../utils/retry-promise';
 
-const tokensPage = lazy(() => import('./tokens'));
-const createTokenPage = lazy(() => import('./create-token'));
-const createLinkPage = lazy(() => import('./create-link'));
-const scopesPage = lazy(() => import('./scopes-list'));
+const tokensPage = lazyRetry(() => import('./tokens'));
+const createTokenPage = lazyRetry(() => import('./create-token'));
+const createLinkPage = lazyRetry(() => import('./create-link'));
+const scopesPage = lazyRetry(() => import('./scopes-list'));
 
 export function tokensRoute(rootPath) {
   return (

--- a/src/components/settings/routes.jsx
+++ b/src/components/settings/routes.jsx
@@ -1,14 +1,15 @@
-import React, { lazy } from 'react';
+import React from 'react';
 import { IndexRoute, Route } from 'react-router';
 
+import { lazyRetry } from '../../utils/retry-promise';
 import { tokensRoute } from './app-tokens/routes';
 
-const Layout = lazy(() => import('./layout'));
-const ProfilePage = lazy(() => import('./profile'));
-const SignInPage = lazy(() => import('./sign-in'));
-const AppearancePage = lazy(() => import('./appearance'));
-const PrivacyPage = lazy(() => import('./privacy'));
-const NotificationsPage = lazy(() => import('./notififications'));
+const Layout = lazyRetry(() => import('./layout'));
+const ProfilePage = lazyRetry(() => import('./profile'));
+const SignInPage = lazyRetry(() => import('./sign-in'));
+const AppearancePage = lazyRetry(() => import('./appearance'));
+const PrivacyPage = lazyRetry(() => import('./privacy'));
+const NotificationsPage = lazyRetry(() => import('./notififications'));
 
 export function settingsRoute(rootPath) {
   return (

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -42,6 +42,7 @@ if (store.getState().authenticated) {
 
 import { bindRouteActions } from './redux/route-actions';
 import { initUnscroll, safeScrollTo } from './services/unscroll';
+import { lazyRetry } from './utils/retry-promise';
 
 // Set initial history state.
 // Without this, there can be problems with third-party
@@ -94,7 +95,7 @@ const generateRouteHooks = (callback) => ({
 
 // For some reason, the import() argument must have an explicit string type.
 // See https://github.com/webpack/webpack/issues/4921#issuecomment-357147299
-const lazyLoad = (path) => React.lazy(() => import(`${path}`));
+const lazyLoad = (path) => lazyRetry(() => import(`${path}`));
 
 function InitialLayout({ children }) {
   return (

--- a/src/utils/retry-promise.js
+++ b/src/utils/retry-promise.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import createDebug from 'debug';
+
+const debug = createDebug('freefeed:react:retryPromise');
+
+/**
+ * Returns function that retries the given function until it succeeds or throws
+ * error after the maxAttempts attempts.
+ *
+ * @param {()=>Promise<T>} fn
+ * @param {number} maxAttempts
+ * @param {number} interval
+ * @returns {()=>Promise<T>}
+ */
+export function retry(fn, maxAttempts = 5, interval = 1000) {
+  return async function () {
+    try {
+      return await fn();
+    } catch (err) {
+      debug('error happened while retrying:', err);
+      if (maxAttempts > 1) {
+        await new Promise((resolve) => setTimeout(resolve, interval));
+        return await retry(fn, maxAttempts - 1, interval)();
+      }
+      throw err;
+    }
+  };
+}
+
+/**
+ * Use React.lazy with retry
+ *
+ * @param {()=>Promise} fn
+ */
+export function lazyRetry(fn) {
+  return React.lazy(retry(fn));
+}

--- a/test/unit/utils/retry-promise.js
+++ b/test/unit/utils/retry-promise.js
@@ -1,0 +1,54 @@
+import { describe, it, before, after } from 'mocha';
+import unexpected from 'unexpected';
+import unexpectedSinon from 'unexpected-sinon';
+import sinon from 'sinon';
+
+import { retry as retryIt } from '../../../src/utils/retry-promise';
+
+const expect = unexpected.clone();
+expect.use(unexpectedSinon);
+
+// Fixing the retry function arguments
+const retry = (fn) => retryIt(fn, 5, 1000);
+
+describe('retry', () => {
+  let clock;
+  before(() => (clock = sinon.useFakeTimers()));
+  after(() => clock.restore());
+
+  it('should return first result if function succeeds', async () => {
+    const fn = sinon.stub().returns(Promise.resolve(42));
+    const retryFn = retry(fn);
+    const result = await retryFn();
+    expect(result, 'to be', 42);
+    expect(fn, 'was called once');
+  });
+
+  it('should return result if function succeeds at second call', async () => {
+    let i = 0;
+    const fn = sinon.spy(async () => {
+      if (i === 0) {
+        i++;
+        throw new Error('some error');
+      }
+      return 42;
+    });
+    const retryFn = retry(fn);
+    const start = Date.now();
+    const [result] = await Promise.all([retryFn(), clock.runAllAsync()]);
+    expect(result, 'to be', 42);
+    expect(fn, 'was called twice');
+    expect(Date.now() - start, 'to be', 1000);
+  });
+
+  it('should throw error after all unsuccessful calls', async () => {
+    const fn = sinon.stub().returns(Promise.reject(new Error('some error')));
+    const retryFn = retry(fn);
+
+    const start = Date.now();
+    const test = Promise.all([retryFn(), clock.runAllAsync()]);
+    await expect(test, 'to be rejected with', 'some error');
+    expect(fn, 'was called times', 5);
+    expect(Date.now() - start, 'to be', 4000);
+  });
+});


### PR DESCRIPTION
Sometimes because of internet connection problems the code-splitting chunks are failed to load with ChunkLoadError.

Now the React.lazy will repeat attemts to load chunks up to 5 times with 1s interval and will fail only if all atempts was unsuccessful.