### PR TITLE
Check if user statistics exists when show it in user profile

### DIFF
--- a/src/components/user-profile-head.jsx
+++ b/src/components/user-profile-head.jsx
@@ -462,7 +462,7 @@ export const UserProfileHead = withRouter(
           </>
         )}
         <div className={styles.stats}>
-          {!user.isGone && (
+          {!user.isGone && user.statistics && (
             <ul className={styles.statsItems}>
               {user.type === 'user' && (
                 <StatLink


### PR DESCRIPTION
It is possible that the user stats isn't yet loaded on initial render.

Bug report: https://freefeed.net/support/27a98ce2-2a55-4ec3-b2c6-f9aa81012597