### PR TITLE
Show error message and terminate the page loading on config error

### DIFF
--- a/config/lib/loader-browser.js
+++ b/config/lib/loader-browser.js
@@ -9,11 +9,35 @@ const scriptRoot = document.currentScript ? document.currentScript.src.replace(/
 const req = new XMLHttpRequest();
 req.open('GET', `${scriptRoot}/config.json`, false /* Synchronous request! */);
 req.setRequestHeader('Cache-Control', 'no-cache');
-req.send();
+try {
+  req.send();
+} catch (e) {
+  console.error(e);
+  fatalError(`Network error during loading the ${scriptRoot}/config.json.
+This is most likely a temporary error.
+
+Please <button onclick="location.reload(true)">reload</button> this page or contact support if the problem persists.
+`);
+}
+
 if (req.status === 200) {
   try {
     window.CONFIG = merge(window.CONFIG, JSON.parse(req.response));
   } catch (e) {
-    // Do nothing if file is not exists or some other error occurred
+    console.error(e);
+    fatalError(`Error during parsing the ${scriptRoot}/config.json: ${e.message}
+The server is probably misconfigured.
+
+Try to <button onclick="location.reload(true)">reload</button> this page or contact support.`);
   }
+} else if (req.status !== 404) {
+  fatalError(`HTTP error ${req.status} error during loading the ${scriptRoot}/config.json.
+The server is probably misconfigured.
+
+Try to <button onclick="location.reload(true)">reload</button> this page or contact support.`);
+}
+
+function fatalError(msg) {
+  document.write(`<pre>${msg}`);
+  window.stop();
 }


### PR DESCRIPTION
If the config.json cannot be loaded due to network error, invalid JSON or server misconfiguration, print the error message and don't render the rest of page. The the 200 OK (with valid JSON) and the 404 Not Found are the only allowed responses.