### PR TITLE
Update the social-text-tokenizer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-textarea-autosize": "~7.1.2",
     "redux": "~4.0.5",
     "snarkdown": "~1.2.2",
-    "social-text-tokenizer": "~2.1.0",
+    "social-text-tokenizer": "~2.1.1",
     "socket.io-client": "~2.3.0",
     "sortablejs": "~1.10.2",
     "use-subscription": "~1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9134,10 +9134,10 @@ snarkdown@~1.2.2:
   resolved "https://registry.yarnpkg.com/snarkdown/-/snarkdown-1.2.2.tgz#0cfe2f3012b804de120fc0c9f7791e869c59cc74"
   integrity sha1-DP4vMBK4BN4SD8DJ93kehpxZzHQ=
 
-social-text-tokenizer@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/social-text-tokenizer/-/social-text-tokenizer-2.1.0.tgz#9c5de6889ae55aa9814d8ec1253960093d72ea7c"
-  integrity sha512-ZtBgbPa7NBJXR2fqgBMwHgkqcInhbuJ1AmHIrzjjkf6lcxojZqAFZnaEqr50iFlFKTkorExd++AvYK+u8SHS0w==
+social-text-tokenizer@~2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/social-text-tokenizer/-/social-text-tokenizer-2.1.1.tgz#598c69ead68f125e810675b2ca97e19879f5b3d5"
+  integrity sha512-wUgN76V4K2s684NEaUm1SFlggKzkYh+rxfTz94MJ6RNMExlmX3d9IHANZIX4QHIo+RLoZi0npi3q95d2OCliag==
   dependencies:
     lodash.escaperegexp "^4.1.2"
     punycode "^2.1.1"


### PR DESCRIPTION
It now correctly parses links with double quotes. Bug report https://freefeed.net/squadette/b0416474-1363-4633-b6f6-9dae9a352f87