### PR TITLE
Prevent display of link previews from inside spoilers

### DIFF
--- a/src/components/piece-of-text.jsx
+++ b/src/components/piece-of-text.jsx
@@ -2,10 +2,11 @@ import { cloneElement, isValidElement, Component } from 'react';
 
 import { READMORE_STYLE_COMFORT } from '../utils/frontend-preferences-options';
 
+import { StartSpoiler, EndSpoiler } from '../utils/spoiler-tokens';
+import { parseText } from '../utils/parse-text';
+
 import Spoiler from './spoiler';
 import Linkify from './linkify';
-
-const spoilerRegex = /<(spoiler|спойлер)>(?:(?!(<(spoiler|спойлер)>|<\/(spoiler|спойлер)>)).)*<\/(spoiler|спойлер)>/gi;
 
 // Texts longer than thresholdTextLength should be cut to shortenedTextLength
 const thresholdTextLength = 800;
@@ -118,37 +119,27 @@ const getExpandedText = (text) => {
 
 const splitIntoSpoilerBlocks = (input) => {
   if (typeof input === 'string') {
-    const spoilersInText = input.matchAll(spoilerRegex);
+    const tokens = parseText(input);
 
-    if (!spoilersInText) {
-      return input;
-    }
-
-    let i = 0;
     const newNodes = [];
+    let isInSpoiler = false;
+    let spoilerText = '';
 
-    for (const spoilerMatch of spoilersInText) {
-      const [content] = spoilerMatch;
-      const from = spoilerMatch.index;
-      const to = from + content.length;
-
-      if (from > i) {
-        newNodes.push(input.slice(i, from));
+    tokens.forEach((token) => {
+      if (token instanceof StartSpoiler) {
+        newNodes.push(token.text);
+        isInSpoiler = true;
+      } else if (token instanceof EndSpoiler) {
+        const spoilerNode = <Spoiler key={`spoiler-${token.offset}`}>{spoilerText}</Spoiler>;
+        newNodes.push(spoilerNode, token.text);
+        isInSpoiler = false;
+        spoilerText = '';
+      } else if (isInSpoiler) {
+        spoilerText += token.text;
+      } else {
+        newNodes.push(token.text);
       }
-      i = to;
-
-      const tagBefore = content.slice(0, 9);
-      const spoilerText = content.slice(9, -10);
-      const tagAfter = content.slice(-10);
-
-      newNodes.push(tagBefore);
-      newNodes.push(<Spoiler key={`spoiler-${from}`}>{spoilerText}</Spoiler>);
-      newNodes.push(tagAfter);
-    }
-
-    if (i < input.length) {
-      newNodes.push(input.slice(i));
-    }
+    });
 
     return newNodes;
   }

--- a/src/utils/spoiler-tokens.js
+++ b/src/utils/spoiler-tokens.js
@@ -1,0 +1,14 @@
+import { Token } from 'social-text-tokenizer';
+
+import byRegexp, { makeToken } from 'social-text-tokenizer/build/cjs/lib/byRegexp';
+
+const startSpoilerRegex = /<(spoiler|спойлер)>/gi;
+const endSpoilerRegex = /<\/(spoiler|спойлер)>/gi;
+
+class StartSpoiler extends Token {}
+class EndSpoiler extends Token {}
+
+const tokenizerStartSpoiler = byRegexp(startSpoilerRegex, makeToken(StartSpoiler));
+const tokenizerEndSpoiler = byRegexp(endSpoilerRegex, makeToken(EndSpoiler));
+
+export { tokenizerStartSpoiler, tokenizerEndSpoiler, StartSpoiler, EndSpoiler };

--- a/test/unit/utils/parse-text.js
+++ b/test/unit/utils/parse-text.js
@@ -2,7 +2,7 @@ import { describe, it } from 'mocha';
 import expect from 'unexpected';
 import { Link as TLink } from 'social-text-tokenizer';
 
-import { Link } from '../../../src/utils/parse-text';
+import { Link, getFirstLinkToEmbed } from '../../../src/utils/parse-text';
 
 const localDomains = ['freefeed.net', 'omega.freefeed.net'];
 
@@ -41,6 +41,36 @@ describe('parse-text', () => {
       const link = new Link(new TLink(0, 'https://omega.freefeed.net/hello'), localDomains);
       expect(link.isLocal, 'to be true');
       expect(link.localURI, 'to be', '/hello');
+    });
+  });
+
+  describe('Get first link to embed', () => {
+    it('should return undefined for no links', () => {
+      expect(getFirstLinkToEmbed('abc def'), 'to be', undefined);
+    });
+
+    it('should return first link out of many', () => {
+      expect(
+        getFirstLinkToEmbed('abc https://link1.com https://link2.com def'),
+        'to be',
+        'https://link1.com/',
+      );
+    });
+
+    it('should return first non-excluded link', () => {
+      expect(
+        getFirstLinkToEmbed('abc !https://link1.com https://link2.com def'),
+        'to be',
+        'https://link2.com/',
+      );
+    });
+
+    it('should not return links inside spoilders', () => {
+      expect(
+        getFirstLinkToEmbed('abc <spoiler>https://link1.com</spoiler> https://link2.com def'),
+        'to be',
+        'https://link2.com/',
+      );
     });
   });
 });


### PR DESCRIPTION
This PR disables link previews for links that are inside spoiler tags.

See https://user-images.githubusercontent.com/632081/103550322-b0760780-4ee3-11eb-98fb-28105fdd6d94.mp4

Also this is a refactor of spoiler implementation into using `social-text-tokenizer`, which makes rendering and detection of links easier at the cost of having to manually validate spoiler start and end tags. 

