### PR TITLE
Render comment item separators (' - ' or ' | ') explicitly by React

### DIFF
--- a/src/components/post-comment.jsx
+++ b/src/components/post-comment.jsx
@@ -22,6 +22,7 @@ import CommentIcon, { JustCommentIcon } from './comment-icon';
 import { CommentEditForm } from './comment-edit-form';
 import { ButtonLink } from './button-link';
 import { PostCommentMore } from './post-comment-more';
+import { Separated } from './separated';
 
 class PostComment extends Component {
   commentContainer;
@@ -128,64 +129,72 @@ class PostComment extends Component {
         aria-label={this.props.user ? `Comment by ${this.props.user.username}` : `Hidden comment`}
         className="comment-tail"
       >
-        {this.props.user && (
-          <span className="comment-tail__item">
-            <UserName user={this.props.user} userHover={this.props.authorHighlightHandlers} />
-          </span>
-        )}
-        <span className="comment-tail__item comment-tail__actions">
-          {this.props.isEditable && (
-            <span className="comment-tail__action">
-              <ButtonLink className="comment-tail__action-link" onClick={this.handleEditOrCancel}>
-                edit
-              </ButtonLink>
+        {' - '}
+        <Separated separator=" - ">
+          {this.props.user && (
+            <span className="comment-tail__item">
+              <UserName user={this.props.user} userHover={this.props.authorHighlightHandlers} />
             </span>
           )}
-          {canDelete && this.props.isModeratingComments && (
-            <span className="comment-tail__action">
-              <ButtonLink
-                className="comment-tail__action-link comment-tail__action-link--delete"
-                onClick={this.handleDeleteComment}
+          <span className="comment-tail__item comment-tail__actions">
+            <Separated separator=" | ">
+              {this.props.isEditable && (
+                <span className="comment-tail__action">
+                  <ButtonLink
+                    className="comment-tail__action-link"
+                    onClick={this.handleEditOrCancel}
+                  >
+                    edit
+                  </ButtonLink>
+                </span>
+              )}
+              {canDelete && this.props.isModeratingComments && (
+                <span className="comment-tail__action">
+                  <ButtonLink
+                    className="comment-tail__action-link comment-tail__action-link--delete"
+                    onClick={this.handleDeleteComment}
+                  >
+                    delete
+                  </ButtonLink>
+                </span>
+              )}
+              <span className="comment-tail__action">
+                <PostCommentMore
+                  className="comment-tail__action-link comment-tail__action-link--more"
+                  id={this.props.id}
+                  authorUsername={this.props.user?.username}
+                  doEdit={this.props.isEditable && this.handleEditOrCancel}
+                  doDelete={canDelete && ownComment && this.handleDeleteComment}
+                  doReply={canReply && this.reply}
+                  doMention={canReply && this.mention}
+                  doLike={canLike && !this.props.hasOwnLike && this.like}
+                  doUnlike={canLike && this.props.hasOwnLike && this.unlike}
+                  getBackwardIdx={this.backwardIdx}
+                  createdAt={this.props.createdAt}
+                  updatedAt={this.props.updatedAt}
+                  permalink={`${this.props.entryUrl}#comment-${this.props.id}`}
+                  likesCount={this.props.likes}
+                  setMenuOpener={this.setMoreMenuOpener}
+                  onMenuOpened={this.onMoreMenuOpened}
+                />
+              </span>
+            </Separated>
+          </span>
+          {(this.props.showTimestamps || this.props.forceAbsTimestamps) && (
+            <span className="comment-tail__item">
+              <Link
+                to={`${this.props.entryUrl}#comment-${this.props.id}`}
+                className="comment-tail__timestamp"
               >
-                delete
-              </ButtonLink>
+                <TimeDisplay
+                  timeStamp={+this.props.createdAt}
+                  inline
+                  absolute={this.props.forceAbsTimestamps}
+                />
+              </Link>
             </span>
           )}
-          <span className="comment-tail__action">
-            <PostCommentMore
-              className="comment-tail__action-link comment-tail__action-link--more"
-              id={this.props.id}
-              authorUsername={this.props.user?.username}
-              doEdit={this.props.isEditable && this.handleEditOrCancel}
-              doDelete={canDelete && ownComment && this.handleDeleteComment}
-              doReply={canReply && this.reply}
-              doMention={canReply && this.mention}
-              doLike={canLike && !this.props.hasOwnLike && this.like}
-              doUnlike={canLike && this.props.hasOwnLike && this.unlike}
-              getBackwardIdx={this.backwardIdx}
-              createdAt={this.props.createdAt}
-              updatedAt={this.props.updatedAt}
-              permalink={`${this.props.entryUrl}#comment-${this.props.id}`}
-              likesCount={this.props.likes}
-              setMenuOpener={this.setMoreMenuOpener}
-              onMenuOpened={this.onMoreMenuOpened}
-            />
-          </span>
-        </span>
-        {(this.props.showTimestamps || this.props.forceAbsTimestamps) && (
-          <span className="comment-tail__item">
-            <Link
-              to={`${this.props.entryUrl}#comment-${this.props.id}`}
-              className="comment-tail__timestamp"
-            >
-              <TimeDisplay
-                timeStamp={+this.props.createdAt}
-                inline
-                absolute={this.props.forceAbsTimestamps}
-              />
-            </Link>
-          </span>
-        )}
+        </Separated>
       </span>
     );
   }

--- a/src/components/separated.jsx
+++ b/src/components/separated.jsx
@@ -1,0 +1,23 @@
+import { Fragment, Children } from 'react';
+
+/**
+ * Inserts separator between the renderable children
+ */
+export function Separated({ separator, children }) {
+  return (
+    <>
+      {Children.toArray(children)
+        .filter(isRenderable)
+        .map((child, i) => (
+          <Fragment key={`sep${i}`}>
+            {i > 0 && separator}
+            {child}
+          </Fragment>
+        ))}
+    </>
+  );
+}
+
+function isRenderable(child) {
+  return typeof child !== 'boolean' && typeof child !== 'undefined' && child !== null;
+}

--- a/styles/shared/comments.scss
+++ b/styles/shared/comments.scss
@@ -120,23 +120,10 @@
     --danger-color: #d66;
   }
 
-  &__item::before {
-    color: var(--gray-color);
-    content: ' - ';
-  }
+  color: var(--gray-color);
 
   &__actions {
     white-space: nowrap;
-    color: var(--gray-color);
-  }
-
-  &__action {
-    &::before {
-      content: ' | ';
-    }
-    &:first-child::before {
-      content: none;
-    }
   }
 
   &__timestamp {

--- a/test/jest/__snapshots__/post-comments.test.js.snap
+++ b/test/jest/__snapshots__/post-comments.test.js.snap
@@ -69,6 +69,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
             aria-label="Comment by author"
             class="comment-tail"
           >
+             - 
             <span
               class="comment-tail__item"
             >
@@ -86,6 +87,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
                 </a>
               </span>
             </span>
+             - 
             <span
               class="comment-tail__item comment-tail__actions"
             >
@@ -184,6 +186,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
             aria-label="Comment by other"
             class="comment-tail"
           >
+             - 
             <span
               class="comment-tail__item"
             >
@@ -201,6 +204,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
                 </a>
               </span>
             </span>
+             - 
             <span
               class="comment-tail__item comment-tail__actions"
             >
@@ -285,6 +289,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
             aria-label="Comment by author"
             class="comment-tail"
           >
+             - 
             <span
               class="comment-tail__item"
             >
@@ -302,6 +307,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
                 </a>
               </span>
             </span>
+             - 
             <span
               class="comment-tail__item comment-tail__actions"
             >


### PR DESCRIPTION
Earlier we used CSS pseudoelements for this, but they are not selectable in the browser.