### PR TITLE
Correct style of long sidebar headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- The sidebar block headers can be multiline now. It is useful for long variable phrases like “Memories of September 30”. Also, we prevent linebreaks between month and day in the Memories header.

--- a/src/components/sidebar.jsx
+++ b/src/components/sidebar.jsx
@@ -177,7 +177,7 @@ const SideBarMemories = () => {
   ));
   return (
     <div className="box">
-      <div className="box-header-memories">Memories of {format(today, 'MMMM d')}</div>
+      <div className="box-header-memories">Memories of {format(today, 'MMMM\u00A0d')}</div>
       <div className="box-body">
         <div className="year-links-row">{yearLinks}</div>
       </div>

--- a/styles/helvetica/boxes.scss
+++ b/styles/helvetica/boxes.scss
@@ -7,7 +7,7 @@
 // --- Block headers ---
 .box-header {
   line-height: 28px;
-  height: 28px;
+  min-height: 28px;
   border-bottom: 2px black solid;
   color: #000;
 }


### PR DESCRIPTION
The sidebar block headers can be multiline now. It is useful for long variable phrases like “Memories of September 30”. Also, we prevent linebreaks between month and day in the Memories header.

Bug report: https://freefeed.net/support/107453d6-e3fb-4c2d-adfa-f24a0c93358e