### PR TITLE
Update group screennames in the right menu and in the page titles in the real time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.94.0] - 2021-02-18
 ### Fixed
 - Tiktok previews work for videos with empty title
+- Group screennames in the right menu and in the page titles now updates in the
+  real time
 
 ### Changed
 - Optimized build results: split code in smaller js-bundles, pre-compress js/css files

--- a/src/components/groups.jsx
+++ b/src/components/groups.jsx
@@ -87,8 +87,9 @@ function selectState(state) {
   const managedIds = new Set(_.map(state.managedGroups, (g) => g.id));
   const sortingRule = (g) => -(g.updatedAt || g.createdAt);
 
-  const adminGroups = _.filter(state.groups, (group) => managedIds.has(group.id));
-  const regularGroups = _.filter(state.groups, (group) => !managedIds.has(group.id));
+  const allGroups = Object.values(state.users).filter((u) => u.type === 'group');
+  const adminGroups = allGroups.filter((g) => managedIds.has(g.id));
+  const regularGroups = allGroups.filter((g) => !managedIds.has(g.id));
 
   const myGroups = {
     header: 'Groups you admin',

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -214,7 +214,6 @@ function select(state, ownProps) {
     user: state.user,
     authenticated: state.authenticated,
     loadingView: state.routeLoadingState,
-    recentGroups: state.recentGroups,
     routeName: getCurrentRouteName(ownProps),
     title: state.title,
   };

--- a/src/components/notifications.jsx
+++ b/src/components/notifications.jsx
@@ -311,7 +311,7 @@ const mapStateToProps = (state) => {
           state.users[event.created_user_id] || state.subscribers[event.created_user_id] || mock,
         affectedUser:
           state.users[event.affected_user_id] || state.subscribers[event.affected_user_id] || mock,
-        group: state.groups[event.group_id] || mock,
+        group: state.users[event.group_id] || mock,
         postAuthor: state.users[event.post_author_id],
         post: state.posts[event.post_id] || mock,
         comment: state.comments[event.comment_id] || mock,

--- a/src/components/recent-groups.jsx
+++ b/src/components/recent-groups.jsx
@@ -1,22 +1,35 @@
 import classnames from 'classnames';
 
+import { shallowEqual, useSelector } from 'react-redux';
 import UserName from './user-name';
 import TimeDisplay from './time-display';
 
-const renderRecentGroup = (recentGroup) => (
-  <li
-    className={classnames('p-my-groups-link', recentGroup.isPinned && 'pinned')}
-    key={recentGroup.id}
-  >
-    <UserName user={recentGroup} applyHyphenations={true}>
-      {recentGroup.screenName}
+const renderRecentGroup = (group, isPinned) => (
+  <li className={classnames('p-my-groups-link', isPinned && 'pinned')} key={group.id}>
+    <UserName user={group} applyHyphenations={true}>
+      {group.screenName}
     </UserName>
-    <TimeDisplay className="updated-ago" timeStamp={+recentGroup.updatedAt} />
+    <TimeDisplay className="updated-ago" timeStamp={+group.updatedAt} />
   </li>
 );
 
-export default (props) => {
-  const recentGroups = props.recentGroups.map(renderRecentGroup);
+export default () => {
+  const recentGroups = useSelector(
+    (state) => state.recentGroups.map((g) => state.users[g.id]),
+    shallowEqual,
+  );
+  const pinnedGroupIds = useSelector(
+    (state) =>
+      state.recentGroups
+        .filter((g) => g.isPinned)
+        .map((g) => g.id)
+        .sort(),
+    shallowEqual,
+  );
 
-  return <ul className="p-my-groups">{recentGroups}</ul>;
+  return (
+    <ul className="p-my-groups">
+      {recentGroups.map((g) => renderRecentGroup(g, pinnedGroupIds.includes(g.id)))}
+    </ul>
+  );
 };

--- a/src/components/select-utils.js
+++ b/src/components/select-utils.js
@@ -317,8 +317,7 @@ export function canAcceptDirects(user, state) {
  * @param {object} state
  */
 export function destinationsPrivacy(destNames, state) {
-  const { user: me, groups } = state;
-  const dests = [me, ...Object.values(groups)];
+  const dests = [state.user, ...Object.values(state.users).filter((u) => u.type === 'group')];
   let isPrivate = true;
   let isProtected = true;
   for (const d of dests) {

--- a/src/components/settings/layout.jsx
+++ b/src/components/settings/layout.jsx
@@ -66,6 +66,11 @@ export default function Layout({ children, router }) {
     [router],
   );
 
+  if (!authenticated) {
+    // Do not allow anonymous access
+    return null;
+  }
+
   return (
     <div className="content">
       <Helmet

--- a/src/components/sidebar.jsx
+++ b/src/components/sidebar.jsx
@@ -197,19 +197,21 @@ const SideBarMemories = () => {
   );
 };
 
-const SideBarGroups = ({ recentGroups }) => (
-  <div className="box" role="navigation">
-    <div className="box-header-groups" role="heading">
-      Groups
+const SideBarGroups = () => {
+  return (
+    <div className="box" role="navigation">
+      <div className="box-header-groups" role="heading">
+        Groups
+      </div>
+      <div className="box-body">
+        <RecentGroups />
+      </div>
+      <div className="box-footer">
+        <Link to="/groups">Browse/edit groups</Link>
+      </div>
     </div>
-    <div className="box-body">
-      <RecentGroups recentGroups={recentGroups} />
-    </div>
-    <div className="box-footer">
-      <Link to="/groups">Browse/edit groups</Link>
-    </div>
-  </div>
-);
+  );
+};
 
 const SideBarCoinJar = () => (
   <div className="box" role="region">
@@ -414,13 +416,13 @@ const SideBarAppearance = connect(
   );
 });
 
-const SideBar = ({ user, signOut, recentGroups }) => {
+const SideBar = ({ user, signOut }) => {
   return (
     <div className="col-md-3 sidebar" role="complementary">
       <ErrorBoundary>
         <LoggedInBlock user={user} signOut={signOut} />
         <SideBarFriends user={user} />
-        <SideBarGroups recentGroups={recentGroups} />
+        <SideBarGroups />
         <SideBarArchive user={user} />
         <SideBarFreeFeed />
         <SideBarBookmarklet />

--- a/src/components/subscribers.jsx
+++ b/src/components/subscribers.jsx
@@ -48,9 +48,7 @@ function selectState(state, ownProps) {
   const username = ownProps.params.userName;
   const amIGroupAdmin = state.managedGroups.find((group) => group.username == username) != null;
 
-  const thisUser = [..._.values(state.users), ..._.values(state.groups)].find(
-    (u) => u.username == username,
-  );
+  const thisUser = Object.values(state.users).find((u) => u.username == username);
   const thisIsGroup = thisUser && thisUser.type === 'group';
   const adminIds = thisIsGroup ? thisUser.administrators : [];
 

--- a/src/components/user.jsx
+++ b/src/components/user.jsx
@@ -1,5 +1,5 @@
 /* global CONFIG */
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import _ from 'lodash';
@@ -45,6 +45,15 @@ const UserHandler = (props) => {
     props.viewUser.isLoading,
     props.viewUser.username,
   ]);
+
+  const nameForTitle = useMemo(
+    () =>
+      props.viewUser.username === props.viewUser.screenName
+        ? props.viewUser.username
+        : `${props.viewUser.screenName} (${props.viewUser.username})`,
+    [props.viewUser.screenName, props.viewUser.username],
+  );
+
   return (
     <div className="box">
       <ErrorBoundary>
@@ -60,6 +69,9 @@ const UserHandler = (props) => {
               }
               href={`${CONFIG.api.root}/v2/timelines-rss/${props.viewUser.username}`}
             />
+            <title>
+              {nameForTitle} - {CONFIG.siteTitle}
+            </title>
           </Helmet>
         )}
 


### PR DESCRIPTION
This PR removes state.groups, all groups are now in state.users

Fixes #1278 
Fixes #1281