### PR TITLE
Mark Linkify as a region

### DIFF
--- a/src/components/linkify.jsx
+++ b/src/components/linkify.jsx
@@ -131,14 +131,14 @@ export default class Linkify extends Component {
     ]);
     if (!hl || hl.length === 0) {
       return (
-        <span className="Linkify" dir="auto">
+        <span className="Linkify" dir="auto" role="region">
           <ErrorBoundary>{parsed}</ErrorBoundary>
         </span>
       );
     }
     const highlighted = this.processStrings(parsed, (str) => highlightString(str, hl), ['button']);
     return (
-      <span className="Linkify" dir="auto">
+      <span className="Linkify" dir="auto" role="region">
         <ErrorBoundary>{highlighted}</ErrorBoundary>
       </span>
     );


### PR DESCRIPTION
This PR marks Linkify component as a region. This should highlight it to screen-readers, and make it easier to target post and comment texts in tests.