### PR TITLE
Do not auto-collapse comments in the newly created posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Removed old invalid links to Clio and "Archives F.A.Q."
+- Post created by the user with 'Create post' from is showing with expanded
+  comments. The user can add multiple comments to the newly created post and
+  they will not be suddenly collapsed.
 
 ## [1.97.0] - 2021-03-18
 ### Fixed

--- a/src/components/post-comments/index.jsx
+++ b/src/components/post-comments/index.jsx
@@ -20,16 +20,21 @@ export default class PostComments extends Component {
     commentsAfterFold: foldConf.afterFold,
     minFoldedComments: foldConf.minFolded,
     minToCollapse: foldConf.minToCollapse,
+    preopened: false,
   };
 
   addingCommentForm = createRef();
   rootEl = createRef();
 
-  state = {
-    folded: true,
-    highlightedAuthor: null,
-    highlightedCommentId: null,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      folded: !props.preopened,
+      highlightedAuthor: null,
+      highlightedCommentId: null,
+    };
+  }
 
   mentionCommentAuthor = (commentId) => {
     const name = this.props.comments.find((c) => c.id === commentId)?.user?.username;

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -711,6 +711,7 @@ class Post extends Component {
               isSinglePost={props.isSinglePost}
               forceAbsTimestamps={this.state.forceAbsTimestamps}
               user={props.user}
+              preopened={props.justCreated}
             />
           </div>
         </ErrorBoundary>

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -361,6 +361,7 @@ const initPostViewState = (post) => {
     isEditing: false,
     isCommenting: false,
     commentText: '',
+    justCreated: false,
     ...NO_ERROR,
   };
 };
@@ -629,10 +630,7 @@ export function postsViewState(state = {}, action) {
 
     case response(ActionTypes.CREATE_POST): {
       const post = action.payload.posts;
-      const { id, omittedLikes } = post;
-      const isEditing = false;
-
-      return { ...state, [id]: { omittedLikes, id, isEditing, ...NO_ERROR } };
+      return { ...state, [post.id]: { ...initPostViewState(post), justCreated: true } };
     }
     case ActionTypes.UNAUTHENTICATED: {
       return {};

--- a/test/unit/components/post-comments-fold.js
+++ b/test/unit/components/post-comments-fold.js
@@ -149,6 +149,30 @@ describe('<PostComments>', () => {
         </div>,
       );
     });
+
+    it(`should not fold comments if its count is above the limit but the post is just created`, () => {
+      const nComments =
+        1 + // first comment
+        minFoldedComments + // folded comments
+        commentsAfterFold + // comments after fold
+        +2;
+      const comments = genComments(nComments);
+
+      expect(
+        <PostComments
+          comments={comments}
+          post={post}
+          commentsAfterFold={commentsAfterFold}
+          minFoldedComments={minFoldedComments}
+          preopened
+        />,
+        'when rendered',
+        'to have rendered with all children',
+        <div className="comments" role="list">
+          {genCommentElements(nComments)}
+        </div>,
+      );
+    });
   });
 
   describe('Post with omitted comments', () => {


### PR DESCRIPTION
Post created by the user with 'Create post' from is showing with expanded comments. The user can add multiple comments to the newly created post and they will not be suddenly collapsed.