### PR TITLE
Properly process the COMPLETE_POST_COMMENTS responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.96.0] - Not released
+### Fixed
+- The COMPLETE_POST_COMMENTS responses was not fully processed, leading to
+  `Cannot read property 'username' of null` errors when updating comments.
 
 ## [1.95.4] - 2021-03-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The COMPLETE_POST_COMMENTS responses was not fully processed, leading to
   `Cannot read property 'username' of null` errors when updating comments.
+### Added
+- Error timestamp in error boundary message
 
 ## [1.95.4] - 2021-03-07
 ### Fixed

--- a/src/components/error-boundary.jsx
+++ b/src/components/error-boundary.jsx
@@ -5,11 +5,11 @@ import * as Sentry from '@sentry/react';
 class ErrorBoundary extends PureComponent {
   constructor(props) {
     super(props);
-    this.state = { hasError: false, error: {}, errorInfo: {} };
+    this.state = { hasError: false, error: {}, errorInfo: {}, errorTime: null };
   }
 
   static getDerivedStateFromError(error) {
-    return { hasError: true, error };
+    return { hasError: true, error, errorTime: new Date() };
   }
 
   componentDidCatch(error, errorInfo) {
@@ -21,7 +21,7 @@ class ErrorBoundary extends PureComponent {
   }
 
   render() {
-    const { error, hasError } = this.state;
+    const { error, hasError, errorTime } = this.state;
 
     if (hasError) {
       return (
@@ -45,6 +45,7 @@ class ErrorBoundary extends PureComponent {
                 CONFIG.betaChannel.isBeta &&
                 ` (⚠ ${CONFIG.betaChannel.subHeading} instance)`}
             </p>
+            <p>Time: {errorTime.toISOString()}</p>
           </div>
         </div>
       );

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -661,6 +661,7 @@ export function attachments(state = {}, action) {
   }
   switch (action.type) {
     case response(ActionTypes.GET_SINGLE_POST):
+    case response(ActionTypes.COMPLETE_POST_COMMENTS):
     case response(ActionTypes.CREATE_POST): {
       return mergeByIds(state, action.payload.attachments);
     }
@@ -880,6 +881,7 @@ export function users(state = {}, action) {
     case response(ActionTypes.SHOW_MORE_COMMENTS):
     case response(ActionTypes.SHOW_MORE_LIKES_ASYNC):
     case response(ActionTypes.GET_SINGLE_POST):
+    case response(ActionTypes.COMPLETE_POST_COMMENTS):
     case response(ActionTypes.GET_ALL_SUBSCRIPTIONS): {
       return mergeAccounts([
         ...action.payload.users,
@@ -933,6 +935,7 @@ export function subscribers(state = {}, action) {
     }
     case response(ActionTypes.WHO_AM_I):
     case response(ActionTypes.GET_SINGLE_POST):
+    case response(ActionTypes.COMPLETE_POST_COMMENTS):
     case response(ActionTypes.CREATE_POST): {
       return mergeByIds(state, (action.payload.subscribers || []).map(userParser));
     }
@@ -1097,6 +1100,7 @@ export function subscriptions(state = {}, action) {
   switch (action.type) {
     case response(ActionTypes.WHO_AM_I):
     case response(ActionTypes.GET_SINGLE_POST):
+    case response(ActionTypes.COMPLETE_POST_COMMENTS):
     case response(ActionTypes.CREATE_POST): {
       return mergeByIds(state, action.payload.subscriptions);
     }


### PR DESCRIPTION
The COMPLETE_POST_COMMENTS responses was not fully processed, leading to `Cannot read property 'username' of null` errors when updating comments.

Also, error timestamp added to error boundary message.