### PR TITLE
Fix statlinks breaking up for private users that I cannot read

### DIFF
--- a/src/components/user-profile-head.jsx
+++ b/src/components/user-profile-head.jsx
@@ -535,7 +535,13 @@ function StatLink({ value, title, linkTo, canFollow, className }) {
   }
 
   if (canFollow) {
-    content = <Link to={linkTo}>{content}</Link>;
+    content = (
+      <Link to={linkTo} className={styles.statlinkText}>
+        {content}
+      </Link>
+    );
+  } else {
+    content = <span className={styles.statlinkText}>{content}</span>;
   }
 
   return <li className={cn(styles.statlink, className)}>{content}</li>;

--- a/src/components/user-profile-head.module.scss
+++ b/src/components/user-profile-head.module.scss
@@ -114,10 +114,10 @@ $actions-padding: 0.75em;
   .statlink {
     margin: 0;
     padding: 0;
+  }
 
-    & a {
-      white-space: nowrap;
-    }
+  .statlinkText {
+    white-space: nowrap;
   }
 
   .allPosts {


### PR DESCRIPTION
This PR fixes this bug:

![image](https://user-images.githubusercontent.com/632081/105637108-9c9c4080-5ea6-11eb-8d00-1d7808a5a9a0.png)
