### PR TITLE
Fix sentRequests and sentRequestsCount reducers for subscription requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix highlight color of expand-panel
 - Fix YouTube previews
 - A tall Embedly previews now folded to a reasonable height
+- Created subscription requests are now visible at 'Requests' page without full
+  page reload.
 
 ### Added
 - Use open-source Vazir font to display Persian letters

--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -826,7 +826,7 @@ export const initialWhoamiMiddleware = (store) => (next) => (action) => {
 };
 
 // Fixing data structures coming from server
-export const dataFixMiddleware = (/*store*/) => (next) => (action) => {
+export const dataFixMiddleware = (store) => (next) => (action) => {
   if (action.type === response(ActionTypes.GET_SINGLE_POST)) {
     [action.payload, action.payload.posts].forEach(fixPostsData);
   }
@@ -856,6 +856,12 @@ export const dataFixMiddleware = (/*store*/) => (next) => (action) => {
 
   if (action.payload && action.payload.posts && _.isArray(action.payload.posts)) {
     action.payload.posts.forEach(fixPostsData);
+  }
+
+  if (action.type === response(ActionTypes.SEND_SUBSCRIPTION_REQUEST)) {
+    // Server doesn't return any data in response to subscription request, so we
+    // fill 'response' from the existiing state for use in reducers.
+    action.payload = store.getState().users[action.request.id] || action.request;
   }
 
   return next(action);

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -2013,6 +2013,9 @@ export function sentRequests(state = [], action) {
       const { username } = action.request;
       return state.filter((user) => user.username !== username);
     }
+    case response(ActionTypes.SEND_SUBSCRIPTION_REQUEST): {
+      return [...state, action.payload];
+    }
   }
 
   return state;
@@ -2054,6 +2057,9 @@ export function sentRequestsCount(state = 0, action) {
     }
     case response(ActionTypes.REVOKE_USER_REQUEST): {
       return Math.max(0, state - 1);
+    }
+    case response(ActionTypes.SEND_SUBSCRIPTION_REQUEST): {
+      return state + 1;
     }
   }
 


### PR DESCRIPTION
Created subscription requests are now visible at 'Requests' page without full page reload.
