### PR TITLE
Rewrite all posts data on feed update, update clikes of collapsed comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved comments highlight logic from redux to PostComments' state
 ### Fixed
 - The numbers of likes of omitted comments now updates in the real time.
+- The posts and comments data now fully rewrites on feed update. It has been
+  broken in recent releases and click on FreeFeed logo wasn't collapse expanded
+  comments and likes
 
 ## [1.95.3] - 2021-03-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.96.0] - Not released
 ### Changed
 - Moved comments highlight logic from redux to PostComments' state
+### Fixed
+- The numbers of likes of omitted comments now updates in the real time.
 
 ## [1.95.3] - 2021-03-05
 ### Fixed

--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -660,7 +660,12 @@ const bindHandlers = (store) => ({
     return dispatchWithPost(store, postId, action, () => true, postFetchDelay);
   },
   'comment:update': (data) =>
-    store.dispatch({ ...data, type: ActionTypes.REALTIME_COMMENT_UPDATE, comment: data.comments }),
+    store.dispatch({
+      ...data,
+      type: ActionTypes.REALTIME_COMMENT_UPDATE,
+      comment: data.comments,
+      event: 'comment:update',
+    }),
   'comment:destroy': (data) =>
     store.dispatch({
       type: ActionTypes.REALTIME_COMMENT_DESTROY,
@@ -680,9 +685,17 @@ const bindHandlers = (store) => ({
       userId: data.meta.userId,
     }),
   'comment_like:new': (data) =>
-    store.dispatch({ type: ActionTypes.REALTIME_COMMENT_UPDATE, comment: data.comments }),
+    store.dispatch({
+      type: ActionTypes.REALTIME_COMMENT_UPDATE,
+      comment: data.comments,
+      event: 'comment_like:new',
+    }),
   'comment_like:remove': (data) =>
-    store.dispatch({ type: ActionTypes.REALTIME_COMMENT_UPDATE, comment: data.comments }),
+    store.dispatch({
+      type: ActionTypes.REALTIME_COMMENT_UPDATE,
+      comment: data.comments,
+      event: 'comment_like:remove',
+    }),
   'global:user:update': (data) =>
     store.dispatch({ type: ActionTypes.REALTIME_GLOBAL_USER_UPDATE, user: data.user }),
 });

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -355,14 +355,23 @@ const POST_SAVE_ERROR = 'Something went wrong while editing the post...';
 
 const initPostViewState = (post) => {
   const { id, omittedLikes } = post;
-  const isEditing = false;
 
-  return { omittedLikes, id, isEditing, ...NO_ERROR };
+  return {
+    id,
+    omittedLikes,
+    isEditing: false,
+    isCommenting: false,
+    commentText: '',
+    ...NO_ERROR,
+  };
 };
 
 export function postsViewState(state = {}, action) {
   if (ActionHelpers.isFeedResponse(action)) {
-    return mergeByIds(state, (action.payload.posts || []).map(initPostViewState));
+    return mergeByIds(state, (action.payload.posts || []).map(initPostViewState), {
+      insert: true,
+      update: true,
+    });
   }
   switch (action.type) {
     case response(ActionTypes.SHOW_MORE_LIKES_ASYNC): {

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -657,7 +657,7 @@ export const postHideStatuses = asyncStatesMap(
 
 export function attachments(state = {}, action) {
   if (ActionHelpers.isFeedResponse(action)) {
-    return mergeByIds(state, action.payload.attachments);
+    return mergeByIds(state, action.payload.attachments, { insert: true, update: true });
   }
   switch (action.type) {
     case response(ActionTypes.GET_SINGLE_POST):
@@ -855,7 +855,10 @@ export function users(state = {}, action) {
     mergeByIds(state, (accounts || []).map(userParser), options);
 
   if (ActionHelpers.isFeedResponse(action)) {
-    return mergeAccounts([...action.payload.users, ...action.payload.subscribers]);
+    return mergeAccounts([...action.payload.users, ...action.payload.subscribers], {
+      insert: true,
+      update: true,
+    });
   }
   switch (action.type) {
     case response(ActionTypes.WHO_AM_I): {
@@ -914,7 +917,10 @@ export function users(state = {}, action) {
 
 export function subscribers(state = {}, action) {
   if (ActionHelpers.isFeedResponse(action)) {
-    return mergeByIds(state, (action.payload.subscribers || []).map(userParser));
+    return mergeByIds(state, (action.payload.subscribers || []).map(userParser), {
+      insert: true,
+      update: true,
+    });
   }
   switch (action.type) {
     case ActionTypes.REALTIME_POST_NEW:
@@ -1078,7 +1084,7 @@ export const archiveRestorationForm = formState(
 
 export function timelines(state = {}, action) {
   if (ActionHelpers.isFeedResponse(action) && action.payload.timelines) {
-    return mergeByIds(state, [action.payload.timelines]);
+    return mergeByIds(state, [action.payload.timelines], { insert: true, update: true });
   }
 
   return state;
@@ -1086,7 +1092,7 @@ export function timelines(state = {}, action) {
 
 export function subscriptions(state = {}, action) {
   if (ActionHelpers.isFeedResponse(action)) {
-    return mergeByIds(state, action.payload.subscriptions);
+    return mergeByIds(state, action.payload.subscriptions, { insert: true, update: true });
   }
   switch (action.type) {
     case response(ActionTypes.WHO_AM_I):

--- a/src/redux/reducers/posts.js
+++ b/src/redux/reducers/posts.js
@@ -15,6 +15,7 @@ import {
   LIKE_POST_OPTIMISTIC,
   REALTIME_COMMENT_DESTROY,
   REALTIME_COMMENT_NEW,
+  REALTIME_COMMENT_UPDATE,
   REALTIME_LIKE_NEW,
   REALTIME_LIKE_REMOVE,
   REALTIME_POST_HIDE,
@@ -440,6 +441,31 @@ export function posts(state = {}, action) {
           comments: [...(post.comments || []), action.comment.id],
         },
       };
+    }
+    case REALTIME_COMMENT_UPDATE: {
+      const post = state[action.comment.postId];
+      if (post && !post.comments.includes(action.comment.id) && post.omittedComments > 0) {
+        // Clikes count changed in omitted comments
+        if (action.event === 'comment_like:new') {
+          return {
+            ...state,
+            [post.id]: {
+              ...post,
+              omittedCommentLikes: post.omittedCommentLikes + 1,
+            },
+          };
+        }
+        if (action.event === 'comment_like:remove' && post.omittedCommentLikes > 0) {
+          return {
+            ...state,
+            [post.id]: {
+              ...post,
+              omittedCommentLikes: post.omittedCommentLikes - 1,
+            },
+          };
+        }
+      }
+      return state;
     }
     case UNAUTHENTICATED: {
       return {};

--- a/src/redux/reducers/posts.js
+++ b/src/redux/reducers/posts.js
@@ -43,7 +43,10 @@ const savePostStatusesReducer = asyncStatesMap(SAVE_POST, {
 
 export function posts(state = {}, action) {
   if (isFeedResponse(action)) {
-    return mergeByIds(state, (action.payload.posts || []).map(postParser));
+    return mergeByIds(state, (action.payload.posts || []).map(postParser), {
+      insert: true,
+      update: true,
+    });
   }
 
   // Handle the savePostStatus changes


### PR DESCRIPTION
- The numbers of likes of omitted comments now updates in the real time.
- The posts and comments data now fully rewrites on feed update. It has been  broken in recent releases and click on FreeFeed logo wasn't collapse expanded comments and likes.

Fixes #1308