### PR TITLE
Include the query string and hash to the /signin's  'back' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.96.1] - 2021-03-11
 ### Fixed
 - Properly update state of groups in realtime
+- If the anonymous user visits the page that require authorization, the browser
+  redirects to the `/signin?back=…` page. Previously, the back parameter
+  included only the pathname of the page, not the query and hash. It is fixed,
+  and now it includes pathname + query + hash. It is especially important for
+  the magic links to the token creation page.
 
 ## [1.96.0] - 2021-03-11
 ### Added

--- a/src/components/settings/layout.jsx
+++ b/src/components/settings/layout.jsx
@@ -44,7 +44,13 @@ export default function Layout({ children, router }) {
   // Do not allow anonymous access
   const authenticated = useSelector((state) => state.authenticated);
   useEffect(
-    () => void (!authenticated && browserHistory.push(`/signin?back=${location.pathname}`)),
+    () =>
+      void (
+        !authenticated &&
+        browserHistory.push(
+          `/signin?back=${encodeURIComponent(location.pathname + location.search + location.hash)}`,
+        )
+      ),
     [authenticated],
   );
 

--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -239,10 +239,13 @@ export const authMiddleware = (store) => {
       next(action);
       if (firstUnauthenticated) {
         firstUnauthenticated = false;
-        const { pathname } = window.location;
-        if (shouldGoToSignIn(pathname)) {
+        if (shouldGoToSignIn(location.pathname)) {
           store.dispatch(ActionCreators.requireAuthentication());
-          return browserHistory.push(`/signin?back=${pathname}`);
+          return browserHistory.push(
+            `/signin?back=${encodeURIComponent(
+              location.pathname + location.search + location.hash,
+            )}`,
+          );
         }
       }
       return;


### PR DESCRIPTION
If the anonymous user visits the page that require authorization, the browser  redirects to the `/signin?back=…` page. Previously, the back parameter  included only the pathname of the page, not the query and hash. It is fixed,  and now it includes pathname + query + hash. It is especially important for  the magic links to the token creation page.