### PR TITLE
Raise minimum password length to 9 chars

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -92,4 +92,6 @@ export default {
     comment: 3000,
     description: 1500,
   },
+
+  minPasswordLength: 9,
 };

--- a/src/components/settings/forms/change-password.jsx
+++ b/src/components/settings/forms/change-password.jsx
@@ -1,3 +1,4 @@
+/* global CONFIG */
 import { encode as qsEncode } from 'querystring';
 import { useMemo } from 'react';
 import { Link } from 'react-router';
@@ -101,7 +102,10 @@ function validate(values) {
   const { currentPassword, password, passwordConfirmation } = mapValues(values, (s) => s.trim());
   return {
     currentPassword: shouldBe(currentPassword !== ''),
-    password: shouldBe(password.length > 4, password && 'Password is too short'),
+    password: shouldBe(
+      password.length >= CONFIG.minPasswordLength,
+      password && 'Password is too short',
+    ),
     passwordConfirmation: shouldBe(passwordConfirmation === password, 'Passwords are not equal'),
   };
 }

--- a/src/components/signup-form.jsx
+++ b/src/components/signup-form.jsx
@@ -36,7 +36,8 @@ const validate = ({ withExtProfile = true, withCaptcha = true } = {}) => (values
   errors.screenname = shouldBe(/^.{3,25}$/i.test(values.screenname.trim()));
   errors.email = shouldBe(isEmail(values.email.trim()));
   errors.password = shouldBe(
-    (withExtProfile && values.connectExtProfile) || values.password.trim().length > 4,
+    (withExtProfile && values.connectExtProfile) ||
+      values.password.trim().length >= CONFIG.minPasswordLength,
   );
   errors.captcha = shouldBe(!withCaptcha || values.captcha !== null);
 
@@ -216,7 +217,12 @@ export default memo(function SignupForm({ invitationId = null, lang = 'en' }) {
               autoComplete="new-password"
               {...password.input}
             />
-            <p className="help-block">{enRu('At least 4 characters', 'Минимум 4 символа')}</p>
+            <p className="help-block">
+              {enRu(
+                `At least ${CONFIG.minPasswordLength} characters`,
+                `Минимум ${CONFIG.minPasswordLength} символов`,
+              )}
+            </p>
           </div>
         )}
 


### PR DESCRIPTION
This PR makes minimum password length configurable and raises it from 4 to 9 chars. 

FTR https://en.wikipedia.org/wiki/Password_strength#Common_guidelines 