### PR TITLE
Add support for Spotify links previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SoundCloud links previews
 - Support of [well-known URL for changing passwords](https://w3c.github.io/webappsec-change-password-url/)
+- Spotify links previews
 
 ### Fixed
 

--- a/src/components/link-preview/preview.js
+++ b/src/components/link-preview/preview.js
@@ -10,6 +10,7 @@ import WikipediaPreview, { canShowURL as wikipediaCanShowURL } from './wikipedia
 import TelegramPreview, { canShowURL as telegramCanShowURL } from './telegram';
 import TikTokPreview, { canShowURL as tikTokCanShowURL } from './tiktok';
 import SoundCloudPreview, { canShowURL as soundCloudCanShowURL } from './soundcloud';
+import SpotifyPreview, { canShowURL as spotifyCanShowURL } from './spotify';
 import EmbedlyPreview from './embedly';
 
 export default function LinkPreview({ allowEmbedly, url }) {
@@ -34,6 +35,8 @@ export default function LinkPreview({ allowEmbedly, url }) {
     return <TikTokPreview url={url} />;
   } else if (soundCloudCanShowURL(url)) {
     return <SoundCloudPreview url={url} />;
+  } else if (spotifyCanShowURL(url)) {
+    return <SpotifyPreview url={url} />;
   }
 
   if (allowEmbedly) {

--- a/src/components/link-preview/spotify.jsx
+++ b/src/components/link-preview/spotify.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+const PLAYLIST_RE = /https:\/\/open.spotify.com(?:\/user\/\d+)?\/playlist\/([^?]*)(\?.*)?$/;
+const TRACK_RE = /https:\/\/open.spotify.com\/track\/([^?]*)(\?.*)?$/;
+const ALBUM_RE = /https:\/\/open.spotify.com\/album\/([^?]*)(\?.*)?$/;
+const ARTIST_RE = /https:\/\/open.spotify.com\/artist\/([^?]*)(\?.*)?$/;
+const EMBED_RE = /https:\/\/open.spotify.com\/embed\/.*$/;
+
+export function canShowURL(url) {
+  return (
+    url.match(PLAYLIST_RE) ||
+    url.match(TRACK_RE) ||
+    url.match(ALBUM_RE) ||
+    url.match(ARTIST_RE) ||
+    url.match(EMBED_RE)
+  );
+}
+
+export default function SpotifyPreview({ url }) {
+  const embedUrl = do {
+    if (url.match(PLAYLIST_RE)) {
+      url.replace(PLAYLIST_RE, 'https://open.spotify.com/embed/playlist/$1');
+    } else if (url.match(TRACK_RE)) {
+      url.replace(TRACK_RE, 'https://open.spotify.com/embed/track/$1');
+    } else if (url.match(ALBUM_RE)) {
+      url.replace(ALBUM_RE, 'https://open.spotify.com/embed/album/$1');
+    } else if (url.match(ARTIST_RE)) {
+      url.replace(ARTIST_RE, 'https://open.spotify.com/embed/artist/$1');
+    } else if (url.match(EMBED_RE)) {
+      url;
+    } else {
+      return false;
+    }
+  };
+
+  return (
+    <div className="spotify-preview link-preview-content">
+      <iframe
+        src={embedUrl}
+        allow="encrypted-media"
+        frameBorder="0"
+        scrolling="no"
+        className="spotify-iframe"
+        style={{ width: '100%', maxWidth: '450px', height: '380px' }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
This changeset adds support for previewing Spotify links (tracks, albums, artists, playlists) using official embed-generator.

Spotify's oembed endpoint doesn't support CORS-headers, so it is not possible to show nice metadata (title, artwork, etc.)
