### PR TITLE
Fix errors when signing out from some of sub-pages of settings

### DIFF
--- a/src/components/settings/forms/appearance.jsx
+++ b/src/components/settings/forms/appearance.jsx
@@ -329,7 +329,7 @@ function initialValues({ frontendPreferences: frontend, preferences: backend, is
     readMoreStyle: frontend.readMoreStyle,
     omitBubbles: frontend.comments.omitRepeatedBubbles,
     highlightComments: frontend.comments.highlightComments,
-    hideBannedComments: backend.hideCommentsOfTypes.includes(COMMENT_HIDDEN_BANNED),
+    hideBannedComments: backend?.hideCommentsOfTypes.includes(COMMENT_HIDDEN_BANNED),
     hideUnreadNotifications: frontend.hideUnreadNotifications,
     allowLinksPreview: frontend.allowLinksPreview,
     hideNSFWContent: !isNSFWVisible,

--- a/src/components/settings/forms/privacy.jsx
+++ b/src/components/settings/forms/privacy.jsx
@@ -100,7 +100,7 @@ export default (function PrivacyForm() {
 function initialValues(userData) {
   return {
     privacy: privacyFlagsToString(userData),
-    acceptDirectsFrom: userData.preferences.acceptDirectsFrom,
+    acceptDirectsFrom: userData.preferences?.acceptDirectsFrom,
   };
 }
 


### PR DESCRIPTION
Fixes TypeErrors when signing out from Privacy and Appearance sub-pages of Settings: 

<img width="955" alt="image" src="https://user-images.githubusercontent.com/632081/105637316-dd488980-5ea7-11eb-88d1-2906dd32af61.png">