### PR TITLE
Move "Save post" action lower

### DIFF
--- a/src/components/post-more-menu.jsx
+++ b/src/components/post-more-menu.jsx
@@ -1,8 +1,18 @@
 import { forwardRef, useMemo } from 'react';
 import { Link } from 'react-router';
 import cn from 'classnames';
-import { faExclamationTriangle, faLink, faEdit, faSave } from '@fortawesome/free-solid-svg-icons';
-import { faClock, faCommentDots, faTrashAlt } from '@fortawesome/free-regular-svg-icons';
+import {
+  faExclamationTriangle,
+  faLink,
+  faEdit,
+  faBookmark as faBookmarkSolid,
+} from '@fortawesome/free-solid-svg-icons';
+import {
+  faClock,
+  faCommentDots,
+  faTrashAlt,
+  faBookmark,
+} from '@fortawesome/free-regular-svg-icons';
 import { noop } from 'lodash';
 
 import { andJoin } from '../utils/and-join';
@@ -69,25 +79,6 @@ export const PostMoreMenu = forwardRef(function PostMoreMenu(
 
   const menuGroups = [
     [
-      amIAuthenticated && (
-        <div className={styles.item} key="save-post">
-          <ButtonLink className={styles.link} onClick={doAndClose(toggleSave)}>
-            <Iconic icon={faSave}>
-              {isSaved ? 'Un-save' : 'Save'} post
-              {savePostStatus.loading && <Throbber />}
-              {savePostStatus.error && (
-                <Icon
-                  icon={faExclamationTriangle}
-                  className="post-like-fail"
-                  title={savePostStatus.errorText}
-                />
-              )}
-            </Iconic>
-          </ButtonLink>
-        </div>
-      ),
-    ],
-    [
       isEditable && (
         <div className={styles.item} key="edit-post">
           <ButtonLink className={styles.link} onClick={doAndClose(toggleEditingPost)}>
@@ -124,6 +115,25 @@ export const PostMoreMenu = forwardRef(function PostMoreMenu(
         </ButtonLink>
       </div>
     )),
+    [
+      amIAuthenticated && (
+        <div className={styles.item} key="save-post">
+          <ButtonLink className={styles.link} onClick={doAndClose(toggleSave)}>
+            <Iconic icon={isSaved ? faBookmarkSolid : faBookmark}>
+              {isSaved ? 'Un-save' : 'Save'} post
+              {savePostStatus.loading && <Throbber />}
+              {savePostStatus.error && (
+                <Icon
+                  icon={faExclamationTriangle}
+                  className="post-like-fail"
+                  title={savePostStatus.errorText}
+                />
+              )}
+            </Iconic>
+          </ButtonLink>
+        </div>
+      ),
+    ],
     [
       <div key="created-on" className={cn(styles.item, styles.content)}>
         <Iconic icon={faClock}>

--- a/test/jest/__snapshots__/post-more-menu.test.jsx.snap
+++ b/test/jest/__snapshots__/post-more-menu.test.jsx.snap
@@ -24,35 +24,6 @@ exports[`PostMoreMenu Renders a More menu for a group moderator 1`] = `
             <span
               class="iconicIcon"
             >
-              fontawesome icon save
-            </span>
-            <span
-              class="iconicContent"
-            >
-              Save post
-            </span>
-          </span>
-        </a>
-      </div>
-    </div>
-    <div
-      class="group"
-    >
-      <div
-        class="item"
-      >
-        <a
-          aria-disabled="false"
-          class="link"
-          role="button"
-          tabindex="0"
-        >
-          <span
-            class="iconic"
-          >
-            <span
-              class="iconicIcon"
-            >
               fontawesome icon comment-dots
             </span>
             <span
@@ -138,6 +109,35 @@ exports[`PostMoreMenu Renders a More menu for a group moderator 1`] = `
               class="iconicContent"
             >
               Remove from @group2
+            </span>
+          </span>
+        </a>
+      </div>
+    </div>
+    <div
+      class="group"
+    >
+      <div
+        class="item"
+      >
+        <a
+          aria-disabled="false"
+          class="link"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon bookmark
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Save post
             </span>
           </span>
         </a>
@@ -254,7 +254,7 @@ exports[`PostMoreMenu Renders a More menu for a logged-in reader 1`] = `
             <span
               class="iconicIcon"
             >
-              fontawesome icon save
+              fontawesome icon bookmark
             </span>
             <span
               class="iconicContent"
@@ -469,35 +469,6 @@ exports[`PostMoreMenu Renders a More menu for a post owner 1`] = `
             <span
               class="iconicIcon"
             >
-              fontawesome icon save
-            </span>
-            <span
-              class="iconicContent"
-            >
-              Save post
-            </span>
-          </span>
-        </a>
-      </div>
-    </div>
-    <div
-      class="group"
-    >
-      <div
-        class="item"
-      >
-        <a
-          aria-disabled="false"
-          class="link"
-          role="button"
-          tabindex="0"
-        >
-          <span
-            class="iconic"
-          >
-            <span
-              class="iconicIcon"
-            >
               fontawesome icon edit
             </span>
             <span
@@ -558,6 +529,35 @@ exports[`PostMoreMenu Renders a More menu for a post owner 1`] = `
               class="iconicContent"
             >
               Delete
+            </span>
+          </span>
+        </a>
+      </div>
+    </div>
+    <div
+      class="group"
+    >
+      <div
+        class="item"
+      >
+        <a
+          aria-disabled="false"
+          class="link"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon bookmark
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Save post
             </span>
           </span>
         </a>


### PR DESCRIPTION
This PR moves "Save post" action lower in the new "more" menu and changes its icon from floppy disk to a bookmark.