### PR TITLE
Add a 'not found' page for invalid routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.88.1] - Not released
+### Added
+- A 'Not Found' page for URI's that does not match any of the site routes.
+- A &lt;spoiler> tag for the sensitive or spoiler texts.
+
 ### Fixed
 - Show explicit error if config.json failed to load, and it wasn't 404
 

--- a/src/components/not-found.jsx
+++ b/src/components/not-found.jsx
@@ -1,3 +1,18 @@
+/* global CONFIG */
 import React from 'react';
+import { Helmet } from 'react-helmet';
 
-export default () => <div className="commentBox">Nothing here :(</div>;
+export function NotFound() {
+  return (
+    <div className="box">
+      <Helmet title={`Page not found - ${CONFIG.siteTitle}`} defer={false} />
+      <div className="box-header-timeline">Page not found</div>
+      <div className="box-body">
+        <p className="alert alert-danger">
+          There is no page with such an address on {CONFIG.siteTitle}.
+        </p>
+      </div>
+      <div className="box-footer" />
+    </div>
+  );
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -43,6 +43,7 @@ import { bindRouteActions } from './redux/route-actions';
 import { initUnscroll, safeScrollTo } from './services/unscroll';
 import { lazyRetry } from './utils/retry-promise';
 import { HomeAux } from './components/home-aux';
+import { NotFound } from './components/not-found';
 
 // Set initial history state.
 // Without this, there can be problems with third-party
@@ -344,7 +345,7 @@ function App() {
         <Route
           name="post"
           path="/:userName/:postId"
-          component={SinglePost}
+          component={checkPath(SinglePost, isPostPath)}
           {...generateRouteHooks(boundRouteActions('post'))}
         />
       </Route>
@@ -358,3 +359,16 @@ ReactDOM.render(
   </Provider>,
   document.getElementById('app'),
 );
+
+function checkPath(Component, checker) {
+  return (props) => {
+    return checker(props) ? <Component {...props} /> : <NotFound {...props} />;
+  };
+}
+
+function isPostPath({ params: { postId, userName } }) {
+  return (
+    /^[a-z\d-]{3,25}$/i.test(userName) &&
+    /^[a-f\d]{8}-[a-f\d]{4}-4[a-f\d]{3}-[89ab][a-f\d]{3}-[a-f\d]{12}$/i.test(postId)
+  );
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -290,7 +290,7 @@ function App() {
         <Route
           name="userFeed"
           path="/:userName"
-          component={User}
+          component={checkPath(User, isAccountPath)}
           {...generateRouteHooks(boundRouteActions('userFeed'))}
         />
         <Route
@@ -371,4 +371,8 @@ function isPostPath({ params: { postId, userName } }) {
     /^[a-z\d-]{3,25}$/i.test(userName) &&
     /^[a-f\d]{8}-[a-f\d]{4}-4[a-f\d]{3}-[89ab][a-f\d]{3}-[a-f\d]{12}$/i.test(postId)
   );
+}
+
+function isAccountPath({ params: { userName } }) {
+  return /^[a-z\d-]{3,25}$/i.test(userName);
 }


### PR DESCRIPTION
Now the single post route acts as a catch-all route, so any non-existing path shows the 'Post not found' message (even if it isn't looks like post path). This PR adds an additional check for path params and shows NotFound page if the path isn't the post path.