### PR TITLE
Respect server's fileSizeLimit setting when uploading files

### DIFF
--- a/src/components/dropzone-component.jsx
+++ b/src/components/dropzone-component.jsx
@@ -2,6 +2,7 @@
 import DropzoneComponent from 'react-dropzone-component';
 
 import { getToken } from '../services/auth';
+import { useServerInfo } from './hooks/server-info';
 
 // DropzoneJS configuration
 const dropzoneComponentConfig = { postUrl: `${CONFIG.api.root}/v1/attachments` };
@@ -26,6 +27,7 @@ const dropzoneConfig = {
   `,
   clickable: '.dropzone-trigger', // Define the element that should be used as click trigger to select files.
   headers: { 'Cache-Control': null },
+  maxFilesize: 1, // in MiB (1000 * 1000 bytes). Dropzone's default is 256
 };
 
 const dropzoneEventHandlers = (props) => ({
@@ -90,10 +92,19 @@ const dropzoneEventHandlers = (props) => ({
   queuecomplete: props.onQueueComplete,
 });
 
-export default (props) => (
-  <DropzoneComponent
-    config={dropzoneComponentConfig}
-    djsConfig={dropzoneConfig}
-    eventHandlers={dropzoneEventHandlers(props)}
-  />
-);
+export default (props) => {
+  const [serverInfo, serverInfoStatus] = useServerInfo();
+
+  if (serverInfoStatus.success && serverInfo.attachments?.fileSizeLimit) {
+    const fileSizeLimitInMibs = (serverInfo.attachments.fileSizeLimit / (1000 * 1000)).toFixed(2);
+    dropzoneConfig.maxFilesize = fileSizeLimitInMibs;
+  }
+
+  return (
+    <DropzoneComponent
+      config={dropzoneComponentConfig}
+      djsConfig={dropzoneConfig}
+      eventHandlers={dropzoneEventHandlers(props)}
+    />
+  );
+};


### PR DESCRIPTION
This PR makes Dropzone aware of server's `fileSizeLimit` setting. If server's config is unavailable then the limit is set to 1 MiB (as opposed to Dropzone's default 256 MiB).

Fixes https://freefeed.net/support/74d959f7-9363-43bb-af55-955f0fbe6167, https://freefeed.net/support/6ed7e54d-6e74-45a4-9007-38439ec9cafe.