### PR TITLE
Add roles everywhere

### DIFF
--- a/src/components/all-groups.jsx
+++ b/src/components/all-groups.jsx
@@ -28,7 +28,9 @@ export default function AllGroups() {
     <div className="content">
       <Helmet title={`All Groups - ${CONFIG.siteTitle}`} defer={false} />
       <div className="box">
-        <div className="box-header-timeline">All Groups</div>
+        <div className="box-header-timeline" role="heading">
+          All Groups
+        </div>
         <div className="box-body">
           {status.loading && <p>Loading...</p>}
           {status.error && (

--- a/src/components/archive-post.jsx
+++ b/src/components/archive-post.jsx
@@ -40,7 +40,9 @@ function ArchivePostHandler({ router, inProgress, success, id }) {
 
   return (
     <div className="box">
-      <div className="box-header-timeline">Friendfeed Post</div>
+      <div className="box-header-timeline" role="heading">
+        Friendfeed Post
+      </div>
       <div className="box-body">{postBody}</div>
       <div className="box-footer" />
     </div>

--- a/src/components/archive.jsx
+++ b/src/components/archive.jsx
@@ -20,7 +20,9 @@ class Archive extends Component {
       return (
         <div className="content">
           <div className="box">
-            <div className="box-header-timeline">Restore from FriendFeed.com Archives</div>
+            <div className="box-header-timeline" role="heading">
+              Restore from FriendFeed.com Archives
+            </div>
             <div className="box-body">
               <p>
                 We do not have any records about your old FriendFeed account. If you think this is a
@@ -35,7 +37,9 @@ class Archive extends Component {
     return (
       <div className="content">
         <div className="box">
-          <div className="box-header-timeline">Restore from FriendFeed.com Archives</div>
+          <div className="box-header-timeline" role="heading">
+            Restore from FriendFeed.com Archives
+          </div>
           <div className="box-body">
             <p>
               In April 2015, before FriendFeed was shut down, a group of volunteers had created an

--- a/src/components/comment-edit-form.jsx
+++ b/src/components/comment-edit-form.jsx
@@ -90,7 +90,7 @@ export const CommentEditForm = forwardRef(function CommentEditForm(
   const disabled = !canSubmit || submitStatus.loading || filesLoading;
 
   return (
-    <div className="comment-body">
+    <div className="comment-body" role="form">
       <PreventPageLeaving prevent={canSubmit || submitStatus.loading} />
       <div>
         <Textarea

--- a/src/components/comment-icon.jsx
+++ b/src/components/comment-icon.jsx
@@ -70,10 +70,10 @@ export default memo(function CommentIcon({ id, omitBubble = false, reply, mentio
     <div className="comment-likes-container" {...touchHandlers}>
       {/* Heart & likes count */}
       <div className={heartClass}>
-        <div className="comment-count" onClick={likesListToggle} ref={countRef}>
+        <div className="comment-count" onClick={likesListToggle} ref={countRef} role="button">
           {likes || ''}
         </div>
-        <div className="comment-heart" onClick={heartClick}>
+        <div className="comment-heart" onClick={heartClick} role="button">
           <Icon
             icon={canLike ? faHeart : faHeartO}
             className={cn('icon', { liked: hasOwnLike })}

--- a/src/components/create-bookmarklet-post.jsx
+++ b/src/components/create-bookmarklet-post.jsx
@@ -111,7 +111,7 @@ export default class CreateBookmarkletPost extends Component {
     ));
 
     return (
-      <div className="create-post post-editor expanded">
+      <div className="create-post post-editor expanded" role="form">
         {this.props.createPostViewState.isError ? (
           <div className="post-error alert alert-danger" role="alert">
             Post has not been saved. Server response:{' '}

--- a/src/components/create-post.jsx
+++ b/src/components/create-post.jsx
@@ -175,7 +175,7 @@ export default class CreatePost extends Component {
 
   render() {
     return (
-      <div className="create-post post-editor">
+      <div className="create-post post-editor" role="form">
         <ErrorBoundary>
           <div>
             {this.props.sendTo.expanded && (
@@ -214,6 +214,7 @@ export default class CreatePost extends Component {
             <span
               className="post-edit-attachments dropzone-trigger"
               disabled={this.state.dropzoneDisabled}
+              role="button"
             >
               <Icon icon={faPaperclip} className="upload-icon" /> Add photos or files
             </span>

--- a/src/components/discussions.jsx
+++ b/src/components/discussions.jsx
@@ -33,7 +33,7 @@ const FeedHandler = (props) => {
   return (
     <div className="box">
       <ErrorBoundary>
-        <div className="box-header-timeline">
+        <div className="box-header-timeline" role="heading">
           {props.boxHeader}
           <div className="pull-right">
             <FeedOptionsSwitch />

--- a/src/components/error-boundary.jsx
+++ b/src/components/error-boundary.jsx
@@ -29,7 +29,7 @@ class ErrorBoundary extends PureComponent {
       const errorMessage = `${error.name}: ${error.message} ${errorLocation}`;
 
       return (
-        <div className="error-boundary">
+        <div className="error-boundary" role="alert">
           <div className="error-boundary-header">
             Oops! {this.props.message || 'Something went wrong :('}
           </div>

--- a/src/components/expandable.jsx
+++ b/src/components/expandable.jsx
@@ -42,7 +42,7 @@ export default class Expandable extends Component {
           {!expanded && (
             <div className="expand-panel">
               <div className="expand-button">
-                <i onClick={this.userExpand}>
+                <i onClick={this.userExpand} role="button">
                   <Icon icon={faChevronDown} className="expand-icon" /> Read more
                 </i>{' '}
                 {this.props.bonusInfo}

--- a/src/components/feed.jsx
+++ b/src/components/feed.jsx
@@ -73,7 +73,7 @@ class Feed extends PureComponent {
     const hiddenEntries = (hiddenPosts || []).map(getEntryComponent('hidden'));
 
     return (
-      <div className="posts">
+      <div className="posts" role="feed list">
         <ErrorBoundary>
           {visibleEntries}
 

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -6,7 +6,7 @@ export default function Footer() {
   const authenticated = useSelector((state) => state.authenticated);
   return (
     <footer className="footer">
-      <p>
+      <p role="navigation">
         &copy; FreeFeed 1.93.0 (Not released)
         <br />
         <Link to="/about">About</Link>

--- a/src/components/friends-page/index.jsx
+++ b/src/components/friends-page/index.jsx
@@ -108,7 +108,7 @@ export const Friends = withLayout(function Friends({ router }) {
         defer={false}
       />
 
-      <ul className={cn('nav nav-tabs', styles.topNav)}>
+      <ul className={cn('nav nav-tabs', styles.topNav)} role="tablist">
         <Tab id="" activeId={activeTab}>
           Subscriptions <small className={styles.tabCounter}>{subscriptionsCount || ''}</small>
         </Tab>
@@ -129,15 +129,17 @@ export const Friends = withLayout(function Friends({ router }) {
         </Tab>
       </ul>
 
-      {activeTab === 'subscribers' ? (
-        <Subscribers />
-      ) : activeTab === 'blocked' ? (
-        <Blocked />
-      ) : activeTab === 'requests' ? (
-        <Requests />
-      ) : (
-        <Subscriptions listId={currentList} onListChange={onListChange} />
-      )}
+      <div role="tabpanel">
+        {activeTab === 'subscribers' ? (
+          <Subscribers />
+        ) : activeTab === 'blocked' ? (
+          <Blocked />
+        ) : activeTab === 'requests' ? (
+          <Requests />
+        ) : (
+          <Subscriptions listId={currentList} onListChange={onListChange} />
+        )}
+      </div>
     </>
   );
 });
@@ -146,7 +148,9 @@ function withLayout(Component) {
   const wrapper = (props) => (
     <div className="box">
       <ErrorBoundary>
-        <div className="box-header-timeline">Friends</div>
+        <div className="box-header-timeline" role="heading">
+          Friends
+        </div>
         <div className="box-body">
           <Component {...props} />
         </div>
@@ -172,7 +176,7 @@ function toAsyncStatus({ initial, isPending, errorString }) {
 function Tab({ id, activeId, children }) {
   const location = useSelector((state) => state.routing.locationBeforeTransitions);
   return (
-    <li role="presentation" className={cn({ active: id === activeId })}>
+    <li role="tab presentation" className={cn({ active: id === activeId })}>
       <Link to={{ ...location, query: id ? { show: id } : {} }}>{children}</Link>
     </li>
   );

--- a/src/components/group-create.jsx
+++ b/src/components/group-create.jsx
@@ -7,7 +7,9 @@ import ErrorBoundary from './error-boundary';
 const GroupCreate = (props) => (
   <div className="box">
     <ErrorBoundary>
-      <div className="box-header-timeline">Create a group</div>
+      <div className="box-header-timeline" role="heading">
+        Create a group
+      </div>
       <div className="box-body">
         <GroupCreateForm
           createGroup={props.createGroup}

--- a/src/components/group-settings.jsx
+++ b/src/components/group-settings.jsx
@@ -74,7 +74,9 @@ function Layout({ username, children }) {
   return (
     <div className="box">
       <Helmet title={`'${username}' group settings - ${CONFIG.siteTitle}`} defer={false} />
-      <div className="box-header-timeline">Group settings</div>
+      <div className="box-header-timeline" role="heading">
+        Group settings
+      </div>
       <div className="box-body">{children}</div>
     </div>
   );

--- a/src/components/groups.jsx
+++ b/src/components/groups.jsx
@@ -59,7 +59,9 @@ const GroupsHandler = (props) => {
   return (
     <div className="box">
       <ErrorBoundary>
-        <div className="box-header-timeline">Groups</div>
+        <div className="box-header-timeline" role="heading">
+          Groups
+        </div>
         <div className="box-body">
           <div className="row">
             <div className="col-md-8">All the groups you are subscribed to</div>

--- a/src/components/home-aux.jsx
+++ b/src/components/home-aux.jsx
@@ -76,7 +76,9 @@ export function HomeAux({ router }) {
   if (!authenticated) {
     return (
       <div className="box">
-        <div className="box-header-timeline">Sign in required</div>
+        <div className="box-header-timeline" role="heading">
+          Sign in required
+        </div>
         <div className="box-body">
           <p>
             Please{' '}
@@ -89,7 +91,9 @@ export function HomeAux({ router }) {
   } else if (allHomeFeedsStatus.error) {
     return (
       <div className="box">
-        <div className="box-header-timeline">Cannot load page</div>
+        <div className="box-header-timeline" role="heading">
+          Cannot load page
+        </div>
         <div className="box-body">
           <p className="alert alert-danger">
             Cannot load home feeds list: {allHomeFeedsStatus.errorText}
@@ -100,7 +104,9 @@ export function HomeAux({ router }) {
   } else if (!allHomeFeedsStatus.success) {
     return (
       <div className="box">
-        <div className="box-header-timeline">{router.params.listTitle}</div>
+        <div className="box-header-timeline" role="heading">
+          {router.params.listTitle}
+        </div>
         <div className="box-body">
           <p>
             Loading... <Throbber />
@@ -111,7 +117,9 @@ export function HomeAux({ router }) {
   } else if (!feed) {
     return (
       <div className="box">
-        <div className="box-header-timeline">List not found</div>
+        <div className="box-header-timeline" role="heading">
+          List not found
+        </div>
         <div className="box-body">
           <p>
             Cannot find list here. You may have followed the wrong link or the list was deleted.
@@ -133,7 +141,7 @@ export function HomeAux({ router }) {
     <div className="box">
       <Helmet title={`${feed.title} - ${CONFIG.siteTitle}`} defer={false} />
       <ErrorBoundary>
-        <div className="box-header-timeline">
+        <div className="box-header-timeline" role="heading">
           <TopHomeSelector id={feed.id} />{' '}
           <small>
             (<ButtonLink onClick={showEditor}>Edit list</ButtonLink>)

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -64,7 +64,7 @@ const FeedHandler = (props) => {
   return (
     <div className="box">
       <ErrorBoundary>
-        <div className="box-header-timeline">
+        <div className="box-header-timeline" role="heading">
           <TopHomeSelector id={feedId} />{' '}
           {feedId && (
             <small>

--- a/src/components/invitation-creation-form.jsx
+++ b/src/components/invitation-creation-form.jsx
@@ -43,7 +43,9 @@ class InvitationCreationForm extends Component {
     const { userFeeds, groupFeeds, user, form, baseLocation } = this.props;
     return (
       <div className="box">
-        <div className="box-header-timeline">Invite to {CONFIG.siteTitle}</div>
+        <div className="box-header-timeline" role="heading">
+          Invite to {CONFIG.siteTitle}
+        </div>
         <div className="box-body">
           <form onSubmit={preventDefault(this.createInvitation)}>
             <div>Suggested users</div>

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -35,7 +35,7 @@ const loadingPageMessage = (
 );
 
 const InternalLayout = ({ authenticated, children }) => (
-  <div className={authenticated ? 'col-md-9' : 'col-md-12'}>
+  <div className={authenticated ? 'col-md-9' : 'col-md-12'} role="main">
     <div className="content">
       <Suspense fallback={loadingPageMessage}>{children}</Suspense>
     </div>
@@ -156,8 +156,8 @@ class Layout extends Component {
             </div>
 
             {props.authenticated ? (
-              <div className="col-xs-12 col-sm-8 hidden-md hidden-lg">
-                <div className="mobile-shortcuts">
+              <div className="col-xs-12 col-sm-8 hidden-md hidden-lg" role="complementary">
+                <div className="mobile-shortcuts" role="navigation">
                   <Link className="mobile-shortcut-link" to="/filter/discussions">
                     Discussions
                   </Link>
@@ -177,7 +177,7 @@ class Layout extends Component {
                 </div>
               </div>
             ) : (
-              <div className="col-xs-3 col-sm-6 col-md-3 text-right">
+              <div className="col-xs-3 col-sm-6 col-md-3 text-right" role="complementary">
                 <div className="signin-link">
                   <Link to="/signin">Sign In</Link>
                 </div>

--- a/src/components/manage-subscribers.jsx
+++ b/src/components/manage-subscribers.jsx
@@ -33,7 +33,9 @@ class ManageSubscribersHandler extends PureComponent {
 
     return (
       <div className="box">
-        <div className="box-header-timeline">{props.boxHeader}</div>
+        <div className="box-header-timeline" role="heading">
+          {props.boxHeader}
+        </div>
         <div className="box-body">
           <div className="row">
             <div className="col-md-6">

--- a/src/components/not-found.jsx
+++ b/src/components/not-found.jsx
@@ -5,7 +5,9 @@ export function NotFound() {
   return (
     <div className="box">
       <Helmet title={`Page not found - ${CONFIG.siteTitle}`} defer={false} />
-      <div className="box-header-timeline">Page not found</div>
+      <div className="box-header-timeline" role="heading">
+        Page not found
+      </div>
       <div className="box-body">
         <p className="alert alert-danger">
           There is no page with such an address on {CONFIG.siteTitle}.

--- a/src/components/notifications.jsx
+++ b/src/components/notifications.jsx
@@ -230,7 +230,7 @@ const isFilterActive = (filterName, filter) => filter && filter.includes(filterN
 const Notifications = (props) => (
   <div className="box notifications">
     <ErrorBoundary>
-      <div className="box-header-timeline">
+      <div className="box-header-timeline" role="heading">
         Notifications
         {props.isLoading && (
           <span className="notifications-throbber">

--- a/src/components/plain-feed.jsx
+++ b/src/components/plain-feed.jsx
@@ -9,7 +9,7 @@ import ErrorBoundary from './error-boundary';
 const FeedHandler = (props) => (
   <div className="box">
     <ErrorBoundary>
-      <div className="box-header-timeline">
+      <div className="box-header-timeline" role="heading">
         {props.boxHeader}
         {props.route.name === 'everything' && (
           <div className="pull-right">

--- a/src/components/post-attachment-audio.jsx
+++ b/src/components/post-attachment-audio.jsx
@@ -24,7 +24,7 @@ class AudioAttachment extends PureComponent {
     }
 
     return (
-      <div className="attachment">
+      <div className="attachment" role="figure">
         <div>
           <audio src={props.url} title={artistAndTitle} preload="none" controls />
         </div>

--- a/src/components/post-attachment-general.jsx
+++ b/src/components/post-attachment-general.jsx
@@ -16,7 +16,7 @@ class GeneralAttachment extends PureComponent {
     const nameAndSize = `${props.fileName} (${formattedFileSize})`;
 
     return (
-      <div className="attachment">
+      <div className="attachment" role="figure">
         <a href={props.url} title={nameAndSize} target="_blank">
           <Icon icon={faFile} className="attachment-icon" />
           <span className="attachment-title">{nameAndSize}</span>

--- a/src/components/post-attachment-image.jsx
+++ b/src/components/post-attachment-image.jsx
@@ -48,7 +48,11 @@ class PostAttachmentImage extends PureComponent {
     };
 
     return (
-      <div className={classnames({ attachment: true, hidden: props.isHidden })} data-id={props.id}>
+      <div
+        className={classnames({ attachment: true, hidden: props.isHidden })}
+        data-id={props.id}
+        role="figure"
+      >
         <a
           href={props.url}
           title={nameAndSize}

--- a/src/components/post-comment.jsx
+++ b/src/components/post-comment.jsx
@@ -157,14 +157,24 @@ class PostComment extends Component {
         {this.props.isEditable ? (
           <span>
             {' '}
-            (<a onClick={this.handleEditOrCancel}>edit</a>
+            (
+            <a onClick={this.handleEditOrCancel} role="button">
+              edit
+            </a>
             &nbsp;|&nbsp;
-            <a onClick={this.handleDeleteComment}>delete</a>)
+            <a onClick={this.handleDeleteComment} role="button">
+              delete
+            </a>
+            )
           </span>
         ) : this.props.isDeletable && this.props.isModeratingComments ? (
           <span>
             {' '}
-            (<a onClick={this.handleDeleteComment}>delete</a>)
+            (
+            <a onClick={this.handleDeleteComment} role="button">
+              delete
+            </a>
+            )
           </span>
         ) : (
           false
@@ -255,6 +265,7 @@ class PostComment extends Component {
         className={className}
         data-author={this.props.user && !this.props.isEditing ? this.props.user.username : ''}
         ref={this.registerCommentContainer}
+        role="comment listitem"
       >
         {this.renderCommentIcon()}
         {this.renderBody()}

--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -64,10 +64,14 @@ export default class PostComments extends Component {
     if (props.comments.length > 2 && !props.post.omittedComments) {
       return (
         <div className="comment">
-          <a className="comment-icon fa-stack" onClick={preventDefault(toggleCommenting)}>
+          <a
+            className="comment-icon fa-stack"
+            onClick={preventDefault(toggleCommenting)}
+            role="button"
+          >
             <Icon icon={faCommentPlus} />
           </a>
-          <a className="add-comment-link" onClick={preventDefault(toggleCommenting)}>
+          <a className="add-comment-link" onClick={preventDefault(toggleCommenting)} role="button">
             Add comment
           </a>
           {disabledForOthers ? <i> - disabled for others</i> : false}
@@ -206,7 +210,7 @@ export default class PostComments extends Component {
     const last = withBackwardNumber(comments.length > 1 && comments[comments.length - 1], 1);
 
     return (
-      <div className="comments" ref={this.rootEl}>
+      <div className="comments" ref={this.rootEl} rel="list">
         <ErrorBoundary>
           {[
             first && this.renderComment(first),

--- a/src/components/post-hides-ui.jsx
+++ b/src/components/post-hides-ui.jsx
@@ -109,7 +109,7 @@ export function HideLink({
   }
 
   return (
-    <a className="post-action" onClick={handler}>
+    <a className="post-action" onClick={handler} role="button">
       {text}
     </a>
   );

--- a/src/components/post-more-menu.jsx
+++ b/src/components/post-more-menu.jsx
@@ -8,7 +8,7 @@ export default function PostMoreMenu({ post, ...props }) {
 
   return (
     <>
-      <a className="post-action" ref={pivotRef} onClick={toggle}>
+      <a className="post-action" ref={pivotRef} onClick={toggle} role="button">
         More&#x200a;&#x25be;
       </a>
       {opened && (
@@ -16,7 +16,7 @@ export default function PostMoreMenu({ post, ...props }) {
           <ul className={styles.list} ref={menuRef}>
             {post.isEditable && (
               <li className={styles.item}>
-                <a className={styles.link} onClick={props.toggleEditingPost}>
+                <a className={styles.link} onClick={props.toggleEditingPost} role="button">
                   Edit
                 </a>
               </li>
@@ -24,7 +24,7 @@ export default function PostMoreMenu({ post, ...props }) {
 
             {post.isModeratable && (
               <li className={styles.item}>
-                <a className={styles.link} onClick={props.toggleModeratingComments}>
+                <a className={styles.link} onClick={props.toggleModeratingComments} role="button">
                   {post.isModeratingComments ? 'Stop moderating comments' : 'Moderate comments'}
                 </a>
               </li>
@@ -32,13 +32,13 @@ export default function PostMoreMenu({ post, ...props }) {
 
             {post.commentsDisabled ? (
               <li className={styles.item}>
-                <a className={styles.link} onClick={props.enableComments}>
+                <a className={styles.link} onClick={props.enableComments} role="button">
                   Enable comments
                 </a>
               </li>
             ) : (
               <li className={styles.item}>
-                <a className={styles.link} onClick={props.disableComments}>
+                <a className={styles.link} onClick={props.disableComments} role="button">
                   Disable comments
                 </a>
               </li>
@@ -48,6 +48,7 @@ export default function PostMoreMenu({ post, ...props }) {
               <a
                 className={`${styles.link} ${styles.danger}`}
                 onClick={confirmFirst(props.deletePost)}
+                role="button"
               >
                 {post.isFullyRemovable ? 'Delete' : 'Remove from group'}
               </a>

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -351,7 +351,7 @@ class Post extends Component {
 
     const commentLink = amIAuthenticated &&
       (!props.commentsDisabled || props.isEditable || props.isModeratable) && (
-        <a className="post-action" onClick={this.handleCommentClick}>
+        <a className="post-action" onClick={this.handleCommentClick} role="button">
           Comment
         </a>
       );
@@ -364,7 +364,11 @@ class Post extends Component {
           {props.likeError ? (
             <Icon icon={faExclamationTriangle} className="post-like-fail" title={props.likeError} />
           ) : null}
-          <a className="post-action" onClick={didILikePost ? this.unlikePost : this.likePost}>
+          <a
+            className="post-action"
+            onClick={didILikePost ? this.unlikePost : this.likePost}
+            role="button"
+          >
             {didILikePost ? 'Un-like' : 'Like'}
           </a>
           {props.isLiking ? (
@@ -382,7 +386,7 @@ class Post extends Component {
     const { isSaved, savePostStatus } = this.props;
     const saveLink = amIAuthenticated && (
       <>
-        <a className="post-action" onClick={this.toggleSave}>
+        <a className="post-action" onClick={this.toggleSave} role="button">
           {isSaved ? 'Un-save' : 'Save'}
         </a>
         {savePostStatus.loading && <Throbber />}
@@ -416,8 +420,10 @@ class Post extends Component {
       (attachment) => attachment.mediaType === 'image',
     );
 
+    const role = `article${props.isSinglePost ? '' : ' listitem'}`;
+
     return (
-      <div className={postClass} data-author={props.createdBy.username}>
+      <div className={postClass} data-author={props.createdBy.username} role={role}>
         <ErrorBoundary>
           <Expandable
             expanded={
@@ -489,6 +495,7 @@ class Post extends Component {
                     <span
                       className="post-edit-attachments dropzone-trigger"
                       disabled={this.state.dropzoneDisabled}
+                      role="button"
                     >
                       <Icon icon={faPaperclip} className="upload-icon" /> Add photos or files
                     </span>
@@ -577,6 +584,7 @@ class Post extends Component {
                     className="post-lock-icon post-private-icon"
                     title="This entry is private"
                     onClick={this.toggleTimestamps}
+                    role="button"
                   />
                 ) : isProtected ? (
                   <Icon
@@ -584,6 +592,7 @@ class Post extends Component {
                     className="post-lock-icon post-protected-icon"
                     title={`This entry is only visible to ${CONFIG.siteTitle} users`}
                     onClick={this.toggleTimestamps}
+                    role="button"
                   />
                 ) : (
                   <Icon
@@ -591,6 +600,7 @@ class Post extends Component {
                     className="post-lock-icon post-public-icon"
                     title="This entry is public"
                     onClick={this.toggleTimestamps}
+                    role="button"
                   />
                 )}
               </div>

--- a/src/components/reset-password.jsx
+++ b/src/components/reset-password.jsx
@@ -62,7 +62,9 @@ class ResetPassword extends Component {
   render() {
     return (
       <div className="box">
-        <div className="box-header-timeline">Hello</div>
+        <div className="box-header-timeline" role="heading">
+          Hello
+        </div>
         <div className="box-body">
           <div className="col-md-12">
             <h2 className="p-signin-header">{this.props.header}</h2>

--- a/src/components/restore-password.jsx
+++ b/src/components/restore-password.jsx
@@ -12,7 +12,9 @@ import { Throbber } from './throbber';
 export default memo(function RestorePasswordPage() {
   return (
     <div className="box">
-      <div className="box-header-timeline">Welcome to {CONFIG.siteTitle}!</div>
+      <div className="box-header-timeline" role="heading">
+        Welcome to {CONFIG.siteTitle}!
+      </div>
       <div className="box-body">
         <div className="col-md-12">
           <h2 className="p-signin-header">Reset {CONFIG.siteTitle} password</h2>

--- a/src/components/search-feed.jsx
+++ b/src/components/search-feed.jsx
@@ -31,7 +31,9 @@ function FeedHandler(props) {
 
   return (
     <div className="box">
-      <div className="box-header-timeline">{props.boxHeader}</div>
+      <div className="box-header-timeline" role="heading">
+        {props.boxHeader}
+      </div>
       <div className="box-body" style={{ marginTop: '1em' }}>
         {queryString && (
           <>

--- a/src/components/search-form.jsx
+++ b/src/components/search-form.jsx
@@ -54,7 +54,7 @@ export default withRouter(function SearchForm({ router }) {
   );
 
   return (
-    <div className="search-form">
+    <div className="search-form" role="search form">
       <input
         value={query}
         onChange={onChange}

--- a/src/components/settings/layout.jsx
+++ b/src/components/settings/layout.jsx
@@ -73,7 +73,9 @@ export default function Layout({ children, router }) {
         defaultTitle={`Settinge - ${CONFIG.siteTitle}`}
       />
       <div className="box">
-        <div className="box-header-timeline">Settings</div>
+        <div className="box-header-timeline" role="heading">
+          Settings
+        </div>
         <div className="box-body">
           {narrowScreen ? (
             <select value={activeTab} className={styles.tabSelect} onChange={selectTab}>
@@ -84,7 +86,7 @@ export default function Layout({ children, router }) {
               ))}
             </select>
           ) : (
-            <ul className={`nav nav-tabs ${styles.navigation}`}>
+            <ul className={`nav nav-tabs ${styles.navigation}`} role="tablist">
               {tabs.map((t) => (
                 <Tab key={t.id} id={t.id} activeId={activeTab} icon={t.icon}>
                   {t.title}
@@ -101,17 +103,17 @@ export default function Layout({ children, router }) {
 
 export function SettingsPage({ title, header = title, children }) {
   return (
-    <>
+    <div role="tabpanel">
       <Helmet title={title} defer={false} />
       <h3 className={styles.pageHeader}>{header}</h3>
       {children}
-    </>
+    </div>
   );
 }
 
 function Tab({ id, activeId, icon, children }) {
   return (
-    <li role="presentation" className={cn(styles.navTab, { active: id === activeId })}>
+    <li role="tab presentation" className={cn(styles.navTab, { active: id === activeId })}>
       <Link to={settingsSection(id)}>
         <Icon icon={icon} className={styles.tabIcon} />{' '}
         <span className={styles.tabText}>{children}</span>

--- a/src/components/sidebar.jsx
+++ b/src/components/sidebar.jsx
@@ -398,7 +398,7 @@ const SideBarAppearance = connect(
 
 const SideBar = ({ user, signOut, recentGroups }) => {
   return (
-    <div className="col-md-3 sidebar">
+    <div className="col-md-3 sidebar" role="navigation complementary">
       <ErrorBoundary>
         <LoggedInBlock user={user} signOut={signOut} />
         <SideBarFriends user={user} />

--- a/src/components/signin.jsx
+++ b/src/components/signin.jsx
@@ -19,7 +19,9 @@ export default memo(function SignInPage() {
 
   return (
     <div className="box">
-      <div className="box-header-timeline">Welcome to {CONFIG.siteTitle}!</div>
+      <div className="box-header-timeline" role="heading">
+        Welcome to {CONFIG.siteTitle}!
+      </div>
       <div className="box-body">
         <div className="col-md-12">
           <h2 className="p-signin-header">Sign in</h2>

--- a/src/components/signup-by-invitation.jsx
+++ b/src/components/signup-by-invitation.jsx
@@ -65,7 +65,9 @@ class SignupByInvitation extends PureComponent {
     const { error } = this.props;
     return (
       <div className="box signup-by-invite">
-        <div className="box-header-timeline">Welcome to {CONFIG.siteTitle}!</div>
+        <div className="box-header-timeline" role="heading">
+          Welcome to {CONFIG.siteTitle}!
+        </div>
         <div className="box-body">
           <div className="col-md-12">
             <h2 className="p-signin-header" />

--- a/src/components/signup.jsx
+++ b/src/components/signup.jsx
@@ -18,7 +18,9 @@ export default memo(function Signup() {
 
   return (
     <div className="box">
-      <div className="box-header-timeline">Hello</div>
+      <div className="box-header-timeline" role="heading">
+        Hello
+      </div>
       <div className="box-body">
         <div className="col-md-12">
           <h2 className="p-signin-header">Sign up</h2>

--- a/src/components/single-post.jsx
+++ b/src/components/single-post.jsx
@@ -66,7 +66,9 @@ class SinglePostHandler extends Component {
 
     return (
       <div className="box">
-        <div className="box-header-timeline">{props.boxHeader}</div>
+        <div className="box-header-timeline" role="heading">
+          {props.boxHeader}
+        </div>
         <div className="box-body">{postBody}</div>
         <div className="box-footer" />
       </div>
@@ -95,7 +97,9 @@ function PrivatePost({ isAuthorized, feedName }) {
   return (
     <div className="box">
       <Helmet title={`Access denied - ${CONFIG.siteTitle}`} defer={false} />
-      <div className="box-header-timeline">Access denied</div>
+      <div className="box-header-timeline" role="heading">
+        Access denied
+      </div>
       <div className="box-body">
         <h3>The post you requested is private</h3>
         {isAuthorized ? (
@@ -125,7 +129,9 @@ function ProtectedPost() {
   return (
     <div className="box">
       <Helmet title={`Access denied - ${CONFIG.siteTitle}`} defer={false} />
-      <div className="box-header-timeline">Access denied</div>
+      <div className="box-header-timeline" role="heading">
+        Access denied
+      </div>
       <div className="box-body">
         <h3>This post is visible to {CONFIG.siteTitle} users only</h3>
         <p>
@@ -142,7 +148,9 @@ function NotFoundPost() {
   return (
     <div className="box">
       <Helmet title={`Post not found - ${CONFIG.siteTitle}`} defer={false} />
-      <div className="box-header-timeline">Post not found</div>
+      <div className="box-header-timeline" role="heading">
+        Post not found
+      </div>
       <div className="box-body">
         <h3>This post does not exist</h3>
         <p>It may have been removed or never existed on {CONFIG.siteTitle}.</p>

--- a/src/components/subscribers.jsx
+++ b/src/components/subscribers.jsx
@@ -18,7 +18,9 @@ class SubscribersHandler extends Component {
     const { props } = this;
     return (
       <div className="box">
-        <div className="box-header-timeline">{props.boxHeader}</div>
+        <div className="box-header-timeline" role="heading">
+          {props.boxHeader}
+        </div>
         <div className="box-body">
           <div className="row">
             <div className="col-md-6">

--- a/src/components/subscriptions.jsx
+++ b/src/components/subscriptions.jsx
@@ -7,7 +7,9 @@ import SubsList from './subs-list';
 const SubscriptionsHandler = (props) => {
   return (
     <div className="box">
-      <div className="box-header-timeline">{props.boxHeader}</div>
+      <div className="box-header-timeline" role="heading">
+        {props.boxHeader}
+      </div>
       <div className="box-body">
         <div>
           <Link to={`/${props.username}`}>{props.username}</Link> › Subscriptions

--- a/src/components/summary.jsx
+++ b/src/components/summary.jsx
@@ -12,7 +12,7 @@ class Summary extends Component {
 
     return (
       <div className="box">
-        <div className="box-header-timeline">
+        <div className="box-header-timeline" role="heading">
           {props.boxHeader}
 
           <div className="sidelinks">

--- a/src/components/throbber.jsx
+++ b/src/components/throbber.jsx
@@ -72,6 +72,10 @@ const ThrobberOnCanvas = memo(function ThrobberOnCanvas({
         width: `${size}px`,
         height: `${size}px`,
       }}
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Please wait..."
     />
   );
 });

--- a/src/components/user.jsx
+++ b/src/components/user.jsx
@@ -63,7 +63,7 @@ const UserHandler = (props) => {
           </Helmet>
         )}
 
-        <div className="box-header-timeline">
+        <div className="box-header-timeline" role="heading">
           {props.boxHeader}
           <div className="pull-right">
             <FeedOptionsSwitch />

--- a/src/utils/search-highlighter.js
+++ b/src/utils/search-highlighter.js
@@ -75,7 +75,7 @@ export function highlightString(text, terms) {
     if (match !== '') {
       result.push(text.slice(0, Math.max(0, minPos)));
       result.push(
-        <span key={`hl-${result.length}`} className={hlClass}>
+        <span key={`hl-${result.length}`} className={hlClass} role="mark">
           {match}
         </span>,
       );


### PR DESCRIPTION
This PR adds `role` attributes to elements according to https://www.codeinwp.com/blog/wai-aria-roles/, https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles, and https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques. This (hopefully) will improve accessibility of Freefeed, and also will be used to select elements when running automated integration tests.