### PR TITLE
Fix highlight color of expand-panel

### DIFF
--- a/styles/helvetica/dark-theme.scss
+++ b/styles/helvetica/dark-theme.scss
@@ -205,6 +205,7 @@ body.dark-theme {
   }
 
   .comment.highlighted::before,
+  .comment.highlighted .expand-panel,
   .comment.highlight-from-url::before {
     background-color: $bg-color-lightest;
   }

--- a/styles/shared/comments.scss
+++ b/styles/shared/comments.scss
@@ -88,7 +88,8 @@
     border-radius: $border-width;
   }
 
-  &.highlighted::before {
+  &.highlighted::before,
+  &.highlighted .expand-panel {
     background-color: #d9ebff;
   }
 


### PR DESCRIPTION
This PR fixes highlight color of expand-panel block:

<img width="675" alt="Screenshot 2021-01-14 at 21 13 33" src="https://user-images.githubusercontent.com/632081/104596620-2f6efb00-56af-11eb-8500-d181e714aebe.png">
