### PR TITLE
Fix text selection in spoiler tags

### DIFF
--- a/src/components/spoiler.jsx
+++ b/src/components/spoiler.jsx
@@ -17,7 +17,11 @@ export default class Spoiler extends PureComponent {
     const cn = classnames(visible ? 'spoiler-visible' : 'spoiler-hidden');
 
     return (
-      <span className={cn} onClick={visible ? undefined : this.onShow}>
+      <span
+        className={cn}
+        onClick={visible ? undefined : this.onShow}
+        title={visible ? undefined : `This is a spoiler. Click to reveal its contents.`}
+      >
         {children}
       </span>
     );

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -191,11 +191,25 @@ $post-line-height: 20px;
 
   .dark-theme & {
     background-color: #666666;
+
+    &:hover {
+      background-color: #555555;
+    }
+  }
+
+  &:hover {
+    background-color: #aaaaaa;
+  }
+
+  &::selection,
+  &::-moz-selection {
+    color: transparent;
   }
 }
 
 .spoiler-hidden * {
-  visibility: hidden !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
 }
 
 // paragraph breaks

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -201,7 +201,10 @@ $post-line-height: 20px;
     background-color: #aaaaaa;
   }
 
-  &::selection,
+  &::selection {
+    color: transparent;
+  }
+
   &::-moz-selection {
     color: transparent;
   }

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -191,14 +191,6 @@ $post-line-height: 20px;
 
   .dark-theme & {
     background-color: #666666;
-
-    &:hover {
-      background-color: #555555;
-    }
-  }
-
-  &:hover {
-    background-color: #aaaaaa;
   }
 
   &::selection {


### PR DESCRIPTION
This PR fixes text selection problems in spoiler tags on Windows:

1. selecting spoiler text now does not reveal its contents
2. selecting spoiler text and copying it now correctly copies links inside spoiler tags

See https://user-images.githubusercontent.com/632081/103475416-ec2ba700-4de7-11eb-9c4a-95cce4079609.mov

Also, this PR makes it more clear that users are supposed to click on spoilers to reveal their contents by adding a minor hover effect and an explanatory title:

See https://user-images.githubusercontent.com/632081/103475459-47f63000-4de8-11eb-98ba-ac6153ab15d2.mp4



