### PR TITLE
Use 'color-scheme' CSS property on dark/light site mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.102.0] - Not released
+### Added
+- The 'color-scheme' CSS property now applies on dark/light site mode. This
+  property allows to set color scheme for browser UI elements such as scrollbars
+  and form inputs.
+
 ## [1.101.0] - 2021-09-19 
 ### Added
 - User can adjust the site font size in settings' Appearance tab. This setting

--- a/index.jade
+++ b/index.jade
@@ -18,11 +18,13 @@ html(lang='en')
       style.
         .jsonly { display: none }
     style.
+      html { color-scheme: light; }
+      html.dark-theme { color-scheme: dark; }
       body { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px }
       h1 { font-size: 36px; font-weight: 500 }
       h1 a { color: #222; text-decoration: none }
-      body.dark-theme h1 a { color: hsl(0, 0%, 70%); }
       body.initial { transition: none; }
+      .dark-theme h1 a { color: hsl(0, 0%, 70%); }
     style.
       .privacy-popup {position: fixed; bottom: 0; left: 0; right: 0; z-index: 100; color: white; background-color: rgba(16,16,16,0.8); padding: 24px; display: flex; flex-flow: row; flex-wrap: wrap; align-items: center; justify-content: center;}
       .privacy-text {line-height: 1.42857; font-size: 16px; margin-bottom: 16px; max-width: 600px;}
@@ -66,7 +68,7 @@ html(lang='en')
               && window.matchMedia
               && window.matchMedia('(prefers-color-scheme: dark)').matches
           ) {
-            document.body.classList.add('dark-theme');
+            document.documentElement.classList.add('dark-theme');
           }
         } catch (e) { }
         setTimeout(function () { document.body.classList.remove('initial') }, 0);

--- a/src/components/color-theme-setter.jsx
+++ b/src/components/color-theme-setter.jsx
@@ -1,27 +1,17 @@
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { Helmet } from 'react-helmet';
 
-import { darkTheme } from './select-utils';
+import { darkTheme as selectDarkTheme } from './select-utils';
 
-class ColorSchemeSetterBase extends Component {
-  componentDidMount() {
-    document.body.classList.toggle('dark-theme', this.props.darkTheme);
-  }
+export function ColorSchemeSetter() {
+  const darkTheme = useSelector(selectDarkTheme);
 
-  componentDidUpdate() {
-    document.body.classList.toggle('dark-theme', this.props.darkTheme);
-  }
+  useEffect(() => document.documentElement.classList.toggle('dark-theme', darkTheme), [darkTheme]);
 
-  render() {
-    return (
-      <Helmet defer={false}>
-        <meta name="theme-color" content={this.props.darkTheme ? 'hsl(220, 9%, 10%)' : 'white'} />
-      </Helmet>
-    );
-  }
+  return (
+    <Helmet defer={false}>
+      <meta name="theme-color" content={darkTheme ? 'hsl(220, 9%, 10%)' : 'white'} />
+    </Helmet>
+  );
 }
-
-export const ColorSchemeSetter = connect((state) => ({ darkTheme: darkTheme(state) }))(
-  ColorSchemeSetterBase,
-);

--- a/src/components/settings/settings.module.scss
+++ b/src/components/settings/settings.module.scss
@@ -15,7 +15,7 @@
   padding: 0.5em;
   border-radius: 0.25em;
 
-  :global(body.dark-theme) & {
+  :global(.dark-theme) & {
     color: inherit;
   }
 
@@ -24,7 +24,7 @@
     text-decoration: none;
     background-color: #f4f4f4;
 
-    :global(body.dark-theme) & {
+    :global(.dark-theme) & {
       color: inherit;
       background-color: $bg-color-lighter;
     }
@@ -55,7 +55,7 @@
   color: #555555;
   margin-right: 0.2em;
 
-  :global(body.dark-theme) & {
+  :global(.dark-theme) & {
     color: $text-color-darker;
   }
 }
@@ -81,7 +81,7 @@
   border: 1px solid #ccc;
   margin-top: 2em;
 
-  :global(body.dark-theme) & {
+  :global(.dark-theme) & {
     background: $bg-color-lighter;
     border: 1px solid $separator-color;
     color: $text-color;

--- a/styles/helvetica/dark-theme.scss
+++ b/styles/helvetica/dark-theme.scss
@@ -10,8 +10,8 @@ body,
   transition: background 0.2s;
 }
 
-body.dark-theme {
-  &,
+.dark-theme {
+  body,
   .sidebar .box-body,
   .search-form .search-button,
   .search-form .search-input,
@@ -61,7 +61,7 @@ body.dark-theme {
     border-color: $separator-color;
   }
 
-  &,
+  body,
   .post .post-body .post-text,
   .post .post-body,
   .box-header,

--- a/styles/shared/attachments.scss
+++ b/styles/shared/attachments.scss
@@ -80,7 +80,7 @@
         align-items: center;
         justify-content: center;
 
-        body.dark-theme & {
+        .dark-theme & {
           background-color: #666;
         }
       }

--- a/styles/shared/comments.scss
+++ b/styles/shared/comments.scss
@@ -201,11 +201,11 @@
     background: scale-color(#eee, $alpha: -10%);
   }
 
-  body.dark-theme & {
+  .dark-theme & {
     background-color: scale-color($bg-color, $alpha: -10%);
   }
 
-  body.dark-theme .direct-post & {
+  .dark-theme .direct-post & {
     background-color: scale-color($bg-color-lighter, $alpha: -10%);
   }
 }
@@ -221,11 +221,11 @@
     box-shadow: 0 0px 4px 8px scale-color(#eee, $alpha: -10%);
   }
 
-  body.dark-theme & {
+  .dark-theme & {
     box-shadow: 0 0px 4px 8px scale-color($bg-color, $alpha: -10%);
   }
 
-  body.dark-theme .direct-post & {
+  .dark-theme .direct-post & {
     box-shadow: 0 0px 4px 8px scale-color($bg-color-lighter, $alpha: -10%);
   }
 }

--- a/styles/shared/error-boundary.scss
+++ b/styles/shared/error-boundary.scss
@@ -8,7 +8,7 @@
   text-align: left;
   line-height: 16px;
 
-  body.dark-theme & {
+  .dark-theme & {
     color: $text-color;
   }
 }


### PR DESCRIPTION
This property allows to set color scheme for browser UI elements such as scrollbars and form inputs (see [spec](https://drafts.csswg.org/css-color-adjust/#color-scheme-prop)). It is supportedby Blink/Webkit browsers for now.

In Chrome/Win10: Light mode UI:
![image](https://user-images.githubusercontent.com/132120/135170034-037778e6-a3ce-408e-97ea-ba3120cded97.png)

Dark mode UI:
![image](https://user-images.githubusercontent.com/132120/135170094-6f861304-2e83-4ebf-8bf6-85c127eb15bb.png)
