### PR TITLE
Make image attachments background (in preview and lightbox) white

### DIFF
--- a/styles/shared/attachments.scss
+++ b/styles/shared/attachments.scss
@@ -42,6 +42,7 @@
   .image-attachment-img {
     max-width: 525px;
     max-height: 175px;
+    background-color: #fff;
     @media (max-width: 560px) {
       max-width: 100%;
       height: auto;
@@ -120,10 +121,10 @@
       content: '\f137';
     }
   }
+}
 
-  .pswp__img {
-    background-color: #fff;
-  }
+.pswp__img {
+  background-color: #fff;
 }
 
 .sortable-images .image-attachment-link {


### PR DESCRIPTION
It affects images with transparency: most of them designed to look better on a white background.

The lightbox background already was white but apparently the layout was change and this style stop workig.