### PR TITLE
Display a link to all my posts in my feed's header

### DIFF
--- a/src/components/user-profile-head.jsx
+++ b/src/components/user-profile-head.jsx
@@ -478,16 +478,14 @@ export const UserProfileHead = withRouter(
                 linkTo={`/${user.username}/subscribers`}
                 canFollow={canFollowStatLinks}
               />
-              {/* Looks like posts statistics is totally incorrect, so dont show it
-                {user.type === 'user' && (
-                  <StatLink
-                    value={user.statistics.posts}
-                    title="post"
-                    linkTo={`/${user.username}`}
-                    canFollow={canFollowStatLinks}
-                  />
-                )}
-                */}
+              {isCurrentUser && (
+                <StatLink
+                  value={user.statistics.posts}
+                  title="post"
+                  linkTo="/search?qs=from%3Ame"
+                  canFollow={canFollowStatLinks}
+                />
+              )}
               {user.type === 'user' && (
                 <StatLink
                   value={user.statistics.comments}


### PR DESCRIPTION
<img width="705" alt="Screenshot 2020-12-28 at 19 51 33" src="https://user-images.githubusercontent.com/632081/103212657-64a4ea80-4946-11eb-9cdd-73eba6eceb4e.png">

Мне бы очень хотелось получить где-нибудь в удобном месте ссылку на все посты, написанные мной (т.е. на https://freefeed.net/search?qs=from%3Ame). Сейчас в шапке моего фида есть похожий кусок кода, который выводит ссылку на почти туда, куда надо, но он закомментирован с жалобой на неправильную цифру постов, которую возвращает API (вернее, ссылка ведет совсем не туда, куда мне надо, но интенция там явно правильная). Лично у меня желание посмотреть свои последние посты (не дискуссии) возникает очень часто, точное количество постов (пусть и неправильное) меня совсем не беспокоит, и иметь простую ссылку на выдачу поиска вместо вбивания `from:me` руками в поисковую строку мне бы очень помогло.
