### PR TITLE
Generate readable classnames with CSS Modules

### DIFF
--- a/webpack/rules.js
+++ b/webpack/rules.js
@@ -128,7 +128,14 @@ class RuleGenerator {
       test: /[.]module[.]scss$/,
       use: [
         this.opts.dev ? 'style-loader' : MiniCssExtractPlugin.loader,
-        'css-loader?modules=true',
+        {
+          loader: 'css-loader',
+          options: {
+            modules: {
+              localIdentName: '[name]-[local]-[hash:base64:5]',
+            },
+          },
+        },
         'sass-loader',
       ],
     };


### PR DESCRIPTION
This PR modifies webpack config to generate readable CSS classnames instead of hashes in components where CSS Modules are used.  

Before:
![image](https://user-images.githubusercontent.com/632081/104114096-6a81cf00-533b-11eb-83c9-b8b7cd762eaa.png)
After:
![image](https://user-images.githubusercontent.com/632081/104114102-7372a080-533b-11eb-9a35-8bac5b98229c.png)
