### PR TITLE
Add aria-labels to make UI more accessible

### DIFF
--- a/src/components/comment-icon.jsx
+++ b/src/components/comment-icon.jsx
@@ -7,6 +7,7 @@ import { faHeart as faHeartO, faComment } from '@fortawesome/free-regular-svg-ic
 
 import { Portal } from 'react-portal';
 import { unlikeComment, likeComment } from '../redux/action-creators';
+import { pluralForm } from '../utils';
 import TimeDisplay from './time-display';
 import UserName from './user-name';
 import { Icon } from './fontawesome-icons';
@@ -70,9 +71,19 @@ export default memo(function CommentIcon({ id, omitBubble = false, reply, mentio
     <div className="comment-likes-container" {...touchHandlers}>
       {/* Heart & likes count */}
       <div className={heartClass}>
-        <div className="comment-count" onClick={likesListToggle} ref={countRef} role="button">
-          {likes || ''}
-        </div>
+        {likes ? (
+          <div
+            className="comment-count"
+            onClick={likesListToggle}
+            ref={countRef}
+            role="button"
+            aria-label={pluralForm(likes, 'comment like')}
+          >
+            {likes}
+          </div>
+        ) : (
+          false
+        )}
         <div className="comment-heart" onClick={heartClick} role="button">
           <Icon
             icon={canLike ? faHeart : faHeartO}

--- a/src/components/create-post.jsx
+++ b/src/components/create-post.jsx
@@ -175,7 +175,7 @@ export default class CreatePost extends Component {
 
   render() {
     return (
-      <div className="create-post post-editor" role="form">
+      <div className="create-post post-editor" role="form" aria-label="Write a post">
         <ErrorBoundary>
           <div>
             {this.props.sendTo.expanded && (

--- a/src/components/expandable.jsx
+++ b/src/components/expandable.jsx
@@ -42,7 +42,7 @@ export default class Expandable extends Component {
           {!expanded && (
             <div className="expand-panel">
               <div className="expand-button">
-                <i onClick={this.userExpand} role="button">
+                <i onClick={this.userExpand} role="button" aria-hidden>
                   <Icon icon={faChevronDown} className="expand-icon" /> Read more
                 </i>{' '}
                 {this.props.bonusInfo}

--- a/src/components/feed-options-switch.jsx
+++ b/src/components/feed-options-switch.jsx
@@ -61,7 +61,7 @@ export default function FeedOptionsSwitch() {
   }, [dispatch, frontendPreferences, userId]);
 
   return (
-    <div className={styles.switchIcon}>
+    <div className={styles.switchIcon} role="button" aria-label="Feed ordering options">
       <Icon icon={faEllipsis} className="dots-icon" onClick={toggle} ref={pivotRef} />
       {opened && (
         <Portal>

--- a/src/components/home-aux.jsx
+++ b/src/components/home-aux.jsx
@@ -141,8 +141,8 @@ export function HomeAux({ router }) {
     <div className="box">
       <Helmet title={`${feed.title} - ${CONFIG.siteTitle}`} defer={false} />
       <ErrorBoundary>
-        <div className="box-header-timeline" role="heading">
-          <TopHomeSelector id={feed.id} />{' '}
+        <div className="box-header-timeline" role="heading" aria-labelledby="feed-name">
+          <TopHomeSelector id={feed.id} feedLabelId="feed-name" />{' '}
           <small>
             (<ButtonLink onClick={showEditor}>Edit list</ButtonLink>)
           </small>

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -64,8 +64,8 @@ const FeedHandler = (props) => {
   return (
     <div className="box">
       <ErrorBoundary>
-        <div className="box-header-timeline" role="heading">
-          <TopHomeSelector id={feedId} />{' '}
+        <div className="box-header-timeline" role="heading" aria-labelledby="feed-name">
+          <TopHomeSelector id={feedId} feedLabelId="feed-name" />{' '}
           {feedId && (
             <small>
               (<ButtonLink onClick={showEditor}>Edit list</ButtonLink>)
@@ -157,7 +157,7 @@ export const SubscrRequests = memo(function SubscrRequests() {
   );
 });
 
-export const TopHomeSelector = withRouter(function TopHomeSelector({ router, id }) {
+export const TopHomeSelector = withRouter(function TopHomeSelector({ router, id, feedLabelId }) {
   const homeFeeds = useSelector((state) => state.homeFeeds);
   const narrowScreen = useMediaQuery('(max-width: 991px)');
 
@@ -167,15 +167,15 @@ export const TopHomeSelector = withRouter(function TopHomeSelector({ router, id 
   );
 
   if (homeFeeds.length === 1) {
-    return homeFeeds[0].title;
+    return <span id={feedLabelId}>{homeFeeds[0].title}</span>;
   }
 
   if (!narrowScreen) {
-    return homeFeeds.find((h) => h.id === id)?.title || 'Home';
+    return <span id={feedLabelId}>{homeFeeds.find((h) => h.id === id)?.title || 'Home'}</span>;
   }
 
   return (
-    <InvisibleSelect value={id} onChange={onChange} withCaret>
+    <InvisibleSelect value={id} onChange={onChange} withCaret labelValueId={feedLabelId}>
       {homeFeeds.map((h) => (
         <option key={h.id} value={h.id}>
           {h.title}

--- a/src/components/invisible-select.jsx
+++ b/src/components/invisible-select.jsx
@@ -5,7 +5,14 @@ import '../../styles/shared/invisible-select.scss';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons';
 import { Icon } from './fontawesome-icons';
 
-export function InvisibleSelect({ children, value, className, withCaret = false, ...rest }) {
+export function InvisibleSelect({
+  children,
+  value,
+  className,
+  labelValueId,
+  withCaret = false,
+  ...rest
+}) {
   const selectedLabel = useMemo(() => {
     const optProps = Children.toArray(children)
       .filter((c) => c.type === 'option')
@@ -28,7 +35,9 @@ export function InvisibleSelect({ children, value, className, withCaret = false,
       )}
     >
       <div className="invisibleSelect__label">
-        {selectedLabel}
+        <span className="invisibleSelect__labelValue" id={labelValueId}>
+          {selectedLabel}
+        </span>
         {withCaret && <Icon icon={faCaretDown} className="invisibleSelect__caret" />}
       </div>
       <select value={value} className="invisibleSelect__select" {...rest}>

--- a/src/components/more-comments-wrapper.jsx
+++ b/src/components/more-comments-wrapper.jsx
@@ -10,6 +10,7 @@ const MoreCommentsWrapper = (props) => (
         className="more-comments-link"
         href={props.entryUrl}
         onClick={preventDefault(() => props.showMoreComments())}
+        role="button"
       >
         {getText(props)}
       </a>

--- a/src/components/pagination-links.jsx
+++ b/src/components/pagination-links.jsx
@@ -11,7 +11,7 @@ export default (props) => {
   delete allQuery.offset;
 
   return (
-    <ul className="pager p-pagination-controls">
+    <ul className="pager p-pagination-controls" role="navigation">
       {props.offset > 0 ? (
         <li>
           <Link

--- a/src/components/post-attachment-audio.jsx
+++ b/src/components/post-attachment-audio.jsx
@@ -24,7 +24,7 @@ class AudioAttachment extends PureComponent {
     }
 
     return (
-      <div className="attachment" role="figure">
+      <div className="attachment" role="figure" aria-label={`Audio attachment ${artistAndTitle}`}>
         <div>
           <audio src={props.url} title={artistAndTitle} preload="none" controls />
         </div>

--- a/src/components/post-attachment-general.jsx
+++ b/src/components/post-attachment-general.jsx
@@ -16,7 +16,7 @@ class GeneralAttachment extends PureComponent {
     const nameAndSize = `${props.fileName} (${formattedFileSize})`;
 
     return (
-      <div className="attachment" role="figure">
+      <div className="attachment" role="figure" aria-label={`Attachment ${nameAndSize}`}>
         <a href={props.url} title={nameAndSize} target="_blank">
           <Icon icon={faFile} className="attachment-icon" />
           <span className="attachment-title">{nameAndSize}</span>

--- a/src/components/post-attachment-image.jsx
+++ b/src/components/post-attachment-image.jsx
@@ -18,6 +18,7 @@ class PostAttachmentImage extends PureComponent {
       ? `, ${props.imageSizes.o.w}×${props.imageSizes.o.h}px`
       : '';
     const nameAndSize = `${props.fileName} (${formattedFileSize}${formattedImageSize})`;
+    const alt = `Image attachment ${props.fileName}`;
 
     let srcSet;
     if (props.imageSizes.t2 && props.imageSizes.t2.url) {
@@ -33,7 +34,7 @@ class PostAttachmentImage extends PureComponent {
     const imageAttributes = {
       src: (props.imageSizes.t && props.imageSizes.t.url) || props.thumbnailUrl,
       srcSet,
-      alt: nameAndSize,
+      alt,
       loading: 'lazy',
       width: props.imageSizes.t
         ? props.imageSizes.t.w

--- a/src/components/post-attachments.jsx
+++ b/src/components/post-attachments.jsx
@@ -55,7 +55,7 @@ export default (props) => {
     );
 
   return attachments.length > 0 ? (
-    <div className="attachments">
+    <div className="attachments" role="region" aria-label={`${attachments.length} attachments`}>
       <ErrorBoundary>
         {imageAttachmentsContainer}
         {audioAttachmentsContainer}

--- a/src/components/post-comment.jsx
+++ b/src/components/post-comment.jsx
@@ -145,7 +145,7 @@ class PostComment extends Component {
     }
 
     const authorAndButtons = (
-      <span>
+      <span aria-label={`Comment by ${this.props.user.username}`}>
         {' -'}&nbsp;
         <UserName
           user={this.props.user}

--- a/src/components/post-comments.jsx
+++ b/src/components/post-comments.jsx
@@ -1,7 +1,7 @@
 import { createRef, Component } from 'react';
 import { Link } from 'react-router';
 
-import { preventDefault } from '../utils';
+import { preventDefault, pluralForm } from '../utils';
 import { safeScrollBy } from '../services/unscroll';
 import PostComment from './post-comment';
 import MoreCommentsWrapper from './more-comments-wrapper';
@@ -210,7 +210,12 @@ export default class PostComments extends Component {
     const last = withBackwardNumber(comments.length > 1 && comments[comments.length - 1], 1);
 
     return (
-      <div className="comments" ref={this.rootEl} role="list">
+      <div
+        className="comments"
+        ref={this.rootEl}
+        role="list"
+        aria-label={pluralForm(totalComments, 'comment')}
+      >
         <ErrorBoundary>
           {[
             first && this.renderComment(first),

--- a/src/components/post-likes.jsx
+++ b/src/components/post-likes.jsx
@@ -1,5 +1,5 @@
 import { faHeart } from '@fortawesome/free-solid-svg-icons';
-import { preventDefault } from '../utils';
+import { preventDefault, pluralForm } from '../utils';
 import UserName from './user-name';
 import ErrorBoundary from './error-boundary';
 import { Icon } from './fontawesome-icons';
@@ -37,7 +37,7 @@ export default ({ likes, showMoreLikes, post }) => {
   const renderedLikes = likeList.map(renderLike);
 
   return (
-    <div className="post-likes">
+    <div className="post-likes" aria-label={pluralForm(likes.length, 'like')}>
       <ErrorBoundary>
         <Icon icon={faHeart} className="icon" />
         <ul className="post-likes-list">{renderedLikes}</ul>

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -14,6 +14,7 @@ import {
   faPaperclip,
 } from '@fortawesome/free-solid-svg-icons';
 
+import { pluralForm } from '../utils';
 import { getFirstLinkToEmbed } from '../utils/parse-text';
 import { READMORE_STYLE_COMPACT } from '../utils/frontend-preferences-options';
 import { postReadmoreConfig } from '../utils/readmore-config';
@@ -422,8 +423,43 @@ class Post extends Component {
 
     const role = `article${props.isSinglePost ? '' : ' listitem'}`;
 
+    const postTypeLabel = props.isDirect
+      ? 'Direct message'
+      : isPrivate
+      ? 'Private post'
+      : isProtected
+      ? 'Protected post'
+      : 'Public post';
+
+    const recipientsWithoutAuthor = props.recipientNames.filter(
+      (r) => r !== props.createdBy.username,
+    );
+    const recipientsLabel =
+      recipientsWithoutAuthor.length > 0 ? `to ${recipientsWithoutAuthor.join(', ')}` : false;
+
+    const commentsAndLikesLabel = `with ${pluralForm(
+      props.omittedComments + props.comments.length,
+      'comment',
+    )} and ${pluralForm(props.likes.length, 'like')}`;
+
+    const postLabel = [
+      props.isNSFW ? 'Not safe for work' : false,
+      postTypeLabel,
+      `by ${props.createdBy.username}`,
+      recipientsLabel,
+      commentsAndLikesLabel,
+      `written on ${new Date(+props.createdAt).toLocaleDateString()}`,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
     return (
-      <div className={postClass} data-author={props.createdBy.username} role={role}>
+      <div
+        className={postClass}
+        data-author={props.createdBy.username}
+        role={role}
+        aria-label={postLabel}
+      >
         <ErrorBoundary>
           <Expandable
             expanded={
@@ -441,7 +477,7 @@ class Post extends Component {
                 loading="lazy"
               />
             </div>
-            <div className="post-body">
+            <div className="post-body" role="region" aria-label="Post body">
               {props.isEditing ? (
                 <div>
                   <SendTo
@@ -569,14 +605,14 @@ class Post extends Component {
                   previews for sensitive content
                 </div>
               ) : (
-                <div className="link-preview">
+                <div className="link-preview" role="region" aria-label="Link preview">
                   <LinkPreview url={linkToEmbed} allowEmbedly={props.allowLinksPreview} />
                 </div>
               ))}
 
             <div className="dropzone-previews" />
 
-            <div className="post-footer">
+            <div className="post-footer" role="region" aria-label="Post footer">
               <div className="post-footer-icon">
                 {isPrivate ? (
                   <Icon
@@ -631,7 +667,7 @@ class Post extends Component {
                     </span>
                   )}
                 </span>
-                <span className="post-footer-block">
+                <span className="post-footer-block" role="region">
                   <span className="post-footer-item">{commentLink}</span>
                   <span className="post-footer-item">{likeLink}</span>
                   <span className="post-footer-item">{saveLink}</span>

--- a/src/components/search-form.jsx
+++ b/src/components/search-form.jsx
@@ -54,7 +54,7 @@ export default withRouter(function SearchForm({ router }) {
   );
 
   return (
-    <div className="search-form" role="search form">
+    <div className="search-form" role="search form" aria-label="Search form">
       <input
         value={query}
         onChange={onChange}

--- a/src/components/send-to.jsx
+++ b/src/components/send-to.jsx
@@ -172,7 +172,7 @@ class SendTo extends Component {
     const [defaultOpt] = this.state.values;
 
     return (
-      <div className="send-to">
+      <div className="send-to" aria-label="Choose post destination">
         {!this.state.showFeedsOption && defaultOpt ? (
           <div>
             To:&nbsp;

--- a/src/components/sidebar.jsx
+++ b/src/components/sidebar.jsx
@@ -416,7 +416,7 @@ const SideBarAppearance = connect(
 
 const SideBar = ({ user, signOut, recentGroups }) => {
   return (
-    <div className="col-md-3 sidebar" role="navigation complementary">
+    <div className="col-md-3 sidebar" role="complementary">
       <ErrorBoundary>
         <LoggedInBlock user={user} signOut={signOut} />
         <SideBarFriends user={user} />

--- a/src/components/user-picture.jsx
+++ b/src/components/user-picture.jsx
@@ -21,7 +21,7 @@ export function UserPicture({
       }
       width={large ? 75 : 50}
       height={large ? 75 : 50}
-      alt={user.username}
+      alt={`Profile picture of ${user.username}`}
       loading={loading}
     />
   ) : (


### PR DESCRIPTION
Я немного поигрался с VoiceOver (как описано в http://css.yoksel.ru/inaccessibility/) на главном фронтенде и пришел к выводу, что фрифидом сложно пользоваться, опираясь только на слух. Многие элементы интерфейса не названы совсем (контролы клайков), некоторые из-за особенностей верстки названы некорректно (заголовки фидов), некоторые подписаны кое-как (автор комментария звучит как просто последнее слово в тексте комментария), и практически нет возможности быстро переходить от неинтересного контента (например, ранее прослушанного поста) в поисках чего-нибудь новенького.

Для работы над этим пулл-реквестом я начал добавлять текстовые лейблы там, где их, по-моему, не хватает, проверяя результаты в Accessibility Inspector в Фаерфоксе и в VoiceOver. Я не специалист, но, по-моему, получилось неплохо. Теперь VoiceOver объявляет информацию о каждом посте без захода в пост, регионы внутри поста названы (что позволяет их пропускать), и некоторые ранее неподписанные кнопки и ссылки теперь подписаны, что позволяет ими бесстрашно пользоваться.

<img width="742" alt="Screenshot 2021-01-28 at 18 02 14" src="https://user-images.githubusercontent.com/632081/106121872-01031c80-6193-11eb-9fc1-4d92b13b4e88.png">
