### PR TITLE
Return a missing throbber to "more comments" loader

### DIFF
--- a/src/components/post-comments/expand-comments.jsx
+++ b/src/components/post-comments/expand-comments.jsx
@@ -24,7 +24,12 @@ export default function ExpandComments({
   return (
     <div className="comment more-comments-wrapper">
       <ErrorBoundary>
-        <span className="more-comments-throbber">{isLoading && <Throbber />}</span>
+        <span
+          className="more-comments-throbber"
+          aria-label={isLoading ? 'Loading comments...' : undefined}
+        >
+          {isLoading && <Throbber />}
+        </span>
         <ButtonLink className="more-comments-link" href={entryUrl} onClick={onClick}>
           {text}
         </ButtonLink>

--- a/src/components/post-comments/index.jsx
+++ b/src/components/post-comments/index.jsx
@@ -253,7 +253,6 @@ export default class PostComments extends Component {
       comments,
       entryUrl,
       isSinglePost,
-      isLoadingComments,
       commentsAfterFold,
       minFoldedComments,
       minToCollapse,
@@ -357,7 +356,7 @@ export default class PostComments extends Component {
           entryUrl={entryUrl}
           omittedComments={post.omittedComments + firstAfterFoldIdx - post.omittedCommentsOffset}
           omittedCommentLikes={foldedCommentLikes}
-          isLoading={isLoadingComments}
+          isLoading={post.isLoadingComments}
         />
       );
       if (post.omittedCommentsOffset > 0) {

--- a/test/jest/post-comments.test.js
+++ b/test/jest/post-comments.test.js
@@ -103,7 +103,7 @@ describe('PostComments', () => {
 
   it('Renders omitted comments and expands them', () => {
     const showMoreComments = jest.fn();
-    renderPostComments({
+    const { rerender } = renderPostComments({
       post: {
         ...POST,
         omittedComments: 12,
@@ -115,6 +115,19 @@ describe('PostComments', () => {
     expect(screen.getByLabelText(/15 comments/)).toBeInTheDocument();
     userEvent.click(screen.getByText('12 more comments with 34 likes', { role: 'button' }));
     expect(showMoreComments).toHaveBeenCalledWith('post-id');
+
+    expect(screen.queryByLabelText('Loading comments...')).not.toBeInTheDocument();
+    rerender({
+      post: {
+        ...POST,
+        omittedComments: 12,
+        omittedCommentLikes: 34,
+        omittedCommentsOffset: 1,
+        isLoadingComments: true,
+      },
+      showMoreComments,
+    });
+    expect(screen.queryByLabelText('Loading comments...')).toBeInTheDocument();
   });
 
   it('Renders add comment link which toggles comment form', () => {


### PR DESCRIPTION
This PR returns a missing throbber to "X more comments with Y Likes" loader.