### PR TITLE
Support usernames up to 30 chars in router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Experimental
+### Fixed
+- In the old days, users could create groups with groupnames up to 27 characters
+  long. Now the client router supports these names.
+
 ## [1.101.0] - 2021-09-19 
 ### Added
 - User can adjust the site font size in settings' Appearance tab. This setting

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -369,14 +369,18 @@ function checkPath(Component, checker) {
 }
 
 function isPostPath({ params: { postId, userName } }) {
+  // The FreeFeed's usernames can have up to 25 characters length now, but some
+  // old grops can have up to 27 characters in username
   return (
-    /^[a-z\d-]{3,25}$/i.test(userName) &&
+    /^[a-z\d-]{3,30}$/i.test(userName) &&
     /^[a-f\d]{8}-[a-f\d]{4}-4[a-f\d]{3}-[89ab][a-f\d]{3}-[a-f\d]{12}$/i.test(postId)
   );
 }
 
 function isAccountPath({ params: { userName } }) {
-  return /^[a-z\d-]{3,25}$/i.test(userName);
+  // The FreeFeed's usernames can have up to 25 characters length now, but some
+  // old grops can have up to 27 characters in username
+  return /^[a-z\d-]{3,30}$/i.test(userName);
 }
 
 function isMemoriesPath({ params: { userName, from } }) {


### PR DESCRIPTION
In the old days, users could create groups with groupnames up to 27 characters long. Now the client router supports these names.