### PR TITLE
Respect screenname/username appearance settings in "my groups" block

### DIFF
--- a/src/components/recent-groups.jsx
+++ b/src/components/recent-groups.jsx
@@ -8,9 +8,7 @@ const renderRecentGroup = (recentGroup) => (
     className={classnames('p-my-groups-link', recentGroup.isPinned && 'pinned')}
     key={recentGroup.id}
   >
-    <UserName user={recentGroup} applyHyphenations={true}>
-      {recentGroup.screenName}
-    </UserName>
+    <UserName user={recentGroup} applyHyphenations={true} />
     <TimeDisplay className="updated-ago" timeStamp={+recentGroup.updatedAt} />
   </li>
 );

--- a/styles/helvetica/boxes.scss
+++ b/styles/helvetica/boxes.scss
@@ -165,6 +165,12 @@
       font-size: 11px;
     }
 
+    .p-my-groups-link {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
     .pinned {
       .updated-ago:after {
         content: ' (pinned)';


### PR DESCRIPTION
This PR fixes a bug where group names in "my groups" block in the sidebar ignore screenname/username appearance settings and always display screenname only (as mentioned in https://freefeed.net/support/293103ce-86bd-43ba-abce-af0dde6f5b5b). Also fixes a problem where very long screennames could break out of the sidebar.

**Current state** (regardless of which setting is chosen in appearance settings):

<img width="284" alt="Screenshot 2021-01-31 at 11 53 34" src="https://user-images.githubusercontent.com/632081/106374122-0b076400-63bb-11eb-8227-b0fb9172d579.png">

**With this fix:**

Display name only:

<img width="224" alt="Screenshot 2021-01-31 at 11 46 30" src="https://user-images.githubusercontent.com/632081/106374070-8f0d1c00-63ba-11eb-9978-a220fd462896.png">

Display name + username:

<img width="224" alt="Screenshot 2021-01-31 at 11 46 51" src="https://user-images.githubusercontent.com/632081/106374085-a9df9080-63ba-11eb-84af-32f5c86a6c5e.png">

Username only:

<img width="226" alt="Screenshot 2021-01-31 at 11 45 35" src="https://user-images.githubusercontent.com/632081/106374093-b49a2580-63ba-11eb-9b68-7bbb6ffd5422.png">

