### PR TITLE
Support the new format of externalAuthProviders server-info key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Client now supports arbitrary list of external identity providers that are
+  available on the server.
+
+
 ## [1.87.1] - 2020-10-14
 
 ### Fixed

--- a/config/default.js
+++ b/config/default.js
@@ -14,11 +14,6 @@ export default {
   auth: {
     tokenPrefix: 'freefeed_',
     userStorageKey: 'USER_KEY',
-    /**
-     * Array of enabled identity providers (e.g. ['facebook', 'google'])
-     * or empty array if no providers are supported.
-     */
-    extAuthProviders: ['facebook', 'google'],
   },
 
   captcha: {

--- a/src/components/ext-auth-buttons.jsx
+++ b/src/components/ext-auth-buttons.jsx
@@ -31,7 +31,7 @@ export const ExtAuthButtons = React.memo(function ExtAuthButtons({ mode = SIGN_I
     (provider) => () => {
       // Popup must be opened synchronously to avoid being blocked by the browser
       const popup = extAuthPopup();
-      dispatch(actionCreator[mode](provider, popup));
+      dispatch(actionCreator[mode](provider.id, popup));
     },
     [dispatch, mode],
   );
@@ -46,11 +46,11 @@ export const ExtAuthButtons = React.memo(function ExtAuthButtons({ mode = SIGN_I
       <p>
         {commonLabel[mode]}
         {providers.map((p) => (
-          <span key={p}>
+          <span key={p.id}>
             <button
               className={cn('btn btn-default', {
                 // [FBC] This class tells FBC that this button is a Facebook login button
-                'fb-login-button': p === 'facebook',
+                'fb-login-button': p.brand === 'facebook',
               })}
               onClick={onClick(p)}
               disabled={status.loading}

--- a/src/components/ext-auth-helpers.jsx
+++ b/src/components/ext-auth-helpers.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { faFacebook, faGoogle } from '@fortawesome/free-brands-svg-icons';
-import { faQuestion } from '@fortawesome/free-solid-svg-icons';
+import { faKey } from '@fortawesome/free-solid-svg-icons';
 
 import { getServerInfo } from '../redux/action-creators';
 import { Icon } from './fontawesome-icons';
@@ -17,24 +17,17 @@ export const useExtAuthProviders = () => {
 };
 
 export function providerTitle(provider, { withText = true, withIcon = true } = {}) {
-  switch (provider) {
-    case 'facebook':
-      return (
-        <>
-          {withIcon && <Icon icon={faFacebook} title="Facebook" />} {withText && 'Facebook'}
-        </>
-      );
-    case 'google':
-      return (
-        <>
-          {withIcon && <Icon icon={faGoogle} title="Google" />} {withText && 'Google'}
-        </>
-      );
-    default:
-      return (
-        <>
-          {withIcon && <Icon icon={faQuestion} title={provider} />} {withText && provider}
-        </>
-      );
+  let icon;
+  if (provider.brand === 'google') {
+    icon = faGoogle;
+  } else if (provider.brand === 'facebook') {
+    icon = faFacebook;
+  } else {
+    icon = faKey;
   }
+  return (
+    <>
+      {withIcon && <Icon icon={icon} title={provider.title} />} {withText && provider.title}
+    </>
+  );
 }

--- a/src/components/settings/forms/ext-auth-accounts.jsx
+++ b/src/components/settings/forms/ext-auth-accounts.jsx
@@ -21,7 +21,9 @@ export default function ExtAuthForm() {
   const serverInfoStatus = useSelector((state) => state.serverInfoStatus);
   const existingProfilesStatus = useSelector((state) => state.extAuth.profilesStatus);
   const existingProfiles = useSelector(({ extAuth: { profiles, providers } }) =>
-    profiles.filter((p) => providers.includes(p.provider)),
+    profiles
+      .filter((p) => providers.some((xp) => xp.id === p.provider))
+      .map((p) => ({ ...p, provider: providers.find((xp) => xp.id === p.provider) })),
   );
 
   const loadStatus = useMemo(() => combineAsyncStates(serverInfoStatus, existingProfilesStatus), [
@@ -90,7 +92,7 @@ const ConnectedProfile = React.memo(function ConnectedProfile({ profile }) {
 
   return (
     <p>
-      {providerTitle(profile.provider, { withText: false })} {profile.title}{' '}
+      {profile.title} ({providerTitle(profile.provider)}){' '}
       <button
         className="btn btn-default btn-sm"
         onClick={doUnlink(profile.id)}

--- a/src/components/signin.jsx
+++ b/src/components/signin.jsx
@@ -1,6 +1,6 @@
 /* global CONFIG */
 import { encode as qsEncode } from 'querystring';
-import React, { useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Link } from 'react-router';
 import { useForm, useField } from 'react-final-form-hooks';
@@ -154,6 +154,11 @@ const ExtAuthSignIn = React.memo(function ExtAuthSignIn() {
   const [providers] = useExtAuthProviders();
   const result = useSelector((state) => state.extAuth.signInResult);
 
+  const resultProfileProvider = useMemo(
+    () => providers.find((p) => p.id === result?.profile?.provider),
+    [providers, result],
+  );
+
   useEffect(() => {
     result.status === 'signed-in' && dispatch(signedIn(result.authToken));
   }, [dispatch, result]);
@@ -173,7 +178,7 @@ const ExtAuthSignIn = React.memo(function ExtAuthSignIn() {
             There is a {CONFIG.siteTitle} account with the email address{' '}
             <strong>{result.profile.email}</strong>, but your account{' '}
             <strong>
-              {providerTitle(result.profile.provider, { withText: false })} {result.profile.name}
+              {providerTitle(resultProfileProvider, { withText: false })} {result.profile.name}
             </strong>{' '}
             is not connected to it.
           </p>
@@ -195,11 +200,11 @@ const ExtAuthSignIn = React.memo(function ExtAuthSignIn() {
           <p>
             The{' '}
             <strong>
-              {providerTitle(result.profile.provider, { withText: false })} {result.profile.name}
+              {providerTitle(resultProfileProvider, { withText: false })} {result.profile.name}
             </strong>{' '}
-            account is not connected to any {CONFIG.siteTitle} account. Do you want to create a new
+            account is not connected to any {CONFIG.siteTitle} account. Do you want to create a new{' '}
             {CONFIG.siteTitle} account based on its data? After creation you will be able to sign in
-            using this {providerTitle(result.profile.provider, { withText: true, withIcon: false })}{' '}
+            using this {providerTitle(resultProfileProvider, { withText: true, withIcon: false })}{' '}
             account.
           </p>
           <p>

--- a/src/components/signup-form.jsx
+++ b/src/components/signup-form.jsx
@@ -8,7 +8,7 @@ import { useField, useForm } from 'react-final-form-hooks';
 
 import { signUp } from '../redux/action-creators';
 import { FieldsetWrapper } from './fieldset-wrapper';
-import { providerTitle } from './ext-auth-helpers';
+import { providerTitle, useExtAuthProviders } from './ext-auth-helpers';
 import { Throbber } from './throbber';
 
 const captchaKey = CONFIG.captcha.siteKey;
@@ -89,6 +89,12 @@ export default React.memo(function SignupForm({ invitationId = null, lang = 'en'
       key: res.externalProfileKey,
     };
   });
+  const [providers] = useExtAuthProviders();
+
+  const extProfileProvider = useMemo(() => providers.find((p) => p.id === extProfile?.provider), [
+    extProfile,
+    providers,
+  ]);
 
   const form = useForm(
     useMemo(
@@ -248,12 +254,12 @@ export default React.memo(function SignupForm({ invitationId = null, lang = 'en'
               />{' '}
               {enRu(
                 <>
-                  Allow to sign in via {providerTitle(extProfile.provider, { withText: false })}{' '}
+                  Allow to sign in via {providerTitle(extProfileProvider, { withText: false })}{' '}
                   {extProfile.name} account
                 </>,
                 <>
                   Разрешить вход через аккаунт{' '}
-                  {providerTitle(extProfile.provider, { withText: false })} {extProfile.name}
+                  {providerTitle(extProfileProvider, { withText: false })} {extProfile.name}
                 </>,
               )}
             </label>

--- a/src/redux/reducers/ext-auth.js
+++ b/src/redux/reducers/ext-auth.js
@@ -17,7 +17,11 @@ import {
 import { setOnLocationChange } from './helpers';
 
 export const extAuth = combineReducers({
-  providers: fromResponse(GET_SERVER_INFO, (action) => action.payload.externalAuthProviders, []),
+  providers: fromResponse(
+    GET_SERVER_INFO,
+    (action) => action.payload.externalAuthProvidersInfo,
+    [],
+  ),
   profiles: fromResponse(
     GET_AUTH_PROFILES,
     ({ payload: { profiles } }) => profiles,

--- a/src/redux/reducers/ext-auth.js
+++ b/src/redux/reducers/ext-auth.js
@@ -1,5 +1,3 @@
-/* global CONFIG */
-import { intersection } from 'lodash';
 import { combineReducers } from 'redux';
 import { LOCATION_CHANGE } from 'react-router-redux';
 import {
@@ -19,12 +17,7 @@ import {
 import { setOnLocationChange } from './helpers';
 
 export const extAuth = combineReducers({
-  providers: fromResponse(
-    GET_SERVER_INFO,
-    (action) =>
-      intersection(CONFIG.auth.extAuthProviders || [], action.payload.externalAuthProviders),
-    [],
-  ),
+  providers: fromResponse(GET_SERVER_INFO, (action) => action.payload.externalAuthProviders, []),
   profiles: fromResponse(
     GET_AUTH_PROFILES,
     ({ payload: { profiles } }) => profiles,


### PR DESCRIPTION
This is a client-side part of freefeed/freefeed-server#486.

The extAuthProviders key removed from the configuration. The client now accepts all providers that the server supported.