### PR TITLE
Fix "edit list" control showing up for anonymous users

### DIFF
--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -38,6 +38,16 @@ const FeedHandler = (props) => {
     dispatch,
   ]);
 
+  if (!props.authenticated) {
+    return (
+      <div className="box">
+        <ErrorBoundary>
+          <Welcome />
+        </ErrorBoundary>
+      </div>
+    );
+  }
+
   const createPostComponent = (
     <CreatePost
       createPostViewState={props.createPostViewState}
@@ -61,19 +71,18 @@ const FeedHandler = (props) => {
               (<ButtonLink onClick={showEditor}>Edit list</ButtonLink>)
             </small>
           )}
-          <div className="pull-right">{props.authenticated && <FeedOptionsSwitch />}</div>
+          <div className="pull-right">
+            <FeedOptionsSwitch />
+          </div>
         </div>
         {isEditing && <ListEditor listId={feedId} close={closeEditor} />}
 
         <SubscrRequests />
 
-        {props.authenticated ? (
-          <PaginatedView firstPageHead={createPostComponent} {...props}>
-            <Feed {...props} isInHomeFeed={!props.feedIsLoading} />
-          </PaginatedView>
-        ) : (
-          <Welcome />
-        )}
+        <PaginatedView firstPageHead={createPostComponent} {...props}>
+          <Feed {...props} isInHomeFeed={!props.feedIsLoading} />
+        </PaginatedView>
+
         <div className="box-footer" />
       </ErrorBoundary>
     </div>


### PR DESCRIPTION
This PR fixes a bug where anonymous users could sometimes see "edit list" control above welcome page.

STR:
1. Open https://candy.freefeed.net/freefeed as anonymous user
2. Click the site logo 

![image](https://user-images.githubusercontent.com/632081/105171089-cda00c80-5b58-11eb-8a52-d42b3a5ccc61.png)
