### PR TITLE
Make "more" menu of posts more mobile-friendly

### DIFF
--- a/src/components/post-more-link.jsx
+++ b/src/components/post-more-link.jsx
@@ -1,10 +1,12 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Portal } from 'react-portal';
+import { intentToScroll } from '../services/unscroll';
 
 import { confirmFirst } from '../utils';
 import { canonicalURI } from '../utils/canonical-uri';
 import { CLOSE_ON_CLICK_OUTSIDE } from './hooks/drop-down';
 import { useDropDownKbd } from './hooks/drop-down-kbd';
+import { useMediaQuery } from './hooks/media-query';
 import { useServerInfo } from './hooks/server-info';
 import { PostMoreMenu } from './post-more-menu';
 import { MoreWithTriangle } from './more-with-triangle';
@@ -12,8 +14,11 @@ import { TimedMessage } from './timed-message';
 import { ButtonLink } from './button-link';
 
 export default function PostMoreLink({ post, user, ...props }) {
+  const fixedMenu = useMediaQuery('(max-width: 450px)');
+
   const { pivotRef, menuRef, opened, toggle } = useDropDownKbd({
     closeOn: CLOSE_ON_CLICK_OUTSIDE,
+    fixed: fixedMenu,
   });
   const [serverInfo, serverInfoStatus] = useServerInfo();
 
@@ -41,6 +46,21 @@ export default function PostMoreLink({ post, user, ...props }) {
     label = <TimedMessage message="Error!">More</TimedMessage>;
   }
 
+  useEffect(() => {
+    if (fixedMenu && opened) {
+      // Fix scroll position
+      const menuTop = document.documentElement.clientHeight - menuRef.current.scrollHeight;
+      const linkBottom = pivotRef.current.getBoundingClientRect().bottom;
+      if (linkBottom > menuTop) {
+        intentToScroll();
+        window.scrollBy({
+          top: linkBottom - menuTop + 4,
+          behavior: 'smooth',
+        });
+      }
+    }
+  }, [fixedMenu, opened, menuRef, pivotRef]);
+
   return (
     <>
       <ButtonLink
@@ -67,6 +87,7 @@ export default function PostMoreLink({ post, user, ...props }) {
             doAndClose={doAndClose}
             permalink={canonicalPostURI}
             toggleSave={props.toggleSave}
+            fixed={fixedMenu}
           />
         </Portal>
       )}

--- a/src/components/post-more-menu.jsx
+++ b/src/components/post-more-menu.jsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo } from 'react';
+import { forwardRef, useLayoutEffect, useState, useMemo } from 'react';
 import { Link } from 'react-router';
 import cn from 'classnames';
 import {
@@ -48,6 +48,7 @@ export const PostMoreMenu = forwardRef(function PostMoreMenu(
     doAndClose,
     permalink,
     toggleSave,
+    fixed = false,
   },
   ref,
 ) {
@@ -166,20 +167,35 @@ export const PostMoreMenu = forwardRef(function PostMoreMenu(
     ],
   ];
 
+  const [initial, setInitial] = useState(true);
+  useLayoutEffect(() => setInitial(false), []);
+
   return (
-    <div className={styles.list} ref={ref} style={{ minWidth: '18em' }}>
-      {menuGroups.map((group, i) => {
-        const items = group.filter(Boolean);
-        if (items.length === 0) {
-          return null;
-        }
-        return (
-          <div className={styles.group} key={`group-${i}`}>
-            {items}
-          </div>
-        );
-      })}
-    </div>
+    <>
+      {fixed && <div className={cn(styles.shadow, initial && styles.initial)} />}
+      <div
+        className={cn(
+          styles.list,
+          styles.focusList,
+          initial && styles.initial,
+          fixed && styles.fixedList,
+        )}
+        ref={ref}
+        style={{ minWidth: '18em' }}
+      >
+        {menuGroups.map((group, i) => {
+          const items = group.filter(Boolean);
+          if (items.length === 0) {
+            return null;
+          }
+          return (
+            <div className={styles.group} key={`group-${i}`}>
+              {items}
+            </div>
+          );
+        })}
+      </div>
+    </>
   );
 });
 

--- a/test/jest/__snapshots__/post-more-menu.test.jsx.snap
+++ b/test/jest/__snapshots__/post-more-menu.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`PostMoreMenu Renders a More menu for a group moderator 1`] = `
 <DocumentFragment>
   <div
-    class="list"
+    class="list focusList"
     style="min-width: 18em;"
   >
     <div
@@ -233,7 +233,7 @@ exports[`PostMoreMenu Renders a More menu for a group moderator 1`] = `
 exports[`PostMoreMenu Renders a More menu for a logged-in reader 1`] = `
 <DocumentFragment>
   <div
-    class="list"
+    class="list focusList"
     style="min-width: 18em;"
   >
     <div
@@ -355,7 +355,7 @@ exports[`PostMoreMenu Renders a More menu for a logged-in reader 1`] = `
 exports[`PostMoreMenu Renders a More menu for a logged-out visitor 1`] = `
 <DocumentFragment>
   <div
-    class="list"
+    class="list focusList"
     style="min-width: 18em;"
   >
     <div
@@ -448,7 +448,7 @@ exports[`PostMoreMenu Renders a More menu for a logged-out visitor 1`] = `
 exports[`PostMoreMenu Renders a More menu for a post owner 1`] = `
 <DocumentFragment>
   <div
-    class="list"
+    class="list focusList"
     style="min-width: 18em;"
   >
     <div


### PR DESCRIPTION
I'm not going to pretend that I know what I'm doing. I copy-pasted @davidmz's code and it seems to work. Both comments' and posts' "more" menus are ripe for a refactoring and de-duplication of code though.

<img width="432" alt="Screenshot 2021-09-15 at 23 39 40" src="https://user-images.githubusercontent.com/632081/133563180-2ef40dde-2c1f-4431-9f4d-0714f3e8e48a.png">
