### PR TITLE
Click to close spoilers

### DIFF
--- a/src/components/spoiler.jsx
+++ b/src/components/spoiler.jsx
@@ -6,8 +6,19 @@ export default class Spoiler extends PureComponent {
     visible: false,
   };
 
-  onShow = () => {
-    this.setState({ visible: true });
+  onToggle = (e) => {
+    const sel = window.getSelection();
+    if (sel.toString() !== '') {
+      // do nothing if there is a text selection, because this click is from
+      // user finishing selecting something inside the spoiler
+      return;
+    }
+    if (e.target.closest('a')) {
+      // clicked element is wrapped in an <a> which means it's something
+      // like a link, which should not close the spoiler
+      return;
+    }
+    this.setState({ visible: !this.state.visible });
   };
 
   render() {
@@ -19,8 +30,8 @@ export default class Spoiler extends PureComponent {
     return (
       <span
         className={cn}
-        onClick={visible ? undefined : this.onShow}
-        title={visible ? undefined : `This is a spoiler. Click to reveal its contents.`}
+        onClick={this.onToggle}
+        title={visible ? undefined : 'This is a spoiler. Click to reveal its contents.'}
       >
         {children}
       </span>

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -202,6 +202,22 @@ $post-line-height: 20px;
   }
 }
 
+.spoiler-visible {
+  cursor: pointer;
+  background-color: #eee;
+
+  .dark-theme & {
+    background-color: #333;
+  }
+}
+
+// To give link-only spoilers a little bit of space where they can
+// be clicked to close
+.spoiler-visible,
+.spoiler-hidden {
+  padding: 0 2px;
+}
+
 .spoiler-hidden * {
   opacity: 0 !important;
   pointer-events: none !important;


### PR DESCRIPTION
This PR makes spoilers close-able by clicking on their text. Clicking on links, usernames or media links does not close the spoiler, and I have added a tiny 2px padding to give link-only spoilers a space where users can click to close them.

<img width="637" alt="Screenshot 2021-01-11 at 22 53 03" src="https://user-images.githubusercontent.com/632081/104198683-78317480-5461-11eb-9bd0-b65000e0db86.png">
<img width="639" alt="Screenshot 2021-01-11 at 22 53 23" src="https://user-images.githubusercontent.com/632081/104198691-7a93ce80-5461-11eb-9dea-1839c3b12f29.png">

See https://user-images.githubusercontent.com/632081/104198713-81224600-5461-11eb-8847-f8c3acafa028.mp4

