### PR TITLE
Display usernames of gone users in post comments in grey color

### DIFF
--- a/src/components/user-name.jsx
+++ b/src/components/user-name.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { Portal } from 'react-portal';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router';
+import classNames from 'classnames';
 
 import ErrorBoundary from './error-boundary';
 import { useDropDown, CLOSE_ON_CLICK_OUTSIDE } from './hooks/drop-down';
@@ -10,7 +11,7 @@ import UserCard from './user-card';
 import { useMediaQueryRef } from './hooks/media-query';
 
 export default function UserName({
-  user: { username, screenName },
+  user: { username, screenName, isGone },
   userHover, // { hover, leave },
   children,
   className,
@@ -81,6 +82,8 @@ export default function UserName({
     };
   }, [opened, onEnter, onLeave, menuRef]);
 
+  const linkCn = classNames(className, isGone ? 'user-is-gone' : false);
+
   return (
     <ErrorBoundary>
       <span
@@ -89,7 +92,7 @@ export default function UserName({
         onMouseEnter={onEnter}
         onMouseLeave={onLeave}
       >
-        <Link to={`/${username}`} className={className} onClick={onClick} onTouchEnd={onTouchEnd}>
+        <Link to={`/${username}`} className={linkCn} onClick={onClick} onTouchEnd={onTouchEnd}>
           {children ? (
             <span dir="ltr">{children}</span>
           ) : (

--- a/styles/shared/user-name.scss
+++ b/styles/shared/user-name.scss
@@ -2,6 +2,10 @@
   position: relative;
   overflow-wrap: break-word;
   word-wrap: break-word;
+
+  .user-is-gone {
+    color: #666;
+  }
 }
 
 .user-card {

--- a/test/jest/__snapshots__/post-comments.test.js.snap
+++ b/test/jest/__snapshots__/post-comments.test.js.snap
@@ -72,7 +72,9 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
             <span
               class="user-name-wrapper"
             >
-              <a>
+              <a
+                class=""
+              >
                 <span
                   dir="ltr"
                 >
@@ -139,7 +141,9 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
               <span
                 class="user-name-wrapper"
               >
-                <a>
+                <a
+                  class=""
+                >
                   <span
                     dir="ltr"
                   >
@@ -161,7 +165,9 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
             <span
               class="user-name-wrapper"
             >
-              <a>
+              <a
+                class=""
+              >
                 <span
                   dir="ltr"
                 >
@@ -238,7 +244,9 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
             <span
               class="user-name-wrapper"
             >
-              <a>
+              <a
+                class=""
+              >
                 <span
                   dir="ltr"
                 >


### PR DESCRIPTION
This PR displays usernames of "gone" users in post comments in grey color:

<img width="652" alt="Screenshot 2021-05-08 at 21 53 16" src="https://user-images.githubusercontent.com/632081/117561214-49ea3b80-b0c7-11eb-9568-842abcce4072.png">
 