### PR TITLE
Several improvements of links preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SoundCloud links previews
 
+### Fixed
+
+- Links to the images hosted on Dropbox are now correctly displayed in a lightbox
+
 ## [1.86.0] - 2020-09-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- SoundCloud links previews
+
 ## [1.86.0] - 2020-09-15
 
 ### Changed

--- a/src/components/link-preview/preview.js
+++ b/src/components/link-preview/preview.js
@@ -9,6 +9,7 @@ import YandexMusicPreview, { canShowURL as yandexMusicCanShowURL } from './yande
 import WikipediaPreview, { canShowURL as wikipediaCanShowURL } from './wikipedia';
 import TelegramPreview, { canShowURL as telegramCanShowURL } from './telegram';
 import TikTokPreview, { canShowURL as tikTokCanShowURL } from './tiktok';
+import SoundCloudPreview, { canShowURL as soundCloudCanShowURL } from './soundcloud';
 import EmbedlyPreview from './embedly';
 
 export default function LinkPreview({ allowEmbedly, url }) {
@@ -31,6 +32,8 @@ export default function LinkPreview({ allowEmbedly, url }) {
     return <TelegramPreview url={url} />;
   } else if (tikTokCanShowURL(url)) {
     return <TikTokPreview url={url} />;
+  } else if (soundCloudCanShowURL(url)) {
+    return <SoundCloudPreview url={url} />;
   }
 
   if (allowEmbedly) {

--- a/src/components/link-preview/soundcloud.jsx
+++ b/src/components/link-preview/soundcloud.jsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import cachedFetch from './cached-fetch';
+
+const SOUNDCLOUD_SONG_RE = /^https:\/\/soundcloud\.com\/([^/]+)\/([^/]+)$/;
+const SOUNDCLOUD_AUTHOR_RE = /^https:\/\/soundcloud\.com\/([^/]+)$/;
+
+const SOUNDCLOUD_TRACK_RE = /api\.soundcloud\.com%2Ftracks%2F(\d+)/;
+const SOUNDCLOUD_USER_RE = /api\.soundcloud\.com%2Fusers%2F(\d+)/;
+
+export function canShowURL(url) {
+  return SOUNDCLOUD_SONG_RE.test(url) || SOUNDCLOUD_AUTHOR_RE.test(url);
+}
+
+export default function SoundCloudPreview({ url }) {
+  const [playerUrl, setPlayerUrl] = useState(null);
+  const [byline, setByline] = useState(null);
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    cachedFetch(`https://soundcloud.com/oembed?url=${encodeURIComponent(url)}&format=json`).then(
+      (data) => {
+        if (!data.title || !data.html) {
+          setIsError(true);
+        }
+
+        setByline(data.title);
+        if (SOUNDCLOUD_TRACK_RE.test(data.html)) {
+          const [, id] = SOUNDCLOUD_TRACK_RE.exec(data.html);
+          setPlayerUrl(`https://api.soundcloud.com/tracks/${id}`);
+        } else if (SOUNDCLOUD_USER_RE.test(data.html)) {
+          const [, id] = SOUNDCLOUD_USER_RE.exec(data.html);
+          setPlayerUrl(`https://api.soundcloud.com/users/${id}`);
+        }
+      },
+    );
+  }, [url]);
+
+  if (!playerUrl && !isError) {
+    return <p>Loading...</p>;
+  }
+
+  if (isError) {
+    return null;
+  }
+
+  return (
+    <div className="soundcloud-preview link-preview-content">
+      <iframe
+        src={`${
+          'https://w.soundcloud.com/player/?' +
+          'auto_play=false&hide_related=true&show_comments=false&show_user=true&show_reposts=false&buying=false' +
+          '&url='
+        }${encodeURIComponent(playerUrl)}`}
+        frameBorder="0"
+        scrolling="no"
+        className="soundcloud-iframe"
+        style={{ width: '100%', maxWidth: '450px', height: '166px' }}
+      />
+      <div className="info">
+        <a href={url} target="_blank" title={byline}>
+          {byline} at SoundCloud
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/components/media-viewer.jsx
+++ b/src/components/media-viewer.jsx
@@ -94,6 +94,10 @@ const getEmbeddableItem = async (url, withoutAutoplay) => {
     }
 
     if (playerHTML) {
+      let text = info.byline;
+      if (text.length > 300) {
+        text = `${text.slice(0, 200)}\u2026`;
+      }
       return {
         html: playerHTML,
         w,
@@ -101,7 +105,7 @@ const getEmbeddableItem = async (url, withoutAutoplay) => {
         pid: 'video',
         title: renderToString(
           <a href={url} target="_blank">
-            {info.byline || url}
+            {text || url}
           </a>,
         ),
       };

--- a/src/components/post-attachment-image-lightbox.jsx
+++ b/src/components/post-attachment-image-lightbox.jsx
@@ -80,6 +80,9 @@ export default class ImageAttachmentsLightbox extends React.Component {
           item.h = (rect.height * item.w) / rect.width;
         }
       } else if (item.src) {
+        item.src = item.src
+          // Convert dropbox page URL to image URL
+          .replace('https://www.dropbox.com/s/', 'https://dl.dropboxusercontent.com/s/');
         // lets try to find out image size when image loads
         const image = new Image();
         item.w = 1;

--- a/src/components/post-attachment-image-lightbox.jsx
+++ b/src/components/post-attachment-image-lightbox.jsx
@@ -79,7 +79,7 @@ export default class ImageAttachmentsLightbox extends React.Component {
         if (rect.width > 0) {
           item.h = (rect.height * item.w) / rect.width;
         }
-      } else {
+      } else if (item.src) {
         // lets try to find out image size when image loads
         const image = new Image();
         item.w = 1;


### PR DESCRIPTION
- Cut the preview description text in the lightbox if it is too long ([bug report](https://freefeed.net/support/6dc96036-013c-4a20-a262-5ff37d147165))
- SoundCloud links previews
- Links to the images hosted on Dropbox are now correctly displayed in a lightbox ([bug report](https://freefeed.net/azalio/802cf370-38ac-428c-8af3-d1dc6d5f2667))

