### PR TITLE
Move "Unread notifications" setting to Notifications tab

### DIFF
--- a/src/components/settings/forms/appearance.jsx
+++ b/src/components/settings/forms/appearance.jsx
@@ -70,7 +70,6 @@ export default function AppearanceForm() {
   const omitBubbles = useField('omitBubbles', form.form);
   const highlightComments = useField('highlightComments', form.form);
   const hideBannedComments = useField('hideBannedComments', form.form);
-  const hideUnreadNotifications = useField('hideUnreadNotifications', form.form);
   const allowLinksPreview = useField('allowLinksPreview', form.form);
   const hideNSFWContent = useField('hideNSFWContent', form.form);
   const commentsTimestamps = useField('commentsTimestamps', form.form);
@@ -240,19 +239,6 @@ export default function AppearanceForm() {
       </section>
 
       <section className={settingsStyles.formSection}>
-        <h4 id="notifications">Unread notifications</h4>
-
-        <div className="form-group">
-          <div className="checkbox">
-            <label>
-              <CheckboxInput field={hideUnreadNotifications} />
-              Hide unread notification counter
-            </label>
-          </div>
-        </div>
-      </section>
-
-      <section className={settingsStyles.formSection}>
         <h4 id="previews">Link previews</h4>
 
         <div className="form-group">
@@ -369,7 +355,6 @@ function initialValues({
     omitBubbles: frontend.comments.omitRepeatedBubbles,
     highlightComments: frontend.comments.highlightComments,
     hideBannedComments: backend?.hideCommentsOfTypes.includes(COMMENT_HIDDEN_BANNED),
-    hideUnreadNotifications: frontend.hideUnreadNotifications,
     allowLinksPreview: frontend.allowLinksPreview,
     hideNSFWContent: !isNSFWVisible,
     commentsTimestamps: frontend.comments.showTimestamps,
@@ -411,7 +396,6 @@ function prefUpdaters(values) {
           highlightComments: values.highlightComments,
           showTimestamps: values.commentsTimestamps,
         },
-        hideUnreadNotifications: values.hideUnreadNotifications,
         allowLinksPreview: values.allowLinksPreview,
         timeDisplay: {
           ...prefs.timeDisplay,

--- a/src/components/settings/forms/notifications.jsx
+++ b/src/components/settings/forms/notifications.jsx
@@ -2,11 +2,15 @@ import { useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router';
 import { useForm, useField } from 'react-final-form-hooks';
-import { pick } from 'lodash';
 import { Throbber } from '../../throbber';
-import { updateUserNotificationPreferences } from '../../../redux/action-creators';
+import {
+  updateActualUserPreferences,
+  updateUserNotificationPreferences,
+} from '../../../redux/action-creators';
+import { doSequence } from '../../../redux/async-helpers';
 import { PreventPageLeaving } from '../../prevent-page-leaving';
 import { CheckboxInput } from '../../form-utils';
+import settingsStyles from '../settings.module.scss';
 
 export default function NotificationsForm() {
   const dispatch = useDispatch();
@@ -23,6 +27,7 @@ export default function NotificationsForm() {
     ),
   );
 
+  const hideUnreadNotifications = useField('hideUnreadNotifications', form.form);
   const sendNotificationsDigest = useField('sendNotificationsDigest', form.form);
   const sendDailyBestOfDigest = useField('sendDailyBestOfDigest', form.form);
   const sendWeeklyBestOfDigest = useField('sendWeeklyBestOfDigest', form.form);
@@ -31,30 +36,45 @@ export default function NotificationsForm() {
     <form onSubmit={form.handleSubmit}>
       <PreventPageLeaving prevent={form.dirty} />
 
-      <p>Email me:</p>
+      <section className={settingsStyles.formSection}>
+        <h4 id="notifications">Unread notifications</h4>
 
-      <div className="form-group">
-        <div className="checkbox">
-          <label>
-            <CheckboxInput field={sendNotificationsDigest} />
-            Daily unread notifications
-          </label>
+        <div className="form-group">
+          <div className="checkbox">
+            <label>
+              <CheckboxInput field={hideUnreadNotifications} />
+              Hide unread notification counter in the sidebar
+            </label>
+          </div>
         </div>
+      </section>
 
-        <div className="checkbox">
-          <label>
-            <CheckboxInput field={sendDailyBestOfDigest} />
-            Daily <Link to="/summary/1">Best of Day</Link> digest
-          </label>
-        </div>
+      <section className={settingsStyles.formSection}>
+        <h4 id="email-me">Email me:</h4>
 
-        <div className="checkbox">
-          <label>
-            <CheckboxInput field={sendWeeklyBestOfDigest} />
-            Weekly <Link to="/summary/7">Best of Week</Link> digest
-          </label>
+        <div className="form-group">
+          <div className="checkbox">
+            <label>
+              <CheckboxInput field={sendNotificationsDigest} />
+              Daily unread notifications
+            </label>
+          </div>
+
+          <div className="checkbox">
+            <label>
+              <CheckboxInput field={sendDailyBestOfDigest} />
+              Daily <Link to="/summary/1">Best of Day</Link> digest
+            </label>
+          </div>
+
+          <div className="checkbox">
+            <label>
+              <CheckboxInput field={sendWeeklyBestOfDigest} />
+              Weekly <Link to="/summary/7">Best of Week</Link> digest
+            </label>
+          </div>
         </div>
-      </div>
+      </section>
 
       <div className="form-group">
         <button
@@ -82,14 +102,39 @@ export default function NotificationsForm() {
   );
 }
 
-function initialValues({ preferences }) {
-  return pick(preferences, [
-    'sendNotificationsDigest',
-    'sendDailyBestOfDigest',
-    'sendWeeklyBestOfDigest',
-  ]);
+function initialValues({ frontendPreferences, preferences }) {
+  return {
+    hideUnreadNotifications: frontendPreferences.hideUnreadNotifications,
+    sendNotificationsDigest: preferences.sendNotificationsDigest,
+    sendDailyBestOfDigest: preferences.sendDailyBestOfDigest,
+    sendWeeklyBestOfDigest: preferences.sendWeeklyBestOfDigest,
+  };
 }
 
 function onSubmit(userData, dispatch) {
-  return (values) => dispatch(updateUserNotificationPreferences(userData.id, values));
+  return ({
+    hideUnreadNotifications,
+    sendNotificationsDigest,
+    sendDailyBestOfDigest,
+    sendWeeklyBestOfDigest,
+  }) =>
+    doSequence(dispatch)(
+      (dispatch) =>
+        dispatch(
+          updateActualUserPreferences({
+            updateFrontendPrefs: () => ({
+              hideUnreadNotifications,
+            }),
+          }),
+        ),
+      (dispatch) => {
+        dispatch(
+          updateUserNotificationPreferences(userData.id, {
+            sendNotificationsDigest,
+            sendDailyBestOfDigest,
+            sendWeeklyBestOfDigest,
+          }),
+        );
+      },
+    );
 }


### PR DESCRIPTION
This PR moves "Unread notifications" setting from Apperance into Notifications tab of Settings page.

<img width="487" alt="Screenshot 2021-08-02 at 14 47 59" src="https://user-images.githubusercontent.com/632081/127928621-a7944a86-569d-42d2-81af-da4f1179130f.png">


