### PR TITLE
search: Replace `qs` with `q` (backward compatible)

### DIFF
--- a/src/components/hooks/search-query.js
+++ b/src/components/hooks/search-query.js
@@ -6,7 +6,8 @@ import { useSelector } from 'react-redux';
 export function useSearchQuery() {
   const query = useSelector((state) => {
     const { pathname, query } = state.routing.locationBeforeTransitions;
-    return ((pathname === '/search' && query.qs) || '').trim();
+    const q = query.q || query.qs || '';
+    return ((pathname === '/search' && q) || '').trim();
   });
 
   return query;

--- a/src/components/linkify.jsx
+++ b/src/components/linkify.jsx
@@ -71,7 +71,7 @@ export default class Linkify extends Component {
           return anchorEl(searchEngine + encodeURIComponent(token.text), token.text);
         }
 
-        return linkEl({ pathname: '/search', query: { qs: token.text } }, <bdi>{token.text}</bdi>);
+        return linkEl({ pathname: '/search', query: { q: token.text } }, <bdi>{token.text}</bdi>);
       }
 
       if (token instanceof Arrows && this.props.arrowHover) {

--- a/src/components/search-form-advanced.jsx
+++ b/src/components/search-form-advanced.jsx
@@ -22,7 +22,7 @@ export const SearchFormAdvanced = withRouter(function SearchFormAdvanced({ route
         initialValues: parseQuery(queryString),
         onSubmit: (values) => {
           const q = generateQuery(values);
-          q && router.push(`/search?qs=${encodeURIComponent(q)}`);
+          q && router.push(`/search?q=${encodeURIComponent(q)}`);
         },
       }),
       [router, queryString],
@@ -73,7 +73,7 @@ export const SearchFormAdvanced = withRouter(function SearchFormAdvanced({ route
     <div>
       <form onSubmit={form.handleSubmit}>
         <div className={`${styles.queryInputGroup} input-group`}>
-          <input type="search" name="qs" className="form-control" {...query.input} />
+          <input type="search" name="q" className="form-control" {...query.input} />
           <span className="input-group-btn">
             <button className="btn btn-primary" type="submit" disabled={form.hasValidationErrors}>
               Search

--- a/src/components/search-form.jsx
+++ b/src/components/search-form.jsx
@@ -33,7 +33,7 @@ export default withRouter(function SearchForm({ router }) {
   useEffect(() => setQuery(initialQuery), [initialQuery]);
 
   const performSearch = useCallback(
-    () => query.trim() !== '' && router.push(`/search?qs=${encodeURIComponent(query.trim())}`),
+    () => query.trim() !== '' && router.push(`/search?q=${encodeURIComponent(query.trim())}`),
     [query, router],
   );
 

--- a/src/components/user-profile-head.jsx
+++ b/src/components/user-profile-head.jsx
@@ -488,7 +488,7 @@ export const UserProfileHead = withRouter(
                 <>
                   <StatLink
                     title="All posts"
-                    linkTo={`/search?qs=${encodeURIComponent(`from:${user.username}`)}`}
+                    linkTo={`/search?q=${encodeURIComponent(`from:${user.username}`)}`}
                     canFollow={canFollowStatLinks}
                     className={styles.allPosts}
                   />

--- a/src/redux/route-actions.js
+++ b/src/redux/route-actions.js
@@ -27,7 +27,8 @@ import {
 //query params are strings, so + hack to convert to number
 const getOffset = (nextRoute) => +nextRoute.location.query.offset || 0;
 
-const getSearchQueryParam = (nextRoute) => nextRoute.location.query.qs;
+const getSearchQueryParam = (nextRoute) =>
+  nextRoute.location.query.q || nextRoute.location.query.qs || '';
 
 const getPostName = (url) => {
   const m = FRIENDFEED_POST.exec(url);


### PR DESCRIPTION
This change replaces parameter `qs` with `q`:
- in search form(s)
- in user-generated texts (hashtag links)
- in user-profile-head (the "All posts" link)

It has backward compatibility, so the old links with `qs` still work.

It does not change communication with the backend API, which still uses `qs`.