### PR TITLE
Better list editor

### DIFF
--- a/src/components/friends-page/list-editor.jsx
+++ b/src/components/friends-page/list-editor.jsx
@@ -286,7 +286,11 @@ export const ListEditor = memo(function ListEditor({
           {homeless.length > 0 && (
             <div className={cn(styles.submitWarning, 'text-muted')}>
               <Icon icon={faExclamationTriangle} />{' '}
-              {andJoin(homeless.slice(0, 5).map((u) => `@${u.username}`))}{' '}
+              {homeless.length < 5
+                ? andJoin(homeless.map((u) => `@${u.username}`))
+                : `${homeless.slice(0, 3).map((u) => `@${u.username}`)} and ${
+                    homeless.length - 3
+                  } more users `}
               {homeless.length === 1 ? 'is' : 'are'} not in any of your friend lists.
             </div>
           )}

--- a/src/components/friends-page/list-editor.module.scss
+++ b/src/components/friends-page/list-editor.module.scss
@@ -51,7 +51,7 @@
   margin: 4px;
   border-radius: 4px;
   width: 200px;
-  word-break: break-all;
+  word-break: break-word;
   font-size: 12px;
   display: grid;
   grid-auto-flow: column;

--- a/test/jest/__snapshots__/list-editor.test.jsx.snap
+++ b/test/jest/__snapshots__/list-editor.test.jsx.snap
@@ -284,7 +284,6 @@ exports[`ListEditor Renders a list and doesn't blow up 1`] = `
       </svg>
        
       @homeless
-       
       is
        not in any of your friend lists.
     </div>

--- a/test/jest/__snapshots__/list-editor.test.jsx.snap
+++ b/test/jest/__snapshots__/list-editor.test.jsx.snap
@@ -1,0 +1,423 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListEditor Renders a list and doesn't blow up 1`] = `
+<section
+  class="wrapper"
+  data-testid="list-editor"
+>
+  <header
+    class="header"
+  >
+    <dl
+      class="topForm"
+    >
+      <dt>
+        List title
+      </dt>
+      <dd>
+        <input
+          class="form-control input-lg"
+          placeholder="Name your list (required)"
+          type="text"
+          value="My amazing list"
+        />
+      </dd>
+    </dl>
+    <p>
+      Show:
+       
+      <span
+        class="currentLink"
+      >
+        All (
+        5
+        )
+      </span>
+       - 
+      <a
+        aria-disabled="false"
+        role="button"
+        tabindex="0"
+      >
+        In the list (
+        3
+        )
+      </a>
+       - 
+      <a
+        aria-disabled="false"
+        role="button"
+        tabindex="0"
+      >
+        Not in the list (
+        2
+        )
+      </a>
+       - 
+      Filter by name:
+       
+      <input
+        class="form-control input-sm filterInput"
+        name="nameFilter"
+        type="search"
+        value=""
+      />
+       
+      (
+      <a
+        aria-disabled="false"
+        role="button"
+        tabindex="0"
+      >
+        clear
+      </a>
+      )
+    </p>
+  </header>
+  <main>
+    <div
+      class="content"
+    >
+      <ul
+        class="list"
+      >
+        <li
+          aria-checked="true"
+          class="cell cellSelected"
+          role="checkbox"
+          tabindex="0"
+        >
+          <div
+            class="picture"
+          >
+            <img
+              alt="Profile picture of group"
+              height="50"
+              width="50"
+            />
+          </div>
+          <div>
+            <div
+              class="screenName"
+            >
+              A group
+            </div>
+            <div
+              class="username"
+            >
+              @
+              group
+            </div>
+          </div>
+        </li>
+        <li
+          aria-checked="false"
+          class="cell"
+          role="checkbox"
+          tabindex="0"
+        >
+          <div
+            class="picture"
+          >
+            <img
+              alt="Profile picture of homeless"
+              height="50"
+              width="50"
+            />
+          </div>
+          <div>
+            <div
+              class="screenName"
+            >
+              Homeless
+            </div>
+            <div
+              class="username"
+            >
+              @
+              homeless
+            </div>
+            <svg
+              aria-hidden="true"
+              class="homelessMark fa-icon fa-icon-fas-exclamation-triangle"
+              focusable="false"
+              role="img"
+              viewBox="0 0 576 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                This user is in no lists
+              </title>
+              <path
+                d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </li>
+        <li
+          aria-checked="true"
+          class="cell cellSelected"
+          role="checkbox"
+          tabindex="0"
+        >
+          <div
+            class="picture"
+          >
+            <img
+              alt="Profile picture of in-list-1"
+              height="50"
+              width="50"
+            />
+          </div>
+          <div>
+            <div
+              class="screenName"
+            >
+              In list
+            </div>
+            <div
+              class="username"
+            >
+              @
+              in-list-1
+            </div>
+          </div>
+        </li>
+        <li
+          aria-checked="true"
+          class="cell cellSelected"
+          role="checkbox"
+          tabindex="0"
+        >
+          <div
+            class="picture"
+          >
+            <img
+              alt="Profile picture of in-list-2"
+              height="50"
+              width="50"
+            />
+          </div>
+          <div>
+            <div
+              class="screenName"
+            >
+              In multiple lists
+            </div>
+            <div
+              class="username"
+            >
+              @
+              in-list-2
+            </div>
+          </div>
+        </li>
+        <li
+          aria-checked="false"
+          class="cell"
+          role="checkbox"
+          tabindex="0"
+        >
+          <div
+            class="picture"
+          >
+            <img
+              alt="Profile picture of not-in-list"
+              height="50"
+              width="50"
+            />
+          </div>
+          <div>
+            <div
+              class="screenName"
+            >
+              In Some Other List
+            </div>
+            <div
+              class="username"
+            >
+              @
+              not-in-list
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </main>
+  <footer
+    class="footer"
+  >
+    <button
+      class="btn btn-primary "
+      type="submit"
+    >
+      Save changes
+    </button>
+    <button
+      class="btn btn-link"
+      type="reset"
+    >
+      Cancel
+    </button>
+    <button
+      class="btn btn-danger pull-right"
+      type="button"
+    >
+      Delete list
+    </button>
+    <div
+      class="submitWarning text-muted"
+    >
+      <svg
+        aria-hidden="true"
+        class="fa-icon fa-icon-fas-exclamation-triangle"
+        focusable="false"
+        role="img"
+        viewBox="0 0 576 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+          fill="currentColor"
+        />
+      </svg>
+       
+      @homeless
+       
+      is
+       not in any of your friend lists.
+    </div>
+  </footer>
+</section>
+`;
+
+exports[`ListEditor Searches for users 1`] = `
+<ul
+  class="list"
+>
+  <li
+    aria-checked="true"
+    class="cell cellSelected"
+    role="checkbox"
+    tabindex="0"
+  >
+    <div
+      class="picture"
+    >
+      <img
+        alt="Profile picture of in-list-1"
+        height="50"
+        width="50"
+      />
+    </div>
+    <div>
+      <div
+        class="screenName"
+      >
+        In 
+        <mark
+          class="mark"
+        >
+          list
+        </mark>
+        
+      </div>
+      <div
+        class="username"
+      >
+        @
+        in-
+        <mark
+          class="mark"
+        >
+          list
+        </mark>
+        -1
+      </div>
+    </div>
+  </li>
+  <li
+    aria-checked="true"
+    class="cell cellSelected"
+    role="checkbox"
+    tabindex="0"
+  >
+    <div
+      class="picture"
+    >
+      <img
+        alt="Profile picture of in-list-2"
+        height="50"
+        width="50"
+      />
+    </div>
+    <div>
+      <div
+        class="screenName"
+      >
+        In multiple 
+        <mark
+          class="mark"
+        >
+          list
+        </mark>
+        s
+      </div>
+      <div
+        class="username"
+      >
+        @
+        in-
+        <mark
+          class="mark"
+        >
+          list
+        </mark>
+        -2
+      </div>
+    </div>
+  </li>
+  <li
+    aria-checked="false"
+    class="cell"
+    role="checkbox"
+    tabindex="0"
+  >
+    <div
+      class="picture"
+    >
+      <img
+        alt="Profile picture of not-in-list"
+        height="50"
+        width="50"
+      />
+    </div>
+    <div>
+      <div
+        class="screenName"
+      >
+        In Some Other 
+        <mark
+          class="mark"
+        >
+          List
+        </mark>
+        
+      </div>
+      <div
+        class="username"
+      >
+        @
+        not-in-
+        <mark
+          class="mark"
+        >
+          list
+        </mark>
+        
+      </div>
+    </div>
+  </li>
+</ul>
+`;

--- a/test/jest/list-editor.test.jsx
+++ b/test/jest/list-editor.test.jsx
@@ -1,0 +1,97 @@
+/* global describe, it, expect, jest, beforeEach */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+import { createStore } from 'redux';
+import * as reactRedux from 'react-redux';
+
+import { ListEditor } from '../../src/components/friends-page/list-editor';
+
+const LIST_ID = 'list-id';
+
+const defaultState = {
+  allSubscriptions: [
+    { id: 'u1', homeFeeds: [LIST_ID] },
+    { id: 'u2', homeFeeds: [LIST_ID, 'some-other-list'] },
+    { id: 'u3', homeFeeds: ['some-other-list'] },
+    { id: 'u4', homeFeeds: [] },
+    { id: 'g1', homeFeeds: [LIST_ID] },
+  ],
+  homeFeeds: [
+    {
+      id: LIST_ID,
+      title: 'My amazing list',
+      isInherent: false,
+    },
+  ],
+  users: {
+    u1: { id: 'u1', type: 'user', username: 'in-list-1', screenName: 'In list' },
+    u2: { id: 'u2', type: 'user', username: 'in-list-2', screenName: 'In multiple lists' },
+    u3: { id: 'u3', type: 'user', username: 'not-in-list', screenName: 'In Some Other List' },
+    u4: { id: 'u4', type: 'user', username: 'homeless', screenName: 'Homeless' },
+    u5: { id: 'u5', type: 'user', username: 'unrelated', screenName: 'Not subscribed' },
+    g1: { id: 'g1', type: 'group', username: 'group', screenName: 'A group' },
+  },
+  allSubscriptionsStatus: { success: true },
+  crudHomeFeedStatus: { success: true },
+};
+
+const renderListEditor = (props = {}, options = {}) => {
+  const { Provider } = reactRedux;
+  const dummyReducer = (state) => state;
+  const store = createStore(dummyReducer, defaultState);
+
+  const defaultProps = {
+    listId: LIST_ID,
+    closeEditor: () => {},
+  };
+
+  const rendered = render(
+    <Provider store={store}>
+      <ListEditor {...defaultProps} {...props} />
+    </Provider>,
+    options,
+  );
+
+  return {
+    ...rendered,
+    rerender: (props = {}, options = {}) =>
+      renderListEditor(props, { container: rendered.container, ...options }),
+  };
+};
+
+describe('ListEditor', () => {
+  const useSelectorMock = jest.spyOn(reactRedux, 'useSelector');
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+
+  beforeEach(() => {
+    useSelectorMock.mockClear();
+    useDispatchMock.mockClear();
+    useSelectorMock.mockImplementation((selector) => selector(defaultState));
+    useDispatchMock.mockImplementation(() => () => {});
+  });
+
+  it("Renders a list and doesn't blow up", () => {
+    renderListEditor();
+    const listEditor = screen.getByTestId('list-editor');
+    expect(listEditor).toMatchSnapshot();
+  });
+
+  it('Add a user to the list by clicking on it', () => {
+    renderListEditor();
+    userEvent.click(screen.getByText(/Not in the list/));
+    expect(screen.getByText('Homeless')).toBeDefined();
+    expect(screen.getByText('In Some Other List')).toBeDefined();
+    expect(screen.getByText(/not in any of your friend lists/)).toBeDefined();
+    expect(screen.queryByText('In list')).toBeNull();
+    userEvent.click(screen.getByText('Homeless'));
+    expect(screen.queryByText('Homeless')).toBeNull();
+    expect(screen.queryByText(/not in any of your friend lists/)).toBeNull();
+  });
+
+  it('Searches for users', () => {
+    renderListEditor();
+    userEvent.type(screen.getByRole('searchbox'), 'LIST');
+    expect(screen.getByRole('list')).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
This PR improves list editor:

1. users are sorted by username
2. better display of long screennames `word-break: break-all;` => `word-break: break-word;`
3. notification about "homeless" users is displayed all the time and has usernames of first five users that are not assigned to any lists
4. added "not in this list" quick-filter
5. search is case-insensitive, search highlight is case-insensitive as well

### Before:

* <img width="911" alt="before-main" src="https://user-images.githubusercontent.com/632081/127946505-4a503f8f-78fe-4b86-9e66-0f1bceb91a35.png">
    Note that "homeless" warning is only shown on main screen
* <img width="914" alt="before-in" src="https://user-images.githubusercontent.com/632081/127946512-0578001f-bb32-4682-81bf-245ab4228efc.png">
    Note how agavr's screen name is broken into two lines.
* <img width="918" alt="before-search" src="https://user-images.githubusercontent.com/632081/127946548-5045d2ff-24da-4d26-86e5-52382f9170ff.png">

### After:

* <img width="917" alt="after-main" src="https://user-images.githubusercontent.com/632081/127946587-97cb76a0-e748-4b84-9220-66e1983a8d58.png">
* <img width="913" alt="after-in" src="https://user-images.githubusercontent.com/632081/127946592-e2ca1d13-6bda-4138-8930-e4da5362eb0b.png">
* <img width="915" alt="after-out" src="https://user-images.githubusercontent.com/632081/127946597-e9fd7ca2-efbf-46d2-ab8e-90af63934a46.png">
* <img width="912" alt="after-search" src="https://user-images.githubusercontent.com/632081/127946602-ed54568b-6b6d-4aef-a3ea-8840df07475b.png">

  

