### PR TITLE
Fix horizontal scrollbar appearing in clikes dropdown

### DIFF
--- a/styles/shared/comment-likes.scss
+++ b/styles/shared/comment-likes.scss
@@ -134,7 +134,7 @@
   z-index: 2;
   color: #898989;
   border: 1px solid #898989;
-  padding: 6px;
+  padding: 6px 17px 6px 6px;
   box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.3);
   white-space: nowrap;
   text-align: left;


### PR DESCRIPTION
Fixes https://freefeed.net/support/3c0bea0b-2d15-4411-8807-cdb9556e2d19

After:

(Firefox on Mac):
<img width="116" alt="Screenshot 2021-08-09 at 23 30 24" src="https://user-images.githubusercontent.com/632081/128819612-e7b71946-d56a-4e0e-82c3-94559faf9687.png">

(Firefox on Win):
![Capture](https://user-images.githubusercontent.com/632081/128819783-00dae00d-ae74-4852-aa32-5e8d9e8731c5.PNG)
