### PR TITLE
Remove logotype click handler

### DIFF
--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -42,13 +42,6 @@ const InternalLayout = ({ authenticated, children }) => (
   </div>
 );
 
-const logoHandler = (routeName, cb) => () => {
-  if (routeName === 'home') {
-    return cb();
-  }
-  return false;
-};
-
 class Layout extends React.Component {
   // Here we have some handling of drag-n-drop, because standard dragenter
   // and dragleave events suck. Current implementation is using ideas from
@@ -156,11 +149,7 @@ class Layout extends React.Component {
           <header className="row">
             <div className="col-xs-9 col-sm-4 col-md-4">
               <h1 className="site-logo">
-                <IndexLink
-                  className="site-logo-link"
-                  to="/"
-                  onClick={logoHandler(props.routeName, props.home)}
-                >
+                <IndexLink className="site-logo-link" to="/">
                   {CONFIG.siteTitle}
                 </IndexLink>
               </h1>


### PR DESCRIPTION
Fixes #1154. Probably the removed handler was doing something good on the older react-router, but now it is useless and causes the #1154 bug.