### PR TITLE
Fix comments folder covering comment likes popup

### DIFF
--- a/styles/shared/comment-likes.scss
+++ b/styles/shared/comment-likes.scss
@@ -131,7 +131,7 @@
   top: 0;
   left: 0;
   background: white;
-  z-index: 1;
+  z-index: 2;
   color: #898989;
   border: 1px solid #898989;
   padding: 6px;


### PR DESCRIPTION
Fixes https://freefeed.net/support/0b82db16-36fe-4a40-9a69-083691d1c4ea, caused by https://github.com/FreeFeed/freefeed-react-client/pull/1268

Before:
<img width="335" alt="Screenshot 2021-02-12 at 13 36 32" src="https://user-images.githubusercontent.com/632081/107734162-b6a7a100-6d37-11eb-946f-c7e0d38ef7c1.png">

After:
<img width="329" alt="Screenshot 2021-02-12 at 13 36 59" src="https://user-images.githubusercontent.com/632081/107734172-bc04eb80-6d37-11eb-9e10-2de099b69b3d.png">

