### PR TITLE
Fix the recent groups order issue in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Embedly previews handle light/dark theme switching properly
 - Home feed edition popups now closes when the Esc key is pressed or the shadow
   overlay is clicked
+- Incorrect sorting of recent groups when getting real-time updates
 
 ### Changed
 - Google Analytics ID isn't hardcoded in index.jade anymore.

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -1754,22 +1754,22 @@ export function sendTo(state = INITIAL_SEND_TO_STATE, action) {
 
 const GROUPS_SIDEBAR_LIST_LENGTH = 4;
 
-const getRecentGroups = ({ subscribers, frontendPreferences }) => {
+function sortRecentGroups(g1, g2) {
+  if (g1.isPinned !== g2.isPinned) {
+    return g1.isPinned ? -1 : 1;
+  }
+  return parseInt(g2.updatedAt) - parseInt(g1.updatedAt);
+}
+
+function getRecentGroups({ subscribers, frontendPreferences }) {
   const clientPreferences = frontendPreferences || {};
   const pinnedGroups = clientPreferences.pinnedGroups || [];
   const groups = (subscribers || []).filter((i) => i.type == 'group');
-  const recentGroups = groups
-    .filter((i) => pinnedGroups.indexOf(i.id) > -1)
-    .sort((i, j) => parseInt(j.updatedAt) - parseInt(i.updatedAt))
-    .map((i) => ({ ...i, isPinned: true }));
-
-  return recentGroups.concat(
-    groups
-      .filter((i) => pinnedGroups.indexOf(i.id) === -1)
-      .sort((i, j) => parseInt(j.updatedAt) - parseInt(i.updatedAt))
-      .slice(0, GROUPS_SIDEBAR_LIST_LENGTH),
-  );
-};
+  return groups
+    .map((g) => ({ ...g, isPinned: pinnedGroups.includes(g.id) }))
+    .sort(sortRecentGroups)
+    .slice(0, GROUPS_SIDEBAR_LIST_LENGTH + pinnedGroups.length);
+}
 
 export function recentGroups(state = [], action) {
   switch (action.type) {
@@ -1802,18 +1802,14 @@ export function recentGroups(state = [], action) {
     }
     case ActionTypes.REALTIME_USER_UPDATE: {
       if (action.updatedGroups) {
-        let groups = action.updatedGroups.map((g) => ({
+        const updatedGroups = action.updatedGroups.map((g) => ({
           ...g,
           // Do we already have this group pinned?
           isPinned: state.find((s) => s.id === g.id)?.isPinned || false,
         }));
-        groups = _.uniqBy([...groups, ...state], 'id').sort((g1, g2) => {
-          if (g1.isPinned !== g2.isPinned) {
-            return g1.isPinned ? -1 : 1;
-          }
-          return parseInt(g2.updatedAt) - parseInt(g1.updatedAt);
-        });
-        return groups.slice(0, state.length);
+        return _.uniqBy([...updatedGroups, ...state], 'id')
+          .sort(sortRecentGroups)
+          .slice(0, state.length);
       }
       return state;
     }


### PR DESCRIPTION
Apparently, Chrome and Firefox had different ways of handling the situation with the missing isPinned property. Now the isPinned is always defined, and the code is more concise.