### PR TITLE
Underline sidebar links on hover

### DIFF
--- a/styles/helvetica/boxes.scss
+++ b/styles/helvetica/boxes.scss
@@ -125,6 +125,10 @@
     a {
       color: #0000cc;
       text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
     @include clearfix;
 


### PR DESCRIPTION
Before:

![Mar-08-2021 20-50-44](https://user-images.githubusercontent.com/632081/110323825-19970a00-8050-11eb-928f-23e443bfc8d6.gif)

After:

![Mar-08-2021 20-49-41](https://user-images.githubusercontent.com/632081/110323821-17cd4680-8050-11eb-8e0e-29aa0b2ac7af.gif)

