### PR TITLE
Move "Save post" into More dropdown, add create/update dates, "copy post link"

### DIFF
--- a/assets/images/logo.svg
+++ b/assets/images/logo.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 16 16" width="160" height="160">
+  <symbol id="snake">
+  <path d="M 1.5,10             l 6.5,0             a 2,2 0,0,0 2,-2             l 0,-6.5            a 1,1 0 0 1 3,0            l 0,6.5            a 5,5 0 0 1 -5,5            l -6.5,0            a 1,1 0 0 1 0,-3            z"/>
+  </symbol>
+  <use xlink:href="#snake" fill="#d43e1b" x="0" y="0"/>
+  <use xlink:href="#snake" fill="#f9b616" x="-16" y="-16" transform="rotate(180)"/>
+  <rect fill="#d43e1b" x="2" y="10" width="5" height="3"/>
+</svg>

--- a/src/components/create-post.jsx
+++ b/src/components/create-post.jsx
@@ -15,6 +15,7 @@ import ErrorBoundary from './error-boundary';
 import { Throbber } from './throbber';
 import { Icon } from './fontawesome-icons';
 import { ButtonLink } from './button-link';
+import { MoreWithTriangle } from './more-with-triangle';
 
 const attachmentsMaxCount = CONFIG.attachments.maxCount;
 
@@ -228,7 +229,7 @@ export default class CreatePost extends Component {
             </span>
 
             <ButtonLink className="post-edit-more-trigger" onClick={this.toggleMore}>
-              More&nbsp;&#x25be;
+              <MoreWithTriangle />
             </ButtonLink>
 
             {this.state.isMoreOpen ? (

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -2,7 +2,7 @@
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router';
 
-export default function Footer() {
+export default function Footer({ short }) {
   const authenticated = useSelector((state) => state.authenticated);
   return (
     <footer className="footer">
@@ -29,7 +29,7 @@ export default function Footer() {
           GitHub
         </a>
       </p>
-      {!authenticated && (
+      {!authenticated && !short ? (
         <>
           <hr />
           <p>
@@ -38,6 +38,8 @@ export default function Footer() {
             our community.
           </p>
         </>
+      ) : (
+        false
       )}
     </footer>
   );

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -141,6 +141,8 @@ class Layout extends Component {
 
     const layoutClassNames = classnames('container', { dragover: this.state.isDragOver });
 
+    const shortFooter = !props.isAuthenticated && props.routeName === 'home';
+
     return (
       <ErrorBoundary>
         <AppUpdated />
@@ -185,7 +187,7 @@ class Layout extends Component {
 
           <div className="row">
             <div className="col-md-12">
-              <Footer />
+              <Footer short={shortFooter} />
             </div>
           </div>
 

--- a/src/components/more-with-triangle.jsx
+++ b/src/components/more-with-triangle.jsx
@@ -1,0 +1,5 @@
+import styles from './more-with-triangle.module.scss';
+
+export const MoreWithTriangle = ({ children = 'More' }) => {
+  return <span className={styles.root}>{children}</span>;
+};

--- a/src/components/more-with-triangle.module.scss
+++ b/src/components/more-with-triangle.module.scss
@@ -1,0 +1,19 @@
+.root {
+  display: inline-flex;
+  align-items: center;
+
+  &::after {
+    $size: 0.45em;
+    content: '';
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: $size (0.6 * $size) 0 (0.6 * $size);
+    border-color: currentColor transparent transparent transparent;
+    opacity: 0.66;
+
+    margin-left: 0.5 * $size;
+    margin-top: 0.4 * $size;
+  }
+}

--- a/src/components/post-comment-more-menu.jsx
+++ b/src/components/post-comment-more-menu.jsx
@@ -14,6 +14,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { faHeart, faClock, faTrashAlt } from '@fortawesome/free-regular-svg-icons';
 import { pluralForm } from '../utils';
+import { copyURL } from '../utils/copy-url';
 import { andJoin } from '../utils/and-join';
 import { ButtonLink } from './button-link';
 import styles from './dropdown-menu.module.scss';
@@ -168,27 +169,6 @@ export const PostCommentMoreMenu = forwardRef(function PostCommentMore(
     </>
   );
 });
-
-function copyURL({ target }) {
-  target.blur();
-
-  // Creating absolute URL
-  const link = document.createElement('a');
-  link.href = target.value;
-
-  const textNode = document.body.appendChild(document.createTextNode(link.href));
-
-  const range = new Range();
-  const selection = document.getSelection();
-
-  range.selectNode(textNode);
-  selection.removeAllRanges();
-  selection.addRange(range);
-  document.execCommand('copy');
-  selection.removeAllRanges();
-
-  textNode.parentNode.removeChild(textNode);
-}
 
 function likersMenuText(likers, myUsername) {
   if (likers.length === 0) {

--- a/src/components/post-comment-more.jsx
+++ b/src/components/post-comment-more.jsx
@@ -9,6 +9,7 @@ import { useDropDownKbd } from './hooks/drop-down-kbd';
 import { useMediaQuery } from './hooks/media-query';
 import { PostCommentLikes } from './post-comment-likes';
 import { PostCommentMoreMenu } from './post-comment-more-menu';
+import { MoreWithTriangle } from './more-with-triangle';
 
 export const PostCommentMore = memo(function PostCommentMore({
   className,
@@ -70,7 +71,7 @@ export const PostCommentMore = memo(function PostCommentMore({
         aria-haspopup
         aria-expanded={opened}
       >
-        more
+        <MoreWithTriangle>more</MoreWithTriangle>
       </ButtonLink>
       {opened && (
         <Portal>

--- a/src/components/post-more-link.jsx
+++ b/src/components/post-more-link.jsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { Portal } from 'react-portal';
 
 import { confirmFirst } from '../utils';
+import { canonicalURI } from '../utils/canonical-uri';
 import { useDropDown } from './hooks/drop-down';
 import { useServerInfo } from './hooks/server-info';
 import { PostMoreMenu } from './post-more-menu';
@@ -11,12 +12,16 @@ export default function PostMoreLink({ post, user, ...props }) {
   const { pivotRef, menuRef, opened, toggle } = useDropDown();
   const [serverInfo, serverInfoStatus] = useServerInfo();
 
+  const doAndClose = useCallback((h) => h && ((...args) => (h(...args), toggle())), [toggle]);
+
   const deletePost = useCallback(
     (...feedNames) => confirmFirst(props.deletePost(...feedNames)),
     [props],
   );
 
   const perGroupDeleteEnabled = serverInfoStatus.success && serverInfo.features.perGroupsPostDelete;
+
+  const canonicalPostURI = canonicalURI(post);
 
   return (
     <>
@@ -28,12 +33,16 @@ export default function PostMoreLink({ post, user, ...props }) {
           <PostMoreMenu
             ref={menuRef}
             post={post}
+            user={user}
             toggleEditingPost={props.toggleEditingPost}
             toggleModeratingComments={props.toggleModeratingComments}
             enableComments={props.enableComments}
             disableComments={props.disableComments}
             deletePost={deletePost}
             perGroupDeleteEnabled={perGroupDeleteEnabled}
+            doAndClose={doAndClose}
+            permalink={canonicalPostURI}
+            toggleSave={props.toggleSave}
           />
         </Portal>
       )}

--- a/src/components/post-more-link.jsx
+++ b/src/components/post-more-link.jsx
@@ -5,8 +5,9 @@ import { confirmFirst } from '../utils';
 import { useDropDown } from './hooks/drop-down';
 import { useServerInfo } from './hooks/server-info';
 import { PostMoreMenu } from './post-more-menu';
+import { MoreWithTriangle } from './more-with-triangle';
 
-export default function PostMoreLink({ post, ...props }) {
+export default function PostMoreLink({ post, user, ...props }) {
   const { pivotRef, menuRef, opened, toggle } = useDropDown();
   const [serverInfo, serverInfoStatus] = useServerInfo();
 
@@ -20,7 +21,7 @@ export default function PostMoreLink({ post, ...props }) {
   return (
     <>
       <a className="post-action" ref={pivotRef} onClick={toggle} role="button">
-        More&#x200a;&#x25be;
+        <MoreWithTriangle />
       </a>
       {opened && (
         <Portal>

--- a/src/components/post-more-link.jsx
+++ b/src/components/post-more-link.jsx
@@ -3,13 +3,17 @@ import { Portal } from 'react-portal';
 
 import { confirmFirst } from '../utils';
 import { canonicalURI } from '../utils/canonical-uri';
-import { useDropDown } from './hooks/drop-down';
+import { CLOSE_ON_CLICK_OUTSIDE } from './hooks/drop-down';
+import { useDropDownKbd } from './hooks/drop-down-kbd';
 import { useServerInfo } from './hooks/server-info';
 import { PostMoreMenu } from './post-more-menu';
 import { MoreWithTriangle } from './more-with-triangle';
+import { ButtonLink } from './button-link';
 
 export default function PostMoreLink({ post, user, ...props }) {
-  const { pivotRef, menuRef, opened, toggle } = useDropDown();
+  const { pivotRef, menuRef, opened, toggle } = useDropDownKbd({
+    closeOn: CLOSE_ON_CLICK_OUTSIDE,
+  });
   const [serverInfo, serverInfoStatus] = useServerInfo();
 
   const doAndClose = useCallback((h) => h && ((...args) => (h(...args), toggle())), [toggle]);
@@ -25,9 +29,15 @@ export default function PostMoreLink({ post, user, ...props }) {
 
   return (
     <>
-      <a className="post-action" ref={pivotRef} onClick={toggle} role="button">
+      <ButtonLink
+        className="post-action"
+        ref={pivotRef}
+        onClick={toggle}
+        aria-haspopup
+        aria-expanded={opened}
+      >
         <MoreWithTriangle />
-      </a>
+      </ButtonLink>
       {opened && (
         <Portal>
           <PostMoreMenu

--- a/src/components/post-more-menu.jsx
+++ b/src/components/post-more-menu.jsx
@@ -1,20 +1,21 @@
 import { forwardRef, useMemo } from 'react';
 import { Link } from 'react-router';
 import cn from 'classnames';
-import { faExclamationTriangle, faLink } from '@fortawesome/free-solid-svg-icons';
-import { faClock } from '@fortawesome/free-regular-svg-icons';
+import { faExclamationTriangle, faLink, faEdit, faSave } from '@fortawesome/free-solid-svg-icons';
+import { faClock, faCommentDots, faTrashAlt } from '@fortawesome/free-regular-svg-icons';
 import { noop } from 'lodash';
 
 import { andJoin } from '../utils/and-join';
 import { copyURL } from '../utils/copy-url';
+import { ButtonLink } from './button-link';
 import { Throbber } from './throbber';
 import { Icon } from './fontawesome-icons';
 import TimeDisplay from './time-display';
 
 import styles from './dropdown-menu.module.scss';
 
-export const PostMoreMenu = forwardRef(function PostMoreMenu(props, ref) {
-  const {
+export const PostMoreMenu = forwardRef(function PostMoreMenu(
+  {
     user,
     post: {
       isEditable = false,
@@ -37,8 +38,9 @@ export const PostMoreMenu = forwardRef(function PostMoreMenu(props, ref) {
     doAndClose,
     permalink,
     toggleSave,
-  } = props;
-
+  },
+  ref,
+) {
   const amIAuthenticated = !!user.id;
 
   const deleteLines = useMemo(() => {
@@ -69,52 +71,57 @@ export const PostMoreMenu = forwardRef(function PostMoreMenu(props, ref) {
     [
       amIAuthenticated && (
         <div className={styles.item} key="save-post">
-          <a className={styles.link} onClick={toggleSave} role="button">
-            {isSaved ? 'Un-save' : 'Save'} post
-            {savePostStatus.loading && <Throbber />}
-            {savePostStatus.error && (
-              <Icon
-                icon={faExclamationTriangle}
-                className="post-like-fail"
-                title={savePostStatus.errorText}
-              />
-            )}
-          </a>
+          <ButtonLink className={styles.link} onClick={doAndClose(toggleSave)}>
+            <Iconic icon={faSave}>
+              {isSaved ? 'Un-save' : 'Save'} post
+              {savePostStatus.loading && <Throbber />}
+              {savePostStatus.error && (
+                <Icon
+                  icon={faExclamationTriangle}
+                  className="post-like-fail"
+                  title={savePostStatus.errorText}
+                />
+              )}
+            </Iconic>
+          </ButtonLink>
         </div>
       ),
     ],
     [
       isEditable && (
         <div className={styles.item} key="edit-post">
-          <a className={styles.link} onClick={toggleEditingPost} role="button">
-            Edit
-          </a>
+          <ButtonLink className={styles.link} onClick={doAndClose(toggleEditingPost)}>
+            <Iconic icon={faEdit}>Edit</Iconic>
+          </ButtonLink>
         </div>
       ),
       isModeratable && (
         <div className={styles.item} key="moderate-comments">
-          <a className={styles.link} onClick={toggleModeratingComments} role="button">
-            {isModeratingComments ? 'Stop moderating comments' : 'Moderate comments'}
-          </a>
+          <ButtonLink className={styles.link} onClick={doAndClose(toggleModeratingComments)}>
+            <Iconic icon={faCommentDots}>
+              {isModeratingComments ? 'Stop moderating comments' : 'Moderate comments'}
+            </Iconic>
+          </ButtonLink>
         </div>
       ),
       (isEditable || isModeratable) && (
         <div className={styles.item} key="toggle-comments">
-          <a
+          <ButtonLink
             className={styles.link}
-            onClick={commentsDisabled ? enableComments : disableComments}
-            role="button"
+            onClick={commentsDisabled ? doAndClose(enableComments) : doAndClose(disableComments)}
           >
-            {commentsDisabled ? 'Enable comments' : 'Disable comments'}
-          </a>
+            <Iconic icon={faCommentDots}>
+              {commentsDisabled ? 'Enable comments' : 'Disable comments'}
+            </Iconic>
+          </ButtonLink>
         </div>
       ),
     ],
     deleteLines.map(({ text, onClick }) => (
       <div className={styles.item} key={`remove-from:${text}`}>
-        <a className={`${styles.link} ${styles.danger}`} onClick={onClick} role="button">
-          {text}
-        </a>
+        <ButtonLink className={cn(styles.link, styles.danger)} onClick={doAndClose(onClick)}>
+          <Iconic icon={faTrashAlt}>{text}</Iconic>
+        </ButtonLink>
       </div>
     )),
     [

--- a/src/components/post-more-menu.jsx
+++ b/src/components/post-more-menu.jsx
@@ -1,10 +1,21 @@
 import { forwardRef, useMemo } from 'react';
+import { Link } from 'react-router';
+import cn from 'classnames';
+import { faExclamationTriangle, faLink } from '@fortawesome/free-solid-svg-icons';
+import { faClock } from '@fortawesome/free-regular-svg-icons';
+import { noop } from 'lodash';
+
 import { andJoin } from '../utils/and-join';
+import { copyURL } from '../utils/copy-url';
+import { Throbber } from './throbber';
+import { Icon } from './fontawesome-icons';
+import TimeDisplay from './time-display';
 
 import styles from './dropdown-menu.module.scss';
 
-export const PostMoreMenu = forwardRef(function PostMoreMenu(
-  {
+export const PostMoreMenu = forwardRef(function PostMoreMenu(props, ref) {
+  const {
+    user,
     post: {
       isEditable = false,
       canBeRemovedFrom = [],
@@ -12,6 +23,10 @@ export const PostMoreMenu = forwardRef(function PostMoreMenu(
       isDeletable = false,
       isModeratingComments = false,
       commentsDisabled = false,
+      createdAt,
+      updatedAt,
+      isSaved = false,
+      savePostStatus = {},
     },
     toggleEditingPost,
     toggleModeratingComments,
@@ -19,9 +34,13 @@ export const PostMoreMenu = forwardRef(function PostMoreMenu(
     disableComments,
     deletePost,
     perGroupDeleteEnabled = false,
-  },
-  ref,
-) {
+    doAndClose,
+    permalink,
+    toggleSave,
+  } = props;
+
+  const amIAuthenticated = !!user.id;
+
   const deleteLines = useMemo(() => {
     const result = [];
     // Not owned post
@@ -46,41 +65,114 @@ export const PostMoreMenu = forwardRef(function PostMoreMenu(
     return result;
   }, [isEditable, isDeletable, canBeRemovedFrom, perGroupDeleteEnabled, deletePost]);
 
-  return (
-    <ul className={styles.list} ref={ref}>
-      {isEditable && (
-        <li className={styles.item}>
+  const menuGroups = [
+    [
+      amIAuthenticated && (
+        <div className={styles.item} key="save-post">
+          <a className={styles.link} onClick={toggleSave} role="button">
+            {isSaved ? 'Un-save' : 'Save'} post
+            {savePostStatus.loading && <Throbber />}
+            {savePostStatus.error && (
+              <Icon
+                icon={faExclamationTriangle}
+                className="post-like-fail"
+                title={savePostStatus.errorText}
+              />
+            )}
+          </a>
+        </div>
+      ),
+    ],
+    [
+      isEditable && (
+        <div className={styles.item} key="edit-post">
           <a className={styles.link} onClick={toggleEditingPost} role="button">
             Edit
           </a>
-        </li>
-      )}
-
-      {isModeratable && (
-        <li className={styles.item}>
+        </div>
+      ),
+      isModeratable && (
+        <div className={styles.item} key="moderate-comments">
           <a className={styles.link} onClick={toggleModeratingComments} role="button">
             {isModeratingComments ? 'Stop moderating comments' : 'Moderate comments'}
           </a>
-        </li>
-      )}
-
-      <li className={styles.item}>
-        <a
-          className={styles.link}
-          onClick={commentsDisabled ? enableComments : disableComments}
-          role="button"
-        >
-          {commentsDisabled ? 'Enable comments' : 'Disable comments'}
-        </a>
-      </li>
-
-      {deleteLines.map(({ text, onClick }) => (
-        <li className={styles.item} key={`remove-from:${text}`}>
-          <a className={`${styles.link} ${styles.danger}`} onClick={onClick} role="button">
-            {text}
+        </div>
+      ),
+      (isEditable || isModeratable) && (
+        <div className={styles.item} key="toggle-comments">
+          <a
+            className={styles.link}
+            onClick={commentsDisabled ? enableComments : disableComments}
+            role="button"
+          >
+            {commentsDisabled ? 'Enable comments' : 'Disable comments'}
           </a>
-        </li>
-      ))}
-    </ul>
+        </div>
+      ),
+    ],
+    deleteLines.map(({ text, onClick }) => (
+      <div className={styles.item} key={`remove-from:${text}`}>
+        <a className={`${styles.link} ${styles.danger}`} onClick={onClick} role="button">
+          {text}
+        </a>
+      </div>
+    )),
+    [
+      <div key="created-on" className={cn(styles.item, styles.content)}>
+        <Iconic icon={faClock}>
+          Created on <TimeDisplay timeStamp={+createdAt} inline absolute />
+        </Iconic>
+      </div>,
+      updatedAt - createdAt > 120000 && (
+        <div key="updated-on" className={cn(styles.item, styles.content)}>
+          <Iconic icon={faClock}>
+            Updated on <TimeDisplay timeStamp={+updatedAt} inline absolute />
+          </Iconic>
+        </div>
+      ),
+      <div key="permalink" className={cn(styles.item, styles.content)}>
+        <Iconic icon={faLink} centered>
+          <Link to={permalink} style={{ marginRight: '1ex' }} onClick={doAndClose(noop)}>
+            Link to post
+          </Link>{' '}
+          <button
+            className="btn btn-default btn-sm"
+            type="button"
+            onClick={doAndClose(copyURL)}
+            value={permalink}
+            aria-label="Copy link"
+          >
+            Copy
+          </button>
+        </Iconic>
+      </div>,
+    ],
+  ];
+
+  return (
+    <div className={styles.list} ref={ref} style={{ minWidth: '18em' }}>
+      {menuGroups.map((group, i) => {
+        const items = group.filter(Boolean);
+        if (items.length === 0) {
+          return null;
+        }
+        return (
+          <div className={styles.group} key={`group-${i}`}>
+            {items}
+          </div>
+        );
+      })}
+    </div>
   );
 });
+
+function Iconic({ icon, centered = false, children }) {
+  return (
+    <span className={cn(styles.iconic, centered && styles.iconicCentered)}>
+      <span className={styles.iconicIcon}>
+        <Icon icon={icon} />
+      </span>
+      <span className={styles.iconicContent}>{children}</span>
+    </span>
+  );
+}

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -18,6 +18,7 @@ import {
 
 import { pluralForm } from '../utils';
 import { getFirstLinkToEmbed } from '../utils/parse-text';
+import { canonicalURI } from '../utils/canonical-uri';
 import { READMORE_STYLE_COMPACT } from '../utils/frontend-preferences-options';
 import { postReadmoreConfig } from '../utils/readmore-config';
 import { savePost, hideByName, unhideNames } from '../redux/action-creators';
@@ -728,16 +729,6 @@ class Post extends Component {
       </div>
     );
   }
-}
-
-// Canonical post URI (pathname)
-export function canonicalURI(post) {
-  // If posted _only_ into groups, use first recipient's username
-  let urlName = post.createdBy.username;
-  if (post.recipients.length > 0 && !post.recipients.some((r) => r.type === 'user')) {
-    urlName = post.recipients[0].username;
-  }
-  return `/${encodeURIComponent(urlName)}/${encodeURIComponent(post.id)}`;
 }
 
 function selectState(state, ownProps) {

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -26,6 +26,7 @@ import { initialAsyncState } from '../redux/async-helpers';
 import { submitByEnter } from '../utils/submit-by-enter';
 import { makeJpegIfNeeded } from '../utils/jpeg-if-needed';
 import { Throbber } from './throbber';
+import { ButtonLink } from './button-link';
 
 import PostAttachments from './post-attachments';
 import PostComments from './post-comments';
@@ -363,9 +364,9 @@ class Post extends Component {
 
     const commentLink = amIAuthenticated &&
       (!props.commentsDisabled || props.isEditable || props.isModeratable) && (
-        <a className="post-action" onClick={this.handleCommentClick} role="button">
+        <ButtonLink className="post-action" onClick={this.handleCommentClick}>
           Comment
-        </a>
+        </ButtonLink>
       );
 
     // "Like" / "Un-like"
@@ -376,13 +377,12 @@ class Post extends Component {
           {props.likeError ? (
             <Icon icon={faExclamationTriangle} className="post-like-fail" title={props.likeError} />
           ) : null}
-          <a
+          <ButtonLink
             className="post-action"
             onClick={didILikePost ? this.unlikePost : this.likePost}
-            role="button"
           >
             {didILikePost ? 'Un-like' : 'Like'}
-          </a>
+          </ButtonLink>
           {props.isLiking ? (
             <span className="post-like-throbber">
               <Throbber />

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -395,37 +395,19 @@ class Post extends Component {
         false
       );
 
-    const { isSaved, savePostStatus } = this.props;
-    const saveLink = amIAuthenticated && (
-      <>
-        <a className="post-action" onClick={this.toggleSave} role="button">
-          {isSaved ? 'Un-save' : 'Save'}
-        </a>
-        {savePostStatus.loading && <Throbber />}
-        {savePostStatus.error && (
-          <Icon
-            icon={faExclamationTriangle}
-            className="post-like-fail"
-            title={savePostStatus.errorText}
-          />
-        )}
-      </>
-    );
-
     // "More" menu
-    const moreLink =
-      props.isEditable || props.isModeratable ? (
-        <PostMoreLink
-          post={props}
-          toggleEditingPost={this.toggleEditingPost}
-          toggleModeratingComments={this.toggleModeratingComments}
-          disableComments={this.disableComments}
-          enableComments={this.enableComments}
-          deletePost={this.handleDeletePost}
-        />
-      ) : (
-        false
-      );
+    const moreLink = (
+      <PostMoreLink
+        user={props.user}
+        post={props}
+        toggleEditingPost={this.toggleEditingPost}
+        toggleModeratingComments={this.toggleModeratingComments}
+        disableComments={this.disableComments}
+        enableComments={this.enableComments}
+        deletePost={this.handleDeletePost}
+        toggleSave={this.toggleSave}
+      />
+    );
 
     const linkToEmbed = getFirstLinkToEmbed(props.body);
     const noImageAttachments = !this.attachments.some(
@@ -681,7 +663,6 @@ class Post extends Component {
                 <span className="post-footer-block" role="region">
                   <span className="post-footer-item">{commentLink}</span>
                   <span className="post-footer-item">{likeLink}</span>
-                  <span className="post-footer-item">{saveLink}</span>
                   {props.isInHomeFeed && (
                     <span className="post-footer-item" ref={this.hideLink}>
                       {this.renderHideLink()}

--- a/src/components/single-post.jsx
+++ b/src/components/single-post.jsx
@@ -3,10 +3,12 @@ import { Component, useMemo } from 'react';
 import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
+
+import { canonicalURI } from '../utils/canonical-uri';
 import { joinPostData, postActions } from './select-utils';
 import UserName from './user-name';
 
-import Post, { canonicalURI } from './post';
+import Post from './post';
 import { SignInLink } from './sign-in-link';
 
 class SinglePostHandler extends Component {

--- a/src/components/welcome.jsx
+++ b/src/components/welcome.jsx
@@ -1,88 +1,148 @@
+import { useState } from 'react';
+import classnames from 'classnames';
 import { Link } from 'react-router';
+import { faHeart } from '@fortawesome/free-solid-svg-icons';
+
+import logoPath from '../../assets/images/logo.svg';
+
+import { Icon } from './fontawesome-icons';
 import { SignInLink } from './sign-in-link';
+import styles from './welcome.module.scss';
 
-export default () => (
-  <div className="box-body">
-    <h3>Welcome to FreeFeed!</h3>
+const LANGUAGES = [
+  { id: 'en', label: 'In English' },
+  { id: 'ru', label: 'По-русски' },
+];
 
-    <p>
-      FreeFeed is a small and free social network. We do not harvest users&apos; personal data, nor
-      serve ads. It is an <a href="https://github.com/FreeFeed">open-source project</a> developed by
-      volunteers and funded by donations from its users.
-    </p>
+const WelcomePage = () => {
+  const [lang, setLang] = useState(LANGUAGES[0].id);
 
-    <h4>No ads</h4>
+  return (
+    <div>
+      <div className={styles.languages}>
+        {LANGUAGES.map((l) => {
+          const onClick = () => setLang(l.id);
+          const cn = classnames(styles.lang, lang === l.id ? styles.active : false);
+          return (
+            // eslint-disable-next-line react/jsx-no-bind
+            <span key={l.id} className={cn} onClick={onClick}>
+              {l.label}
+            </span>
+          );
+        })}
+      </div>
 
-    <p>
-      FreeFeed is backed and maintained by a non-profit organization. We do not show ads, we do not
-      collect our users&apos; data, and we do not sell it.
-    </p>
+      {lang === 'en' ? (
+        <section className={styles.main}>
+          <h3 className={styles.welcome}>
+            Welcome to{' '}
+            <strong className={styles.freefeed}>
+              <img src={logoPath} alt="logo" aria-hidden="true" className={styles.logo} /> FreeFeed!
+            </strong>
+          </h3>
 
-    <h4>No algorithms</h4>
+          <p className={styles.p}>
+            FreeFeed is a small and free social network. We do not harvest users&apos; personal
+            data, nor serve ads. It is an{' '}
+            <a href="https://github.com/FreeFeed" target="_blank">
+              open-source project
+            </a>{' '}
+            developed by volunteers and funded by donations from its users.
+          </p>
 
-    <p>
-      Your feed contains posts that your friends have written, liked, and/or commented on, as well
-      as posts from groups you are subscribed to. There are no algorithms to curate your feed or
-      promote popular users.
-    </p>
+          <div className={styles.actions}>
+            <Link to="/signup" className={classnames(styles.signup, 'btn btn-lg btn-primary')}>
+              Sign up!
+            </Link>{' '}
+            or <SignInLink className={styles.signin}>sign in</SignInLink>
+          </div>
 
-    <h4>Private and personal</h4>
+          <h4>No ads</h4>
 
-    <p>
-      FreeFeed is a service as well as a community. Its small scale lets us know each other better
-      and become close friends. There is no &quot;real names&quot; policy. Your posts can be public,
-      protected from search engines, or restricted to your subscribers.
-    </p>
+          <p className={styles.p}>
+            FreeFeed is backed and maintained by a non-profit organization. We do not show ads, we
+            do not collect our users&apos; data, and we do not sell it.
+          </p>
 
-    <p>
-      <b>
-        <Link to="/signup" className="inline-header">
-          Sign up
-        </Link>
-      </b>{' '}
-      now or <SignInLink className="inline-header">sign in</SignInLink>
-    </p>
+          <h4>No algorithms</h4>
 
-    <h3>Добро пожаловать во Фрифид!</h3>
+          <p className={styles.p}>
+            Your feed contains posts that your friends have written, liked, and/or commented on, as
+            well as posts from groups you are subscribed to. There are no algorithms to curate your
+            feed or promote popular users.
+          </p>
 
-    <p>
-      FreeFeed — маленькая бесплатная социальная сеть, которая не продаёт ваши данные и не
-      показывает рекламу. Это{' '}
-      <a href="https://github.com/FreeFeed">проект с открытым исходным кодом</a>. Его развитием
-      занимаются пользователи-волонтеры за счет пожертвований других пользователей.
-    </p>
+          <h4>
+            Private and personal <Icon icon={faHeart} className={styles.like} />
+          </h4>
 
-    <h4>Без рекламы</h4>
+          <p className={styles.p}>
+            FreeFeed is a service as well as a community. Its small scale lets us know each other
+            better and become close friends. There is no &quot;real names&quot; policy. Your posts
+            can be public, protected from search engines, or restricted to your subscribers.
+          </p>
+        </section>
+      ) : (
+        false
+      )}
 
-    <p>
-      FreeFeed управляется некоммерческой организацией. Мы не размещаем рекламу, не собираем
-      информацию о наших пользователях и никому её не продаём.
-    </p>
+      {lang === 'ru' ? (
+        <section className={styles.main}>
+          <h3 className={styles.welcome}>
+            Добро пожаловать во{' '}
+            <strong className={styles.freefeed}>
+              <img src={logoPath} alt="logo" aria-hidden="true" className={styles.logo} /> Фрифид!
+            </strong>
+          </h3>
 
-    <h4>Без алгоритмов</h4>
+          <p className={styles.p}>
+            FreeFeed — маленькая бесплатная социальная сеть, которая не продаёт ваши данные и не
+            показывает рекламу. Это{' '}
+            <a href="https://github.com/FreeFeed" target="_blank">
+              проект с открытым исходным кодом
+            </a>
+            . Его развитием занимаются пользователи-волонтеры за счет пожертвований других
+            пользователей.
+          </p>
 
-    <p>
-      Ваша лента записей формируется просто: вы видите посты ваших друзей, посты пользователей,
-      которые ваши друзья полайкали или прокомментировали, и посты из групп, на которые вы
-      подписаны. Никаких сложных алгоритмов и подкапотной магии.
-    </p>
+          <div className={styles.actions}>
+            <Link to="/signup" className={classnames(styles.signup, 'btn btn-lg btn-primary')}>
+              Зарегистрируйтесь!
+            </Link>{' '}
+            или <SignInLink className={styles.signin}>войдите</SignInLink>
+          </div>
 
-    <h4>Приватность и безопасность</h4>
+          <h4>Без рекламы</h4>
 
-    <p>
-      FreeFeed — сервис и сообщество, небольшие размеры которого позволяют нам хорошо узнавать друг
-      друга и общаться в кругу друзей. У нас нет политики “реальных имен”. Ваши посты могут быть
-      публичными, закрытыми от поисковиков, или доступными только для ваших подписчиков.
-    </p>
+          <p className={styles.p}>
+            FreeFeed управляется некоммерческой организацией. Мы не размещаем рекламу, не собираем
+            информацию о наших пользователях и никому её не продаём.
+          </p>
 
-    <p>
-      <b>
-        <Link to="/signup" className="inline-header">
-          Зарегистрироваться
-        </Link>
-      </b>{' '}
-      или
-      <SignInLink className="inline-header">войти</SignInLink>
-    </p>
-  </div>
-);
+          <h4>Без алгоритмов</h4>
+
+          <p className={styles.p}>
+            Ваша лента записей формируется просто: вы видите посты ваших друзей, посты
+            пользователей, которые ваши друзья полайкали или прокомментировали, и посты из групп, на
+            которые вы подписаны. Никаких сложных алгоритмов и подкапотной магии.
+          </p>
+
+          <h4>
+            Приватность и безопасность <Icon icon={faHeart} className={styles.like} />
+          </h4>
+
+          <p className={styles.p}>
+            FreeFeed — сервис и сообщество, небольшие размеры которого позволяют нам хорошо узнавать
+            друг друга и общаться в кругу друзей. У нас нет политики “реальных имен”. Ваши посты
+            могут быть публичными, закрытыми от поисковиков, или доступными только для ваших
+            подписчиков.
+          </p>
+        </section>
+      ) : (
+        false
+      )}
+    </div>
+  );
+};
+
+export default WelcomePage;

--- a/src/components/welcome.module.scss
+++ b/src/components/welcome.module.scss
@@ -1,0 +1,114 @@
+.languages {
+  margin: 0;
+  padding: 0;
+  text-align: right;
+}
+
+.lang {
+  display: inline-block;
+  padding: 5px 10px;
+
+  &:hover {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}
+
+.active {
+  font-weight: bold;
+  background-color: #eee;
+  text-decoration: none;
+
+  :global(.dark-theme) & {
+    background-color: #666;
+    color: #000;
+  }
+}
+
+.main {
+  font-size: 16px;
+  margin: 20px 10px 40px;
+  padding-bottom: 80px;
+  border-bottom: 1px solid #eee;
+}
+
+.welcome {
+  line-height: 30px;
+  font-size: 35px;
+  font-weight: normal;
+  margin: 10px 0 20px;
+}
+
+.freefeed {
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.logo {
+  height: 27px;
+  width: 27px;
+  position: relative;
+  top: -3px;
+  right: -9px;
+  margin-left: -7px;
+  font-size: 14px;
+}
+
+.p {
+  margin: 0 0 50px;
+}
+
+.like {
+  color: #f9b616;
+  font-size: 14px;
+  position: relative;
+  top: -0.5px;
+}
+
+.actions {
+  margin: -20px 0 30px;
+}
+
+.signup {
+  display: inline-block;
+  margin-right: 10px;
+}
+
+.signin {
+  margin-left: 5px;
+  font-size: 18px;
+  font-weight: 600;
+  display: inline-block;
+}
+
+@media (max-width: 600px) {
+  .languages {
+    margin-top: -10px;
+  }
+
+  .main {
+    font-size: 14px;
+    margin: 0 0 40px;
+  }
+
+  .welcome {
+    font-size: 25px;
+    margin-bottom: 10px;
+  }
+
+  .logo {
+    height: 20px;
+    width: 20px;
+    top: -3px;
+    right: -7px;
+    margin-left: -7px;
+  }
+
+  .p {
+    margin-bottom: 20px;
+  }
+
+  .actions {
+    margin: 0px 0 20px;
+  }
+}

--- a/src/utils/canonical-uri.js
+++ b/src/utils/canonical-uri.js
@@ -1,0 +1,9 @@
+// Canonical post URI (pathname)
+export function canonicalURI(post) {
+  // If posted _only_ into groups, use first recipient's username
+  let urlName = post.createdBy.username;
+  if (post.recipients.length > 0 && !post.recipients.some((r) => r.type === 'user')) {
+    urlName = post.recipients[0].username;
+  }
+  return `/${encodeURIComponent(urlName)}/${encodeURIComponent(post.id)}`;
+}

--- a/src/utils/copy-url.js
+++ b/src/utils/copy-url.js
@@ -1,0 +1,20 @@
+export function copyURL({ target }) {
+  target.blur();
+
+  // Creating absolute URL
+  const link = document.createElement('a');
+  link.href = target.value;
+
+  const textNode = document.body.appendChild(document.createTextNode(link.href));
+
+  const range = new Range();
+  const selection = document.getSelection();
+
+  range.selectNode(textNode);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  document.execCommand('copy');
+  selection.removeAllRanges();
+
+  textNode.parentNode.removeChild(textNode);
+}

--- a/styles/helvetica/dark-theme.scss
+++ b/styles/helvetica/dark-theme.scss
@@ -192,6 +192,11 @@ body.dark-theme {
     border-color: $text-color-lighter;
   }
 
+  .btn-primary,
+  .btn-primary:hover {
+    color: #fff;
+  }
+
   .alert-info {
     color: $text-color-lighter;
     background: $bg-highlight-color;

--- a/styles/shared/comments.scss
+++ b/styles/shared/comments.scss
@@ -139,26 +139,6 @@
   &__action-link--delete {
     color: var(--danger-color) !important;
   }
-
-  &__action-link--more {
-    display: inline-flex;
-    align-items: center;
-
-    &::after {
-      $size: 0.45em;
-      content: '';
-      display: inline-block;
-      width: 0;
-      height: 0;
-      border-style: solid;
-      border-width: $size (0.6 * $size) 0 (0.6 * $size);
-      border-color: currentColor transparent transparent transparent;
-      opacity: 0.66;
-
-      margin-left: 0.5 * $size;
-      margin-top: 2px;
-    }
-  }
 }
 
 .feed-comment-dot {

--- a/test/jest/__snapshots__/post-comments.test.js.snap
+++ b/test/jest/__snapshots__/post-comments.test.js.snap
@@ -102,7 +102,11 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
                   role="button"
                   tabindex="0"
                 >
-                  more
+                  <span
+                    class="root"
+                  >
+                    more
+                  </span>
                 </a>
               </span>
             </span>
@@ -219,7 +223,11 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
                   role="button"
                   tabindex="0"
                 >
-                  more
+                  <span
+                    class="root"
+                  >
+                    more
+                  </span>
                 </a>
               </span>
             </span>
@@ -322,7 +330,11 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
                   role="button"
                   tabindex="0"
                 >
-                  more
+                  <span
+                    class="root"
+                  >
+                    more
+                  </span>
                 </a>
               </span>
             </span>

--- a/test/jest/__snapshots__/post-more-menu.test.jsx.snap
+++ b/test/jest/__snapshots__/post-more-menu.test.jsx.snap
@@ -1,0 +1,501 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PostMoreMenu Renders a More menu for a group moderator 1`] = `
+<DocumentFragment>
+  <div
+    class="list"
+    style="min-width: 18em;"
+  >
+    <div
+      class="group"
+    >
+      <div
+        class="item"
+      >
+        <a
+          class="link"
+          role="button"
+        >
+          Save post
+        </a>
+      </div>
+    </div>
+    <div
+      class="group"
+    >
+      <div
+        class="item"
+      >
+        <a
+          class="link"
+          role="button"
+        >
+          Moderate comments
+        </a>
+      </div>
+      <div
+        class="item"
+      >
+        <a
+          class="link"
+          role="button"
+        >
+          Disable comments
+        </a>
+      </div>
+    </div>
+    <div
+      class="group"
+    >
+      <div
+        class="item"
+      >
+        <a
+          class="link danger"
+          role="button"
+        >
+          Remove from @group1
+        </a>
+      </div>
+      <div
+        class="item"
+      >
+        <a
+          class="link danger"
+          role="button"
+        >
+          Remove from @group2
+        </a>
+      </div>
+    </div>
+    <div
+      class="group"
+    >
+      <div
+        class="item content"
+      >
+        <span
+          class="iconic"
+        >
+          <span
+            class="iconicIcon"
+          >
+            fontawesome icon clock
+          </span>
+          <span
+            class="iconicContent"
+          >
+            Created on 
+            <time
+              datetime="2021-08-22T21:33:20.000Z"
+              title="Aug 22, 2021"
+            >
+              Aug 22, 2021 21:33
+            </time>
+          </span>
+        </span>
+      </div>
+      <div
+        class="item content"
+      >
+        <span
+          class="iconic"
+        >
+          <span
+            class="iconicIcon"
+          >
+            fontawesome icon clock
+          </span>
+          <span
+            class="iconicContent"
+          >
+            Updated on 
+            <time
+              datetime="2021-08-22T21:49:59.999Z"
+              title="Aug 22, 2021"
+            >
+              Aug 22, 2021 21:49
+            </time>
+          </span>
+        </span>
+      </div>
+      <div
+        class="item content"
+      >
+        <span
+          class="iconic iconicCentered"
+        >
+          <span
+            class="iconicIcon"
+          >
+            fontawesome icon link
+          </span>
+          <span
+            class="iconicContent"
+          >
+            <a
+              style="margin-right: 1ex;"
+            >
+              Link to post
+            </a>
+             
+            <button
+              aria-label="Copy link"
+              class="btn btn-default btn-sm"
+              type="button"
+              value="https://freefeed.net/post123"
+            >
+              Copy
+            </button>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`PostMoreMenu Renders a More menu for a logged-in reader 1`] = `
+<DocumentFragment>
+  <div
+    class="list"
+    style="min-width: 18em;"
+  >
+    <div
+      class="group"
+    >
+      <div
+        class="item"
+      >
+        <a
+          class="link"
+          role="button"
+        >
+          Save post
+        </a>
+      </div>
+    </div>
+    <div
+      class="group"
+    >
+      <div
+        class="item content"
+      >
+        <span
+          class="iconic"
+        >
+          <span
+            class="iconicIcon"
+          >
+            fontawesome icon clock
+          </span>
+          <span
+            class="iconicContent"
+          >
+            Created on 
+            <time
+              datetime="2021-08-22T21:33:20.000Z"
+              title="Aug 22, 2021"
+            >
+              Aug 22, 2021 21:33
+            </time>
+          </span>
+        </span>
+      </div>
+      <div
+        class="item content"
+      >
+        <span
+          class="iconic"
+        >
+          <span
+            class="iconicIcon"
+          >
+            fontawesome icon clock
+          </span>
+          <span
+            class="iconicContent"
+          >
+            Updated on 
+            <time
+              datetime="2021-08-22T21:49:59.999Z"
+              title="Aug 22, 2021"
+            >
+              Aug 22, 2021 21:49
+            </time>
+          </span>
+        </span>
+      </div>
+      <div
+        class="item content"
+      >
+        <span
+          class="iconic iconicCentered"
+        >
+          <span
+            class="iconicIcon"
+          >
+            fontawesome icon link
+          </span>
+          <span
+            class="iconicContent"
+          >
+            <a
+              style="margin-right: 1ex;"
+            >
+              Link to post
+            </a>
+             
+            <button
+              aria-label="Copy link"
+              class="btn btn-default btn-sm"
+              type="button"
+              value="https://freefeed.net/post123"
+            >
+              Copy
+            </button>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`PostMoreMenu Renders a More menu for a logged-out visitor 1`] = `
+<DocumentFragment>
+  <div
+    class="list"
+    style="min-width: 18em;"
+  >
+    <div
+      class="group"
+    >
+      <div
+        class="item content"
+      >
+        <span
+          class="iconic"
+        >
+          <span
+            class="iconicIcon"
+          >
+            fontawesome icon clock
+          </span>
+          <span
+            class="iconicContent"
+          >
+            Created on 
+            <time
+              datetime="2021-08-22T21:33:20.000Z"
+              title="Aug 22, 2021"
+            >
+              Aug 22, 2021 21:33
+            </time>
+          </span>
+        </span>
+      </div>
+      <div
+        class="item content"
+      >
+        <span
+          class="iconic"
+        >
+          <span
+            class="iconicIcon"
+          >
+            fontawesome icon clock
+          </span>
+          <span
+            class="iconicContent"
+          >
+            Updated on 
+            <time
+              datetime="2021-08-22T21:49:59.999Z"
+              title="Aug 22, 2021"
+            >
+              Aug 22, 2021 21:49
+            </time>
+          </span>
+        </span>
+      </div>
+      <div
+        class="item content"
+      >
+        <span
+          class="iconic iconicCentered"
+        >
+          <span
+            class="iconicIcon"
+          >
+            fontawesome icon link
+          </span>
+          <span
+            class="iconicContent"
+          >
+            <a
+              style="margin-right: 1ex;"
+            >
+              Link to post
+            </a>
+             
+            <button
+              aria-label="Copy link"
+              class="btn btn-default btn-sm"
+              type="button"
+              value="https://freefeed.net/post123"
+            >
+              Copy
+            </button>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`PostMoreMenu Renders a More menu for a post owner 1`] = `
+<DocumentFragment>
+  <div
+    class="list"
+    style="min-width: 18em;"
+  >
+    <div
+      class="group"
+    >
+      <div
+        class="item"
+      >
+        <a
+          class="link"
+          role="button"
+        >
+          Save post
+        </a>
+      </div>
+    </div>
+    <div
+      class="group"
+    >
+      <div
+        class="item"
+      >
+        <a
+          class="link"
+          role="button"
+        >
+          Edit
+        </a>
+      </div>
+      <div
+        class="item"
+      >
+        <a
+          class="link"
+          role="button"
+        >
+          Disable comments
+        </a>
+      </div>
+    </div>
+    <div
+      class="group"
+    >
+      <div
+        class="item"
+      >
+        <a
+          class="link danger"
+          role="button"
+        >
+          Delete
+        </a>
+      </div>
+    </div>
+    <div
+      class="group"
+    >
+      <div
+        class="item content"
+      >
+        <span
+          class="iconic"
+        >
+          <span
+            class="iconicIcon"
+          >
+            fontawesome icon clock
+          </span>
+          <span
+            class="iconicContent"
+          >
+            Created on 
+            <time
+              datetime="2021-08-22T21:33:20.000Z"
+              title="Aug 22, 2021"
+            >
+              Aug 22, 2021 21:33
+            </time>
+          </span>
+        </span>
+      </div>
+      <div
+        class="item content"
+      >
+        <span
+          class="iconic"
+        >
+          <span
+            class="iconicIcon"
+          >
+            fontawesome icon clock
+          </span>
+          <span
+            class="iconicContent"
+          >
+            Updated on 
+            <time
+              datetime="2021-08-22T21:49:59.999Z"
+              title="Aug 22, 2021"
+            >
+              Aug 22, 2021 21:49
+            </time>
+          </span>
+        </span>
+      </div>
+      <div
+        class="item content"
+      >
+        <span
+          class="iconic iconicCentered"
+        >
+          <span
+            class="iconicIcon"
+          >
+            fontawesome icon link
+          </span>
+          <span
+            class="iconicContent"
+          >
+            <a
+              style="margin-right: 1ex;"
+            >
+              Link to post
+            </a>
+             
+            <button
+              aria-label="Copy link"
+              class="btn btn-default btn-sm"
+              type="button"
+              value="https://freefeed.net/post123"
+            >
+              Copy
+            </button>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/test/jest/__snapshots__/post-more-menu.test.jsx.snap
+++ b/test/jest/__snapshots__/post-more-menu.test.jsx.snap
@@ -13,10 +13,25 @@ exports[`PostMoreMenu Renders a More menu for a group moderator 1`] = `
         class="item"
       >
         <a
+          aria-disabled="false"
           class="link"
           role="button"
+          tabindex="0"
         >
-          Save post
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon save
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Save post
+            </span>
+          </span>
         </a>
       </div>
     </div>
@@ -27,20 +42,50 @@ exports[`PostMoreMenu Renders a More menu for a group moderator 1`] = `
         class="item"
       >
         <a
+          aria-disabled="false"
           class="link"
           role="button"
+          tabindex="0"
         >
-          Moderate comments
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon comment-dots
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Moderate comments
+            </span>
+          </span>
         </a>
       </div>
       <div
         class="item"
       >
         <a
+          aria-disabled="false"
           class="link"
           role="button"
+          tabindex="0"
         >
-          Disable comments
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon comment-dots
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Disable comments
+            </span>
+          </span>
         </a>
       </div>
     </div>
@@ -51,20 +96,50 @@ exports[`PostMoreMenu Renders a More menu for a group moderator 1`] = `
         class="item"
       >
         <a
+          aria-disabled="false"
           class="link danger"
           role="button"
+          tabindex="0"
         >
-          Remove from @group1
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon trash-alt
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Remove from @group1
+            </span>
+          </span>
         </a>
       </div>
       <div
         class="item"
       >
         <a
+          aria-disabled="false"
           class="link danger"
           role="button"
+          tabindex="0"
         >
-          Remove from @group2
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon trash-alt
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Remove from @group2
+            </span>
+          </span>
         </a>
       </div>
     </div>
@@ -168,10 +243,25 @@ exports[`PostMoreMenu Renders a More menu for a logged-in reader 1`] = `
         class="item"
       >
         <a
+          aria-disabled="false"
           class="link"
           role="button"
+          tabindex="0"
         >
-          Save post
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon save
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Save post
+            </span>
+          </span>
         </a>
       </div>
     </div>
@@ -368,10 +458,25 @@ exports[`PostMoreMenu Renders a More menu for a post owner 1`] = `
         class="item"
       >
         <a
+          aria-disabled="false"
           class="link"
           role="button"
+          tabindex="0"
         >
-          Save post
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon save
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Save post
+            </span>
+          </span>
         </a>
       </div>
     </div>
@@ -382,20 +487,50 @@ exports[`PostMoreMenu Renders a More menu for a post owner 1`] = `
         class="item"
       >
         <a
+          aria-disabled="false"
           class="link"
           role="button"
+          tabindex="0"
         >
-          Edit
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon edit
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Edit
+            </span>
+          </span>
         </a>
       </div>
       <div
         class="item"
       >
         <a
+          aria-disabled="false"
           class="link"
           role="button"
+          tabindex="0"
         >
-          Disable comments
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon comment-dots
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Disable comments
+            </span>
+          </span>
         </a>
       </div>
     </div>
@@ -406,10 +541,25 @@ exports[`PostMoreMenu Renders a More menu for a post owner 1`] = `
         class="item"
       >
         <a
+          aria-disabled="false"
           class="link danger"
           role="button"
+          tabindex="0"
         >
-          Delete
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon trash-alt
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Delete
+            </span>
+          </span>
         </a>
       </div>
     </div>

--- a/test/jest/__snapshots__/post.test.js.snap
+++ b/test/jest/__snapshots__/post.test.js.snap
@@ -123,8 +123,10 @@ exports[`Post Renders a post and doesn't blow up 1`] = `
               class="post-footer-item"
             >
               <a
+                aria-disabled="false"
                 class="post-action"
                 role="button"
+                tabindex="0"
               >
                 Comment
               </a>
@@ -133,8 +135,10 @@ exports[`Post Renders a post and doesn't blow up 1`] = `
               class="post-footer-item"
             >
               <a
+                aria-disabled="false"
                 class="post-action"
                 role="button"
+                tabindex="0"
               >
                 Like
               </a>
@@ -143,8 +147,12 @@ exports[`Post Renders a post and doesn't blow up 1`] = `
               class="post-footer-item"
             >
               <a
+                aria-disabled="false"
+                aria-expanded="false"
+                aria-haspopup="true"
                 class="post-action"
                 role="button"
+                tabindex="0"
               >
                 <span
                   class="root"

--- a/test/jest/__snapshots__/post.test.js.snap
+++ b/test/jest/__snapshots__/post.test.js.snap
@@ -146,12 +146,13 @@ exports[`Post Renders a post and doesn't blow up 1`] = `
                 class="post-action"
                 role="button"
               >
-                Save
+                <span
+                  class="root"
+                >
+                  More
+                </span>
               </a>
             </span>
-            <span
-              class="post-footer-item"
-            />
           </span>
         </div>
       </div>

--- a/test/jest/post-more-menu.test.jsx
+++ b/test/jest/post-more-menu.test.jsx
@@ -1,0 +1,100 @@
+/* global jest, describe, it, expect */
+import { render } from '@testing-library/react';
+import { createStore } from 'redux';
+import * as reactRedux from 'react-redux';
+
+import { PostMoreMenu } from '../../src/components/post-more-menu';
+
+jest.mock('../../src/components/fontawesome-icons', () => ({
+  Icon: ({ icon }) => `fontawesome icon ${icon.iconName}`, // mocking out icon to make snapshots smaller
+}));
+
+const VIEWER = {
+  id: 'user-id',
+  username: 'viewer',
+  frontendPreferences: {
+    timeDisplay: {},
+  },
+};
+
+const POST = {
+  id: 'post123',
+  isEditable: false,
+  canBeRemovedFrom: [],
+  isModeratable: false,
+  isDeletable: false,
+  isModeratingComments: false,
+  commentsDisabled: false,
+  createdAt: '1629668000000',
+  updatedAt: '1629668999999',
+  isSaved: false,
+  savePostStatus: {},
+};
+
+const defaultState = {
+  user: VIEWER,
+};
+
+const renderPostMoreMenu = (props = {}) => {
+  const { Provider } = reactRedux;
+  const dummyReducer = (state) => state;
+  const store = createStore(dummyReducer, defaultState);
+
+  const defaultProps = {
+    user: VIEWER,
+    post: POST,
+    toggleEditingPost: () => {},
+    toggleModeratingComments: () => {},
+    enableComments: () => {},
+    disableComments: () => {},
+    deletePost: () => {},
+    perGroupDeleteEnabled: true,
+    doAndClose: () => {},
+    permalink: 'https://freefeed.net/post123',
+    toggleSave: () => {},
+  };
+
+  return render(
+    <Provider store={store}>
+      <PostMoreMenu {...defaultProps} {...props} />
+    </Provider>,
+  );
+};
+
+describe('PostMoreMenu', () => {
+  it('Renders a More menu for a logged-out visitor', () => {
+    const { asFragment } = renderPostMoreMenu({ user: {} });
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('Renders a More menu for a logged-in reader', () => {
+    const { asFragment } = renderPostMoreMenu();
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('Renders a More menu for a group moderator', () => {
+    const { asFragment } = renderPostMoreMenu({
+      post: {
+        ...POST,
+        isModeratable: true,
+        canBeRemovedFrom: ['group1', 'group2'],
+      },
+    });
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('Renders a More menu for a post owner', () => {
+    const { asFragment } = renderPostMoreMenu({
+      post: {
+        ...POST,
+        isEditable: true,
+        isDeletable: true,
+      },
+    });
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/test/jest/post.test.js
+++ b/test/jest/post.test.js
@@ -314,20 +314,23 @@ describe('Post', () => {
       deletePost,
     });
     expect(screen.getByText(/More/, { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText(/More/, { role: 'button' }));
 
+    userEvent.click(screen.getByText(/More/, { role: 'button' }));
     expect(screen.getByText('Edit', { role: 'button' })).toBeInTheDocument();
     userEvent.click(screen.getByText('Edit', { role: 'button' }));
     expect(toggleEditingPost).toHaveBeenCalledWith('post-id');
 
+    userEvent.click(screen.getByText(/More/, { role: 'button' }));
     expect(screen.getByText('Moderate comments', { role: 'button' })).toBeInTheDocument();
     userEvent.click(screen.getByText('Moderate comments', { role: 'button' }));
     expect(toggleModeratingComments).toHaveBeenCalledWith('post-id');
 
+    userEvent.click(screen.getByText(/More/, { role: 'button' }));
     expect(screen.getByText('Disable comments', { role: 'button' })).toBeInTheDocument();
     userEvent.click(screen.getByText('Disable comments', { role: 'button' }));
     expect(disableComments).toHaveBeenCalledWith('post-id');
 
+    userEvent.click(screen.getByText(/More/, { role: 'button' }));
     expect(screen.getByText('Delete', { role: 'button' })).toBeInTheDocument();
     userEvent.click(screen.getByText('Delete', { role: 'button' }));
     expect(confirmMock).toHaveBeenCalledWith('Are you sure?');


### PR DESCRIPTION
This PR makes changes described in p.3 of Share RFC https://docs.google.com/document/d/1qv7psaTqGf4p1_Ed-zEhRWKYrAXLvi5O_SxxAlufVl8/:

1. "More" menu is now being displayed for _all_ posts
1. "Save post" is moved into "More" menu
2. Added create and update dates to more menu
3. Added "copy post link" button

### Someone else's post:
<img width="662" alt="Screenshot 2021-08-22 at 19 21 37" src="https://user-images.githubusercontent.com/632081/130385971-0774f9e3-aaff-4d56-a4a9-0d79d7aab7af.png">

### My own post:
<img width="478" alt="Screenshot 2021-08-22 at 19 22 00" src="https://user-images.githubusercontent.com/632081/130385973-9770d79c-01be-43f6-a6c7-9eddfd4e469b.png">

### Moderatable post in a group:
<img width="475" alt="Screenshot 2021-08-22 at 19 22 46" src="https://user-images.githubusercontent.com/632081/130385976-040f20b5-d3c9-4645-894b-07820d7e605c.png">


----

Also, all "More ▾" links are refactored to use a single component to make UI more uniform:

### Before:
<img width="232" alt="Screenshot 2021-08-22 at 17 48 38" src="https://user-images.githubusercontent.com/632081/130385886-fbc82e9f-8573-41e2-b2a4-9a12c1c760da.png">
<img width="482" alt="Screenshot 2021-08-22 at 17 48 49" src="https://user-images.githubusercontent.com/632081/130385890-aef3a996-d93e-4bb0-943a-9a5bc096e616.png">

### After:
<img width="221" alt="Screenshot 2021-08-22 at 17 49 48" src="https://user-images.githubusercontent.com/632081/130385893-505cffca-266b-4a10-bc0f-867c4c64a257.png">
<img width="475" alt="Screenshot 2021-08-22 at 17 49 00" src="https://user-images.githubusercontent.com/632081/130385892-277f4b78-ed22-4998-a5b2-b760c98af1a4.png">