### PR TITLE
Play video attachments using inline video tag

### DIFF
--- a/src/components/post/post-attachment-video.jsx
+++ b/src/components/post/post-attachment-video.jsx
@@ -1,0 +1,47 @@
+import { PureComponent } from 'react';
+import { faFileVideo } from '@fortawesome/free-regular-svg-icons';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+
+import { formatFileSize } from '../../utils';
+import { Icon } from '../fontawesome-icons';
+
+class VideoAttachment extends PureComponent {
+  handleClickOnRemoveAttachment = () => {
+    this.props.removeAttachment(this.props.id);
+  };
+
+  render() {
+    const { props } = this;
+    const formattedFileSize = formatFileSize(props.fileSize);
+
+    const title = `${props.fileName} (${formattedFileSize})`;
+
+    return (
+      <div className="attachment" role="figure" aria-label={`Video attachment ${title}`}>
+        <div>
+          <video title={title} preload="none" muted controls>
+            <source src={props.url} />
+            Your browser does not support HTML5 video tag.
+          </video>
+        </div>
+        <div>
+          <a href={props.url} title={title} target="_blank">
+            <Icon icon={faFileVideo} className="attachment-icon" />
+            <span>{title}</span>
+          </a>
+
+          {props.isEditing && (
+            <Icon
+              icon={faTimes}
+              className="remove-attachment"
+              title="Remove video file"
+              onClick={this.handleClickOnRemoveAttachment}
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default VideoAttachment;

--- a/src/components/post/post-attachment-video.jsx
+++ b/src/components/post/post-attachment-video.jsx
@@ -1,29 +1,49 @@
 import { PureComponent } from 'react';
-import { faFileVideo } from '@fortawesome/free-regular-svg-icons';
+import { faFileVideo, faPlayCircle } from '@fortawesome/free-regular-svg-icons';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import { formatFileSize } from '../../utils';
+import { ButtonLink } from '../button-link';
 import { Icon } from '../fontawesome-icons';
 
 class VideoAttachment extends PureComponent {
+  state = {
+    isOpen: false,
+  };
+
   handleClickOnRemoveAttachment = () => {
     this.props.removeAttachment(this.props.id);
   };
 
+  toggleOpen = () => {
+    this.setState({ isOpen: true });
+  };
+
   render() {
     const { props } = this;
+    const { isOpen } = this.state;
     const formattedFileSize = formatFileSize(props.fileSize);
 
     const title = `${props.fileName} (${formattedFileSize})`;
 
     return (
       <div className="attachment" role="figure" aria-label={`Video attachment ${title}`}>
-        <div>
-          <video title={title} preload="none" muted controls>
-            <source src={props.url} />
-            Your browser does not support HTML5 video tag.
-          </video>
-        </div>
+        {isOpen ? (
+          <div>
+            <video title={title} autoPlay controls>
+              <source src={props.url} />
+              Your browser does not support HTML5 video tag.
+            </video>
+          </div>
+        ) : (
+          <ButtonLink
+            onClick={this.toggleOpen}
+            className="video-attachment-click-to-play"
+            title="Click to play video"
+          >
+            <Icon icon={faPlayCircle} />
+          </ButtonLink>
+        )}
         <div>
           <a href={props.url} title={title} target="_blank">
             <Icon icon={faFileVideo} className="attachment-icon" />

--- a/src/components/post/post-attachments.jsx
+++ b/src/components/post/post-attachments.jsx
@@ -3,11 +3,33 @@ import ErrorBoundary from '../error-boundary';
 import ImageAttachmentsContainer from './post-attachment-image-container';
 import AudioAttachment from './post-attachment-audio';
 import GeneralAttachment from './post-attachment-general';
+import VideoAttachment from './post-attachment-video';
+
+const looksLikeAVideoFile = (attachment) => {
+  const lowercaseFileName = attachment.fileName.toLowerCase();
+  return lowercaseFileName.endsWith('.mov') || lowercaseFileName.endsWith('.mp4');
+};
 
 export default (props) => {
   const attachments = props.attachments || [];
 
-  const imageAttachments = attachments.filter((attachment) => attachment.mediaType === 'image');
+  const imageAttachments = [];
+  const audioAttachments = [];
+  const videoAttachments = [];
+  const generalAttachments = [];
+
+  attachments.forEach((attachment) => {
+    if (attachment.mediaType === 'image') {
+      imageAttachments.push(attachment);
+    } else if (attachment.mediaType === 'audio') {
+      audioAttachments.push(attachment);
+    } else if (attachment.mediaType === 'general' && looksLikeAVideoFile(attachment)) {
+      videoAttachments.push(attachment);
+    } else {
+      generalAttachments.push(attachment);
+    }
+  });
+
   const imageAttachmentsContainer =
     imageAttachments.length > 0 ? (
       <ImageAttachmentsContainer
@@ -23,7 +45,6 @@ export default (props) => {
       false
     );
 
-  const audioAttachments = attachments.filter((attachment) => attachment.mediaType === 'audio');
   const audioAttachmentsNodes = audioAttachments.map((attachment) => (
     <AudioAttachment
       key={attachment.id}
@@ -39,7 +60,21 @@ export default (props) => {
       false
     );
 
-  const generalAttachments = attachments.filter((attachment) => attachment.mediaType === 'general');
+  const videoAttachmentsNodes = videoAttachments.map((attachment) => (
+    <VideoAttachment
+      key={attachment.id}
+      isEditing={props.isEditing}
+      removeAttachment={props.removeAttachment}
+      {...attachment}
+    />
+  ));
+  const videoAttachmentsContainer =
+    videoAttachments.length > 0 ? (
+      <div className="video-attachments">{videoAttachmentsNodes}</div>
+    ) : (
+      false
+    );
+
   const generalAttachmentsNodes = generalAttachments.map((attachment) => (
     <GeneralAttachment
       key={attachment.id}
@@ -60,6 +95,7 @@ export default (props) => {
       <ErrorBoundary>
         {imageAttachmentsContainer}
         {audioAttachmentsContainer}
+        {videoAttachmentsContainer}
         {generalAttachmentsContainer}
       </ErrorBoundary>
     </div>

--- a/src/components/post/post-attachments.jsx
+++ b/src/components/post/post-attachments.jsx
@@ -7,7 +7,12 @@ import VideoAttachment from './post-attachment-video';
 
 const looksLikeAVideoFile = (attachment) => {
   const lowercaseFileName = attachment.fileName.toLowerCase();
-  return lowercaseFileName.endsWith('.mov') || lowercaseFileName.endsWith('.mp4');
+  return (
+    lowercaseFileName.endsWith('.mov') ||
+    lowercaseFileName.endsWith('.mp4') ||
+    lowercaseFileName.endsWith('.webm') ||
+    lowercaseFileName.endsWith('.ogg')
+  );
 };
 
 export default (props) => {

--- a/src/components/post/post-attachments.jsx
+++ b/src/components/post/post-attachments.jsx
@@ -5,14 +5,35 @@ import AudioAttachment from './post-attachment-audio';
 import GeneralAttachment from './post-attachment-general';
 import VideoAttachment from './post-attachment-video';
 
+const videoTypes = {
+  mov: 'video/quicktime',
+  mp4: 'video/mp4; codecs="avc1.42E01E"',
+  ogg: 'video/ogg; codecs="theora"',
+  webm: 'video/webm; codecs="vp8, vorbis"',
+};
+
+// find video-types which browser supports
+let video = document.createElement('video');
+const supportedVideoTypes = [];
+Object.keys(videoTypes).forEach((extension) => {
+  const mime = videoTypes[extension];
+
+  if (video.canPlayType(mime) !== '') {
+    supportedVideoTypes.push(extension);
+  }
+});
+video = null;
+
 const looksLikeAVideoFile = (attachment) => {
   const lowercaseFileName = attachment.fileName.toLowerCase();
-  return (
-    lowercaseFileName.endsWith('.mov') ||
-    lowercaseFileName.endsWith('.mp4') ||
-    lowercaseFileName.endsWith('.webm') ||
-    lowercaseFileName.endsWith('.ogg')
-  );
+
+  for (const extension of supportedVideoTypes) {
+    if (lowercaseFileName.endsWith(`.${extension}`)) {
+      return true;
+    }
+  }
+
+  return false;
 };
 
 export default (props) => {

--- a/styles/shared/attachments-edit.scss
+++ b/styles/shared/attachments-edit.scss
@@ -74,6 +74,7 @@
 }
 
 .audio-attachments,
+.video-attachments,
 .general-attachments {
   .attachment:hover .remove-attachment {
     display: block;

--- a/styles/shared/attachments.scss
+++ b/styles/shared/attachments.scss
@@ -131,6 +131,7 @@
 }
 
 .audio-attachments,
+.video-attachments,
 .general-attachments {
   .attachment {
     position: relative;
@@ -146,5 +147,13 @@
     .attachment-title {
       overflow-wrap: break-word;
     }
+  }
+}
+
+.video-attachments {
+  video {
+    max-width: 100%;
+    max-height: 400px;
+    background-color: #eee;
   }
 }

--- a/styles/shared/attachments.scss
+++ b/styles/shared/attachments.scss
@@ -151,6 +151,17 @@
 }
 
 .video-attachments {
+  .video-attachment-click-to-play {
+    display: flex;
+    width: 3em;
+    height: 3em;
+    justify-content: center;
+    align-items: center;
+    border-radius: 2px;
+    background-color: #eee;
+    font-size: 2em;
+  }
+
   video {
     max-width: 100%;
     max-height: 400px;

--- a/styles/shared/media-viewer.scss
+++ b/styles/shared/media-viewer.scss
@@ -39,11 +39,11 @@
     width: 100%;
     height: 100%;
   }
-}
 
-video {
-  width: 100% !important;
-  height: auto !important;
+  video {
+    width: 100% !important;
+    height: auto !important;
+  }
 }
 
 .media-link {

--- a/test/jest-setup.js
+++ b/test/jest-setup.js
@@ -1,1 +1,6 @@
 require('../config/lib/loader-node');
+
+// https://github.com/testing-library/react-testing-library/issues/470
+Object.defineProperty(HTMLMediaElement.prototype, 'muted', {
+  set: () => {},
+});

--- a/test/jest/__snapshots__/post-attachments.test.js.snap
+++ b/test/jest/__snapshots__/post-attachments.test.js.snap
@@ -123,18 +123,27 @@ exports[`PostAttachments Displays all post attachment types 1`] = `
         class="attachment"
         role="figure"
       >
-        <div>
-          <video
-            controls=""
-            preload="none"
-            title="sunrise.mp4 (117.7 MiB)"
+        <a
+          aria-disabled="false"
+          class="video-attachment-click-to-play"
+          role="button"
+          tabindex="0"
+          title="Click to play video"
+        >
+          <svg
+            aria-hidden="true"
+            class="fa-icon fa-icon-far-play-circle"
+            focusable="false"
+            role="img"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <source
-              src="https://media/sunrise.mp4"
+            <path
+              d="M371.7 238l-176-107c-15.8-8.8-35.7 2.5-35.7 21v208c0 18.4 19.8 29.8 35.7 21l176-101c16.4-9.1 16.4-32.8 0-42zM504 256C504 119 393 8 256 8S8 119 8 256s111 248 248 248 248-111 248-248zm-448 0c0-110.5 89.5-200 200-200s200 89.5 200 200-89.5 200-200 200S56 366.5 56 256z"
+              fill="currentColor"
             />
-            Your browser does not support HTML5 video tag.
-          </video>
-        </div>
+          </svg>
+        </a>
         <div>
           <a
             href="https://media/sunrise.mp4"

--- a/test/jest/__snapshots__/post-attachments.test.js.snap
+++ b/test/jest/__snapshots__/post-attachments.test.js.snap
@@ -1,0 +1,202 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PostAttachments Displays all post attachment types 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="5 attachments"
+    class="attachments"
+    role="region"
+  >
+    <div
+      class="image-attachments is-folded"
+    >
+      <div
+        class="attachment"
+        data-id="im1"
+        role="figure"
+      >
+        <a
+          class="image-attachment-link"
+          href="https://media/CAT.JPG"
+          target="_blank"
+          title="CAT.JPG (195.3 KiB, 2000×1500px)"
+        >
+          <img
+            alt="Image attachment CAT.JPG"
+            class="image-attachment-img"
+            height="300"
+            loading="lazy"
+            src="https://thumbnail/CAT.JPG"
+            width="400"
+          />
+        </a>
+      </div>
+      <div
+        class="attachment"
+        data-id="im2"
+        role="figure"
+      >
+        <a
+          class="image-attachment-link"
+          href="https://media/food.jpg"
+          target="_blank"
+          title="food.jpg (2 KiB, 2000×1500px)"
+        >
+          <img
+            alt="Image attachment food.jpg"
+            class="image-attachment-img"
+            height="1500"
+            loading="lazy"
+            src="https://thumbnail/food.jpg"
+            width="2000"
+          />
+        </a>
+      </div>
+      <div
+        class="show-more"
+      >
+        <svg
+          aria-hidden="true"
+          class="show-more-icon fa-icon fa-icon-fas-chevron-circle-right"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            Show more (1)
+          </title>
+          <path
+            d="M256 8c137 0 248 111 248 248S393 504 256 504 8 393 8 256 119 8 256 8zm113.9 231L234.4 103.5c-9.4-9.4-24.6-9.4-33.9 0l-17 17c-9.4 9.4-9.4 24.6 0 33.9L285.1 256 183.5 357.6c-9.4 9.4-9.4 24.6 0 33.9l17 17c9.4 9.4 24.6 9.4 33.9 0L369.9 273c9.4-9.4 9.4-24.6 0-34z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      class="audio-attachments"
+    >
+      <div
+        aria-label="Audio attachment Oasis – Wonderwall (1.2 MiB)"
+        class="attachment"
+        role="figure"
+      >
+        <div>
+          <audio
+            controls=""
+            preload="none"
+            src="https://media/wonderwall.mp3"
+            title="Oasis – Wonderwall (1.2 MiB)"
+          />
+        </div>
+        <div>
+          <a
+            href="https://media/wonderwall.mp3"
+            target="_blank"
+            title="Oasis – Wonderwall (1.2 MiB)"
+          >
+            <svg
+              aria-hidden="true"
+              class="attachment-icon fa-icon fa-icon-far-file-audio"
+              focusable="false"
+              role="img"
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M369.941 97.941l-83.882-83.882A48 48 0 0 0 252.118 0H48C21.49 0 0 21.49 0 48v416c0 26.51 21.49 48 48 48h288c26.51 0 48-21.49 48-48V131.882a48 48 0 0 0-14.059-33.941zM332.118 128H256V51.882L332.118 128zM48 464V48h160v104c0 13.255 10.745 24 24 24h104v288H48zm144-76.024c0 10.691-12.926 16.045-20.485 8.485L136 360.486h-28c-6.627 0-12-5.373-12-12v-56c0-6.627 5.373-12 12-12h28l35.515-36.947c7.56-7.56 20.485-2.206 20.485 8.485v135.952zm41.201-47.13c9.051-9.297 9.06-24.133.001-33.439-22.149-22.752 12.235-56.246 34.395-33.481 27.198 27.94 27.212 72.444.001 100.401-21.793 22.386-56.947-10.315-34.397-33.481z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Oasis – Wonderwall (1.2 MiB)
+            </span>
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      class="video-attachments"
+    >
+      <div
+        aria-label="Video attachment sunrise.mp4 (117.7 MiB)"
+        class="attachment"
+        role="figure"
+      >
+        <div>
+          <video
+            controls=""
+            preload="none"
+            title="sunrise.mp4 (117.7 MiB)"
+          >
+            <source
+              src="https://media/sunrise.mp4"
+            />
+            Your browser does not support HTML5 video tag.
+          </video>
+        </div>
+        <div>
+          <a
+            href="https://media/sunrise.mp4"
+            target="_blank"
+            title="sunrise.mp4 (117.7 MiB)"
+          >
+            <svg
+              aria-hidden="true"
+              class="attachment-icon fa-icon fa-icon-far-file-video"
+              focusable="false"
+              role="img"
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M369.941 97.941l-83.882-83.882A48 48 0 0 0 252.118 0H48C21.49 0 0 21.49 0 48v416c0 26.51 21.49 48 48 48h288c26.51 0 48-21.49 48-48V131.882a48 48 0 0 0-14.059-33.941zM332.118 128H256V51.882L332.118 128zM48 464V48h160v104c0 13.255 10.745 24 24 24h104v288H48zm228.687-211.303L224 305.374V268c0-11.046-8.954-20-20-20H100c-11.046 0-20 8.954-20 20v104c0 11.046 8.954 20 20 20h104c11.046 0 20-8.954 20-20v-37.374l52.687 52.674C286.704 397.318 304 390.28 304 375.986V264.011c0-14.311-17.309-21.319-27.313-11.314z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              sunrise.mp4 (117.7 MiB)
+            </span>
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      class="general-attachments"
+    >
+      <div
+        aria-label="Attachment rfc.pdf (48.8 KiB)"
+        class="attachment"
+        role="figure"
+      >
+        <a
+          href="https://media/rfc.pdf"
+          target="_blank"
+          title="rfc.pdf (48.8 KiB)"
+        >
+          <svg
+            aria-hidden="true"
+            class="attachment-icon fa-icon fa-icon-far-file"
+            focusable="false"
+            role="img"
+            viewBox="0 0 384 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M369.9 97.9L286 14C277 5 264.8-.1 252.1-.1H48C21.5 0 0 21.5 0 48v416c0 26.5 21.5 48 48 48h288c26.5 0 48-21.5 48-48V131.9c0-12.7-5.1-25-14.1-34zM332.1 128H256V51.9l76.1 76.1zM48 464V48h160v104c0 13.3 10.7 24 24 24h104v288H48z"
+              fill="currentColor"
+            />
+          </svg>
+          <span
+            class="attachment-title"
+          >
+            rfc.pdf (48.8 KiB)
+          </span>
+        </a>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`PostAttachments Renders an empty attachments container 1`] = `<DocumentFragment />`;

--- a/test/jest/post-attachments.test.js
+++ b/test/jest/post-attachments.test.js
@@ -1,0 +1,82 @@
+/* global describe, it, expect */
+import { render } from '@testing-library/react';
+
+import PostAttachments from '../../src/components/post-attachments';
+
+const renderPostAttachments = (props = {}) => {
+  return render(<PostAttachments {...props} />);
+};
+
+describe('PostAttachments', () => {
+  it('Renders an empty attachments container', () => {
+    const { asFragment } = renderPostAttachments();
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('Displays all post attachment types', () => {
+    const image1 = {
+      id: 'im1',
+      mediaType: 'image',
+      fileName: 'CAT.JPG',
+      fileSize: 200000,
+      thumbnailUrl: 'https://thumbnail/CAT.JPG',
+      url: 'https://media/CAT.JPG',
+      imageSizes: {
+        t: {
+          w: 400,
+          h: 300,
+        },
+        o: {
+          w: 2000,
+          h: 1500,
+        },
+      },
+    };
+
+    const image2 = {
+      id: 'im2',
+      mediaType: 'image',
+      fileName: 'food.jpg',
+      fileSize: 2000,
+      thumbnailUrl: 'https://thumbnail/food.jpg',
+      url: 'https://media/food.jpg',
+      imageSizes: {
+        o: {
+          w: 2000,
+          h: 1500,
+        },
+      },
+    };
+
+    const video1 = {
+      id: 'vi1',
+      mediaType: 'general',
+      fileName: 'sunrise.mp4',
+      fileSize: 123456789,
+      url: 'https://media/sunrise.mp4',
+    };
+
+    const audio1 = {
+      id: 'au1',
+      mediaType: 'audio',
+      fileName: 'wonderwall.mp3',
+      artist: 'Oasis',
+      title: 'Wonderwall',
+      fileSize: 1234567,
+      url: 'https://media/wonderwall.mp3',
+    };
+
+    const general1 = {
+      id: 'ge1',
+      mediaType: 'general',
+      fileName: 'rfc.pdf',
+      fileSize: 50000,
+      url: 'https://media/rfc.pdf',
+    };
+
+    const { asFragment } = renderPostAttachments({
+      attachments: [video1, image1, general1, image2, audio1],
+    });
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/test/jest/post-attachments.test.js
+++ b/test/jest/post-attachments.test.js
@@ -1,7 +1,7 @@
 /* global describe, it, expect */
 import { render } from '@testing-library/react';
 
-import PostAttachments from '../../src/components/post-attachments';
+import PostAttachments from '../../src/components/post/post-attachments';
 
 const renderPostAttachments = (props = {}) => {
   return render(<PostAttachments {...props} />);


### PR DESCRIPTION
This PR makes video attachments (files that end in `.mov` or `.mp4`) play using inline `<video>` tag. The videos do not autoplay and are muted by default. There is no lightbox support for now, and there are no useful thumbnails (this requires backend support).

<img width="720" alt="Screenshot 2021-07-06 at 12 56 05" src="https://user-images.githubusercontent.com/632081/124659632-c175f480-ded7-11eb-97ec-7f66827d946f.png">
<img width="721" alt="Screenshot 2021-07-06 at 12 56 31" src="https://user-images.githubusercontent.com/632081/124659648-c5097b80-ded7-11eb-8d16-b88ef60d2466.png">
