### PR TITLE
Fix list editor styles for narrow screens

### DIFF
--- a/src/components/friends-page/list-editor.module.scss
+++ b/src/components/friends-page/list-editor.module.scss
@@ -7,6 +7,10 @@
   width: 900px;
   max-width: 100%;
   padding: 1em;
+
+  @media (max-width: 600px) {
+    margin-top: 2em;
+  }
 }
 
 .header {
@@ -24,7 +28,7 @@
 
 .content {
   flex: 1;
-  height: 60vh;
+  height: 50vh;
   overflow: auto;
   border-top: 1px solid #ccc;
   border-bottom: 1px solid #ccc;


### PR DESCRIPTION
The Close (x) button should not overlay the title input