### PR TITLE
Add tests for Post component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
     },
   },
   rules: {
+    complexity: ['warn', { max: 20 }],
     curly: 2,
     'func-name-matching': 2,
     'import/default': 2,

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
   "scripts": {
     "start": "run-s dev-server",
     "test": "run-s \"test-just --recursive test/unit\" \"test-jest\"",
-    "test-jest": "jest",
+    "test-jest": "cross-env TZ=utc jest",
     "test-just": "cross-env NODE_ENV=development mochapack --webpack-config webpack.config.tests.babel.js",
     "lint": "eslint --ext .js --ext .jsx src test",
     "checks": "run-p --aggregate-output -c test lint stylelint",

--- a/test/jest/__snapshots__/post.test.js.snap
+++ b/test/jest/__snapshots__/post.test.js.snap
@@ -1,0 +1,163 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Post Renders a post and doesn't blow up 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Public post by author with 0 comments and 0 likes written on 3/14/2021"
+    class="post single-post"
+    data-author="author"
+    role="article"
+  >
+    <div
+      class="expandable expanded"
+    >
+      <div
+        class="post-userpic"
+      >
+        <a
+          class="picture pictureLarge post-userpic-img"
+        >
+          <img
+            alt="Profile picture of author"
+            height="75"
+            loading="lazy"
+            width="75"
+          />
+        </a>
+      </div>
+      <div
+        aria-label="Post body"
+        class="post-body"
+        role="region"
+      >
+        <div
+          class="post-header"
+        >
+          <span
+            class="user-name-wrapper"
+          >
+            <a
+              class="post-author"
+            >
+              <span
+                dir="ltr"
+              >
+                You
+              </span>
+            </a>
+          </span>
+        </div>
+        <div
+          class="post-text"
+        >
+          <span
+            class="Linkify"
+            dir="auto"
+            role="region"
+          >
+            <span>
+              Line 1
+            </span>
+            <br />
+            <span>
+              Line 2
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="post-body"
+    >
+      <div />
+      <div
+        class="dropzone-previews"
+      />
+      <div
+        aria-label="Post footer"
+        class="post-footer"
+        role="region"
+      >
+        <div
+          class="post-footer-icon"
+        >
+          <svg
+            class="post-lock-icon post-public-icon fa-icon fa-icon-fas-globe-americas"
+            role="button"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>
+              This entry is public
+            </title>
+            <use
+              xlink:href="#fa-icon-fas-globe-americas"
+            />
+          </svg>
+        </div>
+        <div
+          class="post-footer-content"
+        >
+          <span
+            class="post-footer-block"
+          >
+            <span
+              class="post-footer-item"
+            >
+              <a
+                class="post-timestamp"
+              >
+                <time
+                  datetime="2021-03-14T03:23:59.035Z"
+                  title="Mar 14, 2021 03:23"
+                >
+                  Mar 14, 2021
+                </time>
+              </a>
+            </span>
+          </span>
+          <span
+            class="post-footer-block"
+            role="region"
+          >
+            <span
+              class="post-footer-item"
+            >
+              <a
+                class="post-action"
+                role="button"
+              >
+                Comment
+              </a>
+            </span>
+            <span
+              class="post-footer-item"
+            >
+              <a
+                class="post-action"
+                role="button"
+              >
+                Like
+              </a>
+            </span>
+            <span
+              class="post-footer-item"
+            >
+              <a
+                class="post-action"
+                role="button"
+              >
+                Save
+              </a>
+            </span>
+            <span
+              class="post-footer-item"
+            />
+          </span>
+        </div>
+      </div>
+      <div />
+      <div />
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/test/jest/post.test.js
+++ b/test/jest/post.test.js
@@ -1,0 +1,345 @@
+/* global describe, it, expect, jest */
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { createStore } from 'redux';
+import * as reactRedux from 'react-redux';
+
+jest.mock('../../src/components/post-comments', () => ({ comments }) => {
+  return <div>{comments.length > 0 ? `Mocked ${comments.length} comments ` : ''}</div>;
+});
+
+jest.mock('../../src/components/post-attachments', () => ({ attachments }) => {
+  return <div>{attachments.length > 0 ? `Mocked ${attachments.length} attachments` : ''}</div>;
+});
+
+import Post from '../../src/components/post';
+
+const AUTHOR = {
+  id: 'author-id',
+  username: 'author',
+  screenName: 'Author',
+  type: 'user',
+  isPrivate: '0',
+  isProtected: '0',
+};
+
+const VIEWER = {
+  ...AUTHOR,
+  frontendPreferences: {
+    timeDisplay: {},
+  },
+};
+
+const defaultState = {
+  user: VIEWER,
+  postHideStatuses: {},
+};
+
+const renderPost = (props = {}) => {
+  const { Provider } = reactRedux;
+  const dummyReducer = (state) => state;
+  const store = createStore(dummyReducer, defaultState);
+
+  const defaultProps = {
+    id: 'post-id',
+    body: 'Line 1\nLine 2',
+    createdAt: '1615692239035',
+    updatedAt: '1615692257002',
+    comments: [],
+    attachments: [],
+    likes: [],
+    createdBy: AUTHOR,
+    recipients: [AUTHOR],
+    recipientNames: [AUTHOR.username],
+    isSinglePost: true,
+    isDirect: false,
+    isNSFW: false,
+    commentsDisabled: false,
+    commentLikes: 0,
+    ownCommentLikes: 0,
+    omittedCommentLikes: 0,
+    omittedOwnCommentLikes: 0,
+    omittedComments: 0,
+    omittedLikes: 0,
+    usersLikedPost: [],
+    user: VIEWER,
+    savePostStatus: {},
+    hideStatus: {},
+    setFinalHideLinkOffset: () => {},
+  };
+  return render(
+    <Provider store={store}>
+      <Post {...defaultProps} {...props} />
+    </Provider>,
+  );
+};
+
+describe('Post', () => {
+  it("Renders a post and doesn't blow up", () => {
+    const { asFragment } = renderPost();
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('Displays all post recipients', () => {
+    const someOtherGuy = {
+      id: 'other-guy-id',
+      username: 'otherguy1',
+      screenName: 'Other Guy',
+      type: 'user',
+    };
+    const someOtherGroup = {
+      id: 'other-group-id',
+      username: 'othergroup',
+      screenName: 'Other Group',
+      type: 'group',
+    };
+    renderPost({
+      recipients: [AUTHOR, someOtherGuy, someOtherGroup],
+      recipientNames: [AUTHOR.username, someOtherGuy.username, someOtherGroup.username],
+    });
+    expect(screen.getByLabelText('Post body')).toHaveTextContent(
+      'You to author’s feed, Other Guy and Other Group',
+    );
+  });
+
+  it('Displays post likes', () => {
+    renderPost({
+      likes: ['u1', 'u2', 'u3'],
+      usersLikedPost: [
+        { id: 'u1', username: 'user1', screenName: 'User 1' },
+        { id: 'u2', username: 'user2', screenName: 'User 2' },
+        { id: 'u3', username: 'user3', screenName: 'User 3' },
+      ],
+    });
+    expect(screen.getByLabelText('3 likes')).toHaveTextContent(
+      'User 1, User 2 and User 3 liked this',
+    );
+  });
+
+  it('Displays post comments', () => {
+    renderPost({
+      comments: [{ id: 'c1' }, { id: 'c2' }],
+    });
+    expect(screen.getByText(/Mocked 2 comments/)).toBeInTheDocument();
+  });
+
+  it('Displays post attachments', () => {
+    renderPost({
+      attachments: [{ id: 'a1' }, { id: 'a2' }],
+    });
+    expect(screen.getByText('Mocked 2 attachments')).toBeInTheDocument();
+  });
+
+  it('Displays NSFW warning for a NSFW post with image attachments', () => {
+    renderPost({
+      isNSFW: true,
+      attachments: [{ id: 'a1', mediaType: 'image' }, { id: 'a2' }],
+    });
+    expect(screen.getByLabelText(/Not safe for work Public post/)).toHaveTextContent(
+      /Turn the NSFW filter off to enable previews for sensitive content/,
+    );
+  });
+
+  it('Displays NSFW warning for a NSFW post with a link embed', () => {
+    renderPost({
+      isNSFW: true,
+      body: 'embed https://example.com/',
+    });
+    expect(screen.getByLabelText(/Not safe for work Public post/)).toHaveTextContent(
+      /Turn the NSFW filter off to enable previews for sensitive content/,
+    );
+  });
+
+  it('Displays a link embed for a normal post with a link embed', () => {
+    renderPost({
+      body: 'embed https://example.com/',
+      allowLinksPreview: false,
+    });
+    expect(screen.getByLabelText(/Link preview/)).toBeInTheDocument();
+  });
+
+  it('Renders a post as public and toggles timestamps if post visibility icon is clicked', () => {
+    renderPost();
+    expect(screen.getByLabelText(/Public post/)).toBeInTheDocument();
+    expect(screen.getByTitle(/This entry is public/, { role: 'button' })).toBeInTheDocument();
+    expect(screen.getByText('Mar 14, 2021')).toBeInTheDocument();
+    fireEvent.click(screen.getByTitle(/This entry is public/, { role: 'button' }));
+    expect(screen.getByText('Mar 14, 2021 03:23')).toBeInTheDocument();
+  });
+
+  it('Renders a post as protected because its author is protected', () => {
+    const protectedAuthor = {
+      ...AUTHOR,
+      isProtected: '1',
+    };
+    renderPost({
+      recipients: [protectedAuthor],
+      createdBy: protectedAuthor,
+    });
+    expect(screen.getByLabelText(/Protected post/)).toBeInTheDocument();
+    expect(screen.getByTitle(/This entry is only visible to FreeFeed users/)).toBeInTheDocument();
+  });
+
+  it('Renders a post as protected because all of its recipients are protected', () => {
+    const protectedGroup = {
+      id: 'pg1',
+      username: 'protected-group',
+      type: 'group',
+      isProtected: '1',
+    };
+    const protectedAuthor = {
+      ...AUTHOR,
+      isProtected: '1',
+    };
+    renderPost({
+      recipients: [protectedAuthor, protectedGroup],
+      createdBy: protectedAuthor,
+    });
+    expect(screen.getByLabelText(/Protected post/)).toBeInTheDocument();
+    expect(screen.getByTitle(/This entry is only visible to FreeFeed users/)).toBeInTheDocument();
+  });
+
+  it('Renders a post as private because its author is private', () => {
+    const privateAuthor = {
+      ...AUTHOR,
+      isPrivate: '1',
+    };
+    renderPost({
+      recipients: [privateAuthor],
+      createdBy: privateAuthor,
+    });
+    expect(screen.getByLabelText(/Private post/)).toBeInTheDocument();
+    expect(screen.getByTitle(/This entry is private/)).toBeInTheDocument();
+  });
+
+  it('Renders a post as a direct message', () => {
+    renderPost({
+      isDirect: true,
+    });
+    expect(screen.getByLabelText(/Direct message/)).toBeInTheDocument();
+    expect(screen.getByTitle(/This is a direct message/)).toBeInTheDocument();
+  });
+
+  it('Renders a comment button which opens the comment form if this is not a single post', () => {
+    const toggleCommenting = jest.fn();
+    renderPost({ toggleCommenting, isSinglePost: false });
+    expect(screen.getByText('Comment', { role: 'button' })).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Comment', { role: 'button' }));
+    expect(toggleCommenting).toHaveBeenCalledWith('post-id');
+  });
+
+  it("Doesn't render a comment button if comments are disabled", () => {
+    renderPost({ commentsDisabled: true });
+    expect(screen.queryByText('Comment', { role: 'button' })).not.toBeInTheDocument();
+    expect(screen.getByText('Comments disabled')).toBeInTheDocument();
+  });
+
+  it('Renders a comment button if comments are disabled but you are the moderator/owner', () => {
+    renderPost({ commentsDisabled: true, isEditable: true });
+    expect(screen.getByText('Comment', { role: 'button' })).toBeInTheDocument();
+    expect(screen.getByText('Comments disabled (not for you)')).toBeInTheDocument();
+  });
+
+  it('Renders a like button which likes the post', () => {
+    const someOtherUser = {
+      id: 'other-id',
+    };
+    const likePost = jest.fn();
+    renderPost({ likePost, isEditable: false, user: someOtherUser });
+    expect(screen.getByText('Like', { role: 'button' })).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Like', { role: 'button' }));
+    expect(likePost).toHaveBeenCalledWith('post-id', 'other-id');
+  });
+
+  it('Renders an un-like button which un-likes the post if this post is already liked', () => {
+    const someOtherUser = {
+      id: 'other-id',
+    };
+    const unlikePost = jest.fn();
+    renderPost({
+      unlikePost,
+      isEditable: false,
+      usersLikedPost: [someOtherUser],
+      user: someOtherUser,
+    });
+    expect(screen.getByText('Un-like', { role: 'button' })).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Un-like', { role: 'button' }));
+    expect(unlikePost).toHaveBeenCalledWith('post-id', 'other-id');
+  });
+
+  it("Doesn't render a like/unlike button if this is a post that I can edit (e.g. my own post)", () => {
+    renderPost({ isEditable: true });
+    expect(screen.queryByText('Like', { role: 'button' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Un-like', { role: 'button' })).not.toBeInTheDocument();
+  });
+
+  it('Renders a more button if this is a post that I can edit (e.g. my own post) which toggles a "more action" menu', () => {
+    const confirmMock = jest.spyOn(global, 'confirm').mockReturnValueOnce(true);
+
+    const toggleEditingPost = jest.fn();
+    const toggleModeratingComments = jest.fn();
+    const disableComments = jest.fn();
+    const deletePost = jest.fn();
+    renderPost({
+      isEditable: true,
+      isModeratable: true,
+      isFullyRemovable: true,
+      toggleEditingPost,
+      toggleModeratingComments,
+      disableComments,
+      deletePost,
+    });
+    expect(screen.getByText(/More/, { role: 'button' })).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/More/, { role: 'button' }));
+
+    expect(screen.getByText('Edit', { role: 'button' })).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Edit', { role: 'button' }));
+    expect(toggleEditingPost).toHaveBeenCalledWith('post-id');
+
+    expect(screen.getByText('Moderate comments', { role: 'button' })).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Moderate comments', { role: 'button' }));
+    expect(toggleModeratingComments).toHaveBeenCalledWith('post-id');
+
+    expect(screen.getByText('Disable comments', { role: 'button' })).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Disable comments', { role: 'button' }));
+    expect(disableComments).toHaveBeenCalledWith('post-id');
+
+    expect(screen.getByText('Delete', { role: 'button' })).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Delete', { role: 'button' }));
+    expect(confirmMock).toHaveBeenCalledWith('Are you sure?');
+    expect(deletePost).toHaveBeenCalledWith('post-id');
+  });
+
+  it('Renders a hide button which hides the post', () => {
+    const someOtherUser = {
+      id: 'other-id',
+    };
+    const hidePost = jest.fn();
+    renderPost({
+      user: someOtherUser,
+      isInHomeFeed: true,
+      isHidden: false,
+      hidePost,
+    });
+    expect(screen.getByText('Hide', { role: 'button' })).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Hide', { role: 'button' }));
+    expect(hidePost).toHaveBeenCalledWith('post-id');
+  });
+
+  it('Renders a un-hide button which unhides the post', () => {
+    const someOtherUser = {
+      id: 'other-id',
+    };
+    const unhidePost = jest.fn();
+    renderPost({
+      user: someOtherUser,
+      isInHomeFeed: true,
+      isHidden: true,
+      hiddenByNames: false,
+      unhidePost,
+    });
+    expect(screen.getByText('Un-hide', { role: 'button' })).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Un-hide', { role: 'button' }));
+    expect(unhidePost).toHaveBeenCalledWith('post-id');
+  });
+});


### PR DESCRIPTION
This PR adds _some_ tests for Post component. Some parts of it are not covered because I'll do it later (editing) and some parts are not covered because I don't yet understand how to do it right (savePost and other action creators).

Note: to check coverage, run `yarn test-jest --coverage`, the detailed report is going to be in /coverage.