### PR TITLE
Use captured event in dropdown's close handler

### DIFF
--- a/src/components/comment-icon.jsx
+++ b/src/components/comment-icon.jsx
@@ -36,7 +36,7 @@ export default memo(function CommentIcon({ id, omitBubble = false, reply, mentio
     ref: panelRef,
     opened: actionsPanelOpened,
     hide: hideActionsPanel,
-    handlers: touchHendlers,
+    handlers: touchHandlers,
   } = useActionsPanel();
 
   const heartClick = useCallback(
@@ -54,10 +54,6 @@ export default memo(function CommentIcon({ id, omitBubble = false, reply, mentio
     [mention, reply],
   );
 
-  const countClick = useCallback((e) => (e.stopPropagation(), likesListToggle()), [
-    likesListToggle,
-  ]);
-
   const heartClass = cn('comment-likes', {
     'has-my-like': hasOwnLike,
     'non-likable': !canLike,
@@ -67,10 +63,10 @@ export default memo(function CommentIcon({ id, omitBubble = false, reply, mentio
   const bubbleProps = { id: `comment-${id}`, onClick: bubbleClick };
 
   return (
-    <div className="comment-likes-container" {...touchHendlers}>
+    <div className="comment-likes-container" {...touchHandlers}>
       {/* Heart & likes count */}
       <div className={heartClass}>
-        <div className="comment-count" onClick={countClick} ref={countRef}>
+        <div className="comment-count" onClick={likesListToggle} ref={countRef}>
           {likes || ''}
         </div>
         <div className="comment-heart" onClick={heartClick}>

--- a/src/components/hooks/drop-down.js
+++ b/src/components/hooks/drop-down.js
@@ -30,8 +30,11 @@ export function useDropDown({
           }
         }
       };
-      document.body.addEventListener('click', h);
-      return () => document.body.removeEventListener('click', h);
+      // Using captured event here to prevent conflict with pivot onClick
+      // handler as recommended in
+      // https://reactjs.org/blog/2020/08/10/react-v17-rc.html#fixing-potential-issues
+      document.body.addEventListener('click', h, { capture: true });
+      return () => document.body.removeEventListener('click', h, { capture: true });
     }
   }, [opened, closeOn]);
 


### PR DESCRIPTION
To prevent conflict with pivot onClick handler as recommended in https://reactjs.org/blog/2020/08/10/react-v17-rc.html#fixing-potential-issues