### PR TITLE
Add spoiler tag

### DIFF
--- a/src/components/piece-of-text.jsx
+++ b/src/components/piece-of-text.jsx
@@ -141,13 +141,9 @@ const splitIntoSpoilerBlocks = (input) => {
       const spoilerText = content.slice(9, -10);
       const tagAfter = content.slice(-10);
 
-      newNodes.push(
-        <React.Fragment key={`spoiler-${from}`}>
-          <span key="spoiler-before">{tagBefore}</span>
-          <Spoiler key="spoiler">{spoilerText}</Spoiler>
-          <span key="spoiler-after">{tagAfter}</span>
-        </React.Fragment>,
-      );
+      newNodes.push(tagBefore);
+      newNodes.push(<Spoiler key={`spoiler-${from}`}>{spoilerText}</Spoiler>);
+      newNodes.push(tagAfter);
     }
 
     if (i < input.length) {

--- a/src/components/piece-of-text.jsx
+++ b/src/components/piece-of-text.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 
 import { READMORE_STYLE_COMFORT } from '../utils/frontend-preferences-options';
 
+import Spoiler from './spoiler';
 import Linkify from './linkify';
+
+const spoilerRegex = /<(spoiler|спойлер)>(?:(?!(<(spoiler|спойлер)>|<\/(spoiler|спойлер)>)).)*<\/(spoiler|спойлер)>/gi;
 
 // Texts longer than thresholdTextLength should be cut to shortenedTextLength
 const thresholdTextLength = 800;
@@ -113,6 +116,56 @@ const getExpandedText = (text) => {
   return injectSeparator(paragraphs, paragraphBreak);
 };
 
+const splitIntoSpoilerBlocks = (input) => {
+  if (typeof input === 'string') {
+    const spoilersInText = input.matchAll(spoilerRegex);
+
+    if (!spoilersInText) {
+      return input;
+    }
+
+    let i = 0;
+    const newNodes = [];
+
+    for (const spoilerMatch of spoilersInText) {
+      const [content] = spoilerMatch;
+      const from = spoilerMatch.index;
+      const to = from + content.length;
+
+      if (from > i) {
+        newNodes.push(input.slice(i, from));
+      }
+      i = to;
+
+      const tagBefore = content.slice(0, 9);
+      const spoilerText = content.slice(9, -10);
+      const tagAfter = content.slice(-10);
+
+      newNodes.push(
+        <React.Fragment key={`spoiler-${from}`}>
+          <span key="spoiler-before">{tagBefore}</span>
+          <Spoiler key="spoiler">{spoilerText}</Spoiler>
+          <span key="spoiler-after">{tagAfter}</span>
+        </React.Fragment>,
+      );
+    }
+
+    if (i < input.length) {
+      newNodes.push(input.slice(i));
+    }
+
+    return newNodes;
+  }
+
+  if (Array.isArray(input)) {
+    return input.map(splitIntoSpoilerBlocks);
+  }
+
+  if (React.isValidElement(input)) {
+    return React.cloneElement(input, {}, splitIntoSpoilerBlocks(input.props.children));
+  }
+};
+
 export default class PieceOfText extends React.Component {
   constructor(props) {
     super(props);
@@ -127,19 +180,25 @@ export default class PieceOfText extends React.Component {
   }
 
   render() {
-    return this.props.text ? (
+    if (!this.props.text) {
+      return <span />;
+    }
+
+    const text = splitIntoSpoilerBlocks(
+      this.state.isExpanded
+        ? getExpandedText(this.props.text)
+        : getCollapsedText(this.props.text, this.expandText.bind(this)),
+    );
+
+    return (
       <Linkify
         userHover={this.props.userHover}
         arrowHover={this.props.arrowHover}
         highlightTerms={this.props.highlightTerms}
         showMedia={this.props.showMedia}
       >
-        {this.state.isExpanded
-          ? getExpandedText(this.props.text)
-          : getCollapsedText(this.props.text, this.expandText.bind(this))}
+        {text}
       </Linkify>
-    ) : (
-      <span />
     );
   }
 }

--- a/src/components/spoiler.jsx
+++ b/src/components/spoiler.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import classnames from 'classnames';
+
+export default class Spoiler extends React.PureComponent {
+  state = {
+    visible: false,
+  };
+
+  onShow = () => {
+    this.setState({ visible: true });
+  };
+
+  render() {
+    const { visible } = this.state;
+    const { children } = this.props;
+
+    const cn = classnames(visible ? 'spoiler-visible' : 'spoiler-hidden');
+
+    return (
+      <span className={cn} onClick={visible ? undefined : this.onShow}>
+        {children}
+      </span>
+    );
+  }
+}

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -188,16 +188,8 @@ $post-line-height: 20px;
   cursor: pointer;
 }
 
-.spoiler-hidden .search-highlight {
-  background-color: #999;
-  padding: 0;
-}
-
-.spoiler-hidden .user-name-wrapper {
-  pointer-events: none;
-}
-
-.spoiler-hidden a {
+.spoiler-hidden * {
+  background-color: #999 !important;
   color: #999 !important;
   pointer-events: none;
 }

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -181,6 +181,30 @@ $post-line-height: 20px;
   cursor: help;
 }
 
+// spoiler
+.spoiler-hidden {
+  background-color: #999;
+  color: #999;
+  cursor: pointer;
+}
+
+.spoiler-hidden .search-highlight {
+  background-color: #999;
+  padding: 0;
+}
+
+.spoiler-hidden .user-name-wrapper {
+  pointer-events: none;
+}
+
+.spoiler-hidden a {
+  color: #999 !important;
+  pointer-events: none;
+}
+
+.spoiler-visible {
+}
+
 // paragraph breaks
 .p-break {
   height: 0.35em;

--- a/test/unit/components/piece-of-text.js
+++ b/test/unit/components/piece-of-text.js
@@ -94,4 +94,15 @@ describe('<PieceOfText>', () => {
       <Linkify>{text}</Linkify>,
     );
   });
+
+  it('should correctly process texts with spoilers', () => {
+    const text = '123 <spoiler>456</spoiler> 789 <спойлер>https://example.com</спойлер> 123';
+
+    expect(
+      <PieceOfText text={text} />,
+      'when rendered',
+      'to have rendered with all children',
+      <Linkify>{text}</Linkify>,
+    );
+  });
 });

--- a/test/unit/components/piece-of-text.js
+++ b/test/unit/components/piece-of-text.js
@@ -5,6 +5,7 @@ import unexpectedReact from 'unexpected-react';
 import React from 'react';
 
 import PieceOfText from '../../../src/components/piece-of-text';
+import Spoiler from '../../../src/components/spoiler';
 import Linkify from '../../../src/components/linkify';
 
 const expect = unexpected.clone().use(unexpectedReact);
@@ -96,13 +97,20 @@ describe('<PieceOfText>', () => {
   });
 
   it('should correctly process texts with spoilers', () => {
-    const text = '123 <spoiler>456</spoiler> 789 <спойлер>https://example.com</спойлер> 123';
+    const text =
+      '123 <spoiler> <spoiler>456</spoiler> 789 <спойлер>https://example.com</спойлер> 123';
 
     expect(
       <PieceOfText text={text} />,
       'when rendered',
       'to have rendered with all children',
-      <Linkify>{text}</Linkify>,
+      <Linkify>
+        123 &lt;spoiler&gt; &lt;spoiler&gt;
+        <Spoiler>456</Spoiler>
+        &lt;/spoiler&gt; 789 &lt;спойлер&gt;
+        <Spoiler>https://example.com</Spoiler>
+        &lt;/спойлер&gt; 123
+      </Linkify>,
     );
   });
 });


### PR DESCRIPTION
This PR adds support for `<spoiler>` tag. Click to reveal.

This text:

```
1. Работает по-простому: <spoiler>текст спойлера</spoiler> и <spoiler>еще один</spoiler>
2. Работает со ссылкой внутри: <spoiler>https://google.com</spoiler>
3. Работает с юзернеймом внутри: <spoiler>@n1313</spoiler> (и с хэштегом тоже <spoiler>#spoiler</spoiler>
4. Незакрытый тег не работает: <spoiler>меня видно!
5. При вложенности работает внутренний: <spoiler>снаружи <spoiler>внутри</spoiler> снаружи</spoiler>
6. Работает по-русски: <спойлер>medved vodka balalaika</спойлер>
7. Пользуйтесь тегом <spoiler>! Он работает вот так: <spoiler>пример спойлера</spoiler>
8. Работает внутри слов: supercali<spoiler>fragilistic</spoiler>expialidocious
```

will look like this:

<img width="689" alt="Screenshot 2020-12-08 at 00 06 54" src="https://user-images.githubusercontent.com/632081/101374939-c34beb00-38e9-11eb-9311-1cc3c44417aa.png">

Works in profile descriptions, but [not in screennames](https://user-images.githubusercontent.com/632081/101375026-e1b1e680-38e9-11eb-9373-2cd47963b596.png).

Works in [search results](https://user-images.githubusercontent.com/632081/101375075-f0000280-38e9-11eb-8fd3-c01d1646f814.png).

