### PR TITLE
Text formatter improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-textarea-autosize": "~8.2.0",
     "redux": "~4.0.5",
     "snarkdown": "~1.2.2",
-    "social-text-tokenizer": "~2.1.2",
+    "social-text-tokenizer": "~2.1.3",
     "socket.io-client": "~2.3.0",
     "use-subscription": "~1.4.1",
     "validator": "~13.1.1"

--- a/src/components/linkify.jsx
+++ b/src/components/linkify.jsx
@@ -90,7 +90,14 @@ export default class Linkify extends React.Component {
 
       if (token instanceof TLink) {
         if (token.isLocal) {
-          return linkEl(token.localURI, token.shorten(MAX_URL_LENGTH));
+          let m, text;
+          // Special shortening of post links
+          if ((m = /^[^/]+\/[\w-]+\/[0-9a-f]{8}-/.exec(token.pretty))) {
+            text = `${m[0]}\u2026`;
+          } else {
+            text = token.shorten(MAX_URL_LENGTH);
+          }
+          return linkEl(token.localURI, text);
         }
 
         if (token.href.match(FRIENDFEED_POST)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8979,14 +8979,14 @@ snarkdown@~1.2.2:
   resolved "https://registry.yarnpkg.com/snarkdown/-/snarkdown-1.2.2.tgz#0cfe2f3012b804de120fc0c9f7791e869c59cc74"
   integrity sha1-DP4vMBK4BN4SD8DJ93kehpxZzHQ=
 
-social-text-tokenizer@~2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/social-text-tokenizer/-/social-text-tokenizer-2.1.2.tgz#f60f049a9b70d094f01e7c428ba12ed0d417a0a9"
-  integrity sha512-WRhJI4CkMslPUuUXsKU/rDiEOSahM23iDnxTl5Loky7dSPBj2HBtPIvJ/TOnCxkiJX8vVFLRGAvqNbfzcYm8Fg==
+social-text-tokenizer@~2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/social-text-tokenizer/-/social-text-tokenizer-2.1.3.tgz#fa064a2e04f4d448944d928b301e4fdee3ee5070"
+  integrity sha512-ws4Xo1MPaAh21Jmr7oRUKMIiZ0XvZpdoupjGxGqS/SSfwuRVjBdC4zdxBy5Od1IxQo39XoL3ZQxApDylxLjDIQ==
   dependencies:
     lodash.escaperegexp "^4.1.2"
     punycode "^2.1.1"
-    tslib "^1.10.0"
+    tslib "^2.0.1"
 
 socket.io-client@~2.3.0:
   version "2.3.0"
@@ -9862,10 +9862,15 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
- Update the social-text-tokenizer version
- Cut the post links in texts after the first UUID octet block (like freefeed.net/username/818f2508-…, [feature request](https://freefeed.net/ffdev/5baa777d-5be3-4ac8-858f-6300ff5b4ffa)). 