### PR TITLE
Add links between All Groups and Your Groups pages

### DIFF
--- a/src/components/all-groups.jsx
+++ b/src/components/all-groups.jsx
@@ -32,6 +32,15 @@ export default function AllGroups() {
           All Groups
         </div>
         <div className="box-body">
+          <div className="row" style={{ marginBottom: 20 }}>
+            <div className="col-md-6">
+              <Link to="/groups">List of your groups</Link>
+            </div>
+            <div className="col-md-6 text-right">
+              <Link to="/groups/create">Create a group</Link>
+            </div>
+          </div>
+
           {status.loading && <p>Loading...</p>}
           {status.error && (
             <p className="alert alert-danger">Can not load groups list: {status.errorText}</p>

--- a/src/components/groups.jsx
+++ b/src/components/groups.jsx
@@ -60,12 +60,14 @@ const GroupsHandler = (props) => {
     <div className="box">
       <ErrorBoundary>
         <div className="box-header-timeline" role="heading">
-          Groups
+          Your groups
         </div>
         <div className="box-body">
           <div className="row">
-            <div className="col-md-8">All the groups you are subscribed to</div>
-            <div className="col-md-4 text-right">
+            <div className="col-md-6">
+              <Link to="/all-groups">List of all groups</Link>
+            </div>
+            <div className="col-md-6 text-right">
               <Link to="/groups/create">Create a group</Link>
             </div>
           </div>


### PR DESCRIPTION
This PR adds links between All Groups and Your Groups pages.

**Before:**
=

<img width="705" alt="Screenshot 2021-02-27 at 20 25 21" src="https://user-images.githubusercontent.com/632081/109387060-f676a700-7939-11eb-8194-61058dadf7e4.png">
<img width="717" alt="Screenshot 2021-02-27 at 20 13 07" src="https://user-images.githubusercontent.com/632081/109387001-85cf8a80-7939-11eb-908d-deed51f088b4.png">

**After:**

<img width="713" alt="Screenshot 2021-02-27 at 20 19 49" src="https://user-images.githubusercontent.com/632081/109387006-8bc56b80-7939-11eb-9b44-15902a781e86.png">
<img width="714" alt="Screenshot 2021-02-27 at 20 20 04" src="https://user-images.githubusercontent.com/632081/109387007-8c5e0200-7939-11eb-9005-b6479fcfe37c.png">

