### PR TITLE
Make comments-folder display above readmore in comments

### DIFF
--- a/styles/shared/comments.scss
+++ b/styles/shared/comments.scss
@@ -130,7 +130,7 @@
 .comments-folder {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 2;
   font-style: italic;
   padding: 8px 0 0 59px;
   margin-left: -40px;


### PR DESCRIPTION
Before:

<img width="393" alt="Screenshot 2021-01-28 at 14 04 56" src="https://user-images.githubusercontent.com/632081/106097333-14ea5680-6172-11eb-9e2f-44274c2a5e57.png">

After:

<img width="393" alt="Screenshot 2021-01-28 at 14 05 09" src="https://user-images.githubusercontent.com/632081/106097353-1b78ce00-6172-11eb-8675-13a8b059578f.png">

