### PR TITLE
Reset the page number on search on All Groups page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.99.0] - Not released
+### Fixed
+- Changes in search field on the "All Groups" page now resets the page number to
+  the first page. Also the page and the query string are now synchronized with
+  the URL's query parameters.
 
 ## [1.98.2] - 2021-04-09
 ### Fixed


### PR DESCRIPTION
Changes in search field on the "All Groups" page now resets the page number to the first page. Also the page and the query string are now synchronized with the URL's query parameters.