### PR TITLE
Add loading="lazy" attribute to image attachments and posts avatars

### DIFF
--- a/src/components/post-attachment-image.jsx
+++ b/src/components/post-attachment-image.jsx
@@ -34,6 +34,7 @@ class PostAttachmentImage extends React.PureComponent {
       src: (props.imageSizes.t && props.imageSizes.t.url) || props.thumbnailUrl,
       srcSet,
       alt: nameAndSize,
+      loading: 'lazy',
       width: props.imageSizes.t
         ? props.imageSizes.t.w
         : props.imageSizes.o

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -438,6 +438,7 @@ class Post extends React.Component {
                   src={profilePicture}
                   width={profilePictureSize}
                   height={profilePictureSize}
+                  loading="lazy"
                 />
               </Link>
             </div>


### PR DESCRIPTION
This is especially useful in picture-rich groups like ggg or gifzz