### PR TITLE
Add missing space in "post removed from a group" notification

### DIFF
--- a/src/components/notifications.jsx
+++ b/src/components/notifications.jsx
@@ -175,7 +175,7 @@ const notificationTemplates = {
     <div>
       <Linkify>{`@${event.createdUser.username} has removed the `}</Linkify>
       {event.post_id ? postLink(event) : 'post'}
-      <Linkify>{`from @${event.affectedUser.username} `}</Linkify>
+      <Linkify>{` from @${event.affectedUser.username} `}</Linkify>
       {event.group_id ? <Linkify>{` from the group @${event.group.username}`}</Linkify> : null}
     </div>
   ),


### PR DESCRIPTION
Before:

<img width="453" alt="Screenshot 2021-07-05 at 13 15 53" src="https://user-images.githubusercontent.com/632081/124515153-4f3adc80-de11-11eb-8576-06e4a3e10afc.png">

After:

<img width="450" alt="Screenshot 2021-07-05 at 13 17 23" src="https://user-images.githubusercontent.com/632081/124515170-56fa8100-de11-11eb-9100-ae7905172e49.png">
