### PR TITLE
Comment spacer

### DIFF
--- a/src/components/post-comments/comment-spacer.jsx
+++ b/src/components/post-comments/comment-spacer.jsx
@@ -6,19 +6,22 @@ import { Icon } from '../fontawesome-icons';
 
 import styles from './comment-spacer.module.scss';
 
-export function CommentSpacer({ className, from, to }) {
+export function CommentSpacer({ className, from, to, isAboveCommentForm }) {
   const rootCn = classnames(className, styles.spacer);
 
   const fromDate = new Date(+from);
   const toDate = new Date(+to);
   const distance = formatDistance(fromDate, toDate);
+  const word = isAboveCommentForm ? 'passed' : 'later';
 
   return (
     <div className={rootCn} aria-hidden>
       <div className={styles.icon}>
         <Icon icon={faClock} />
       </div>
-      <div className={styles.body}>{distance} later</div>
+      <div className={styles.body}>
+        {distance} {word}
+      </div>
     </div>
   );
 }

--- a/src/components/post-comments/index.jsx
+++ b/src/components/post-comments/index.jsx
@@ -80,9 +80,9 @@ export default class PostComments extends Component {
 
     if (post.comments?.length > 0) {
       const lastComment = post.comments[post.comments.length - 1];
-      spacer = this.renderCommentSpacer(now, lastComment.createdAt);
+      spacer = this.renderCommentSpacer(now, lastComment.createdAt, true);
     } else {
-      spacer = this.renderCommentSpacer(now, post.createdAt);
+      spacer = this.renderCommentSpacer(now, post.createdAt, true);
     }
 
     return (
@@ -177,7 +177,7 @@ export default class PostComments extends Component {
     return !post.commentsDisabled || post.isEditable || post.isModeratable;
   }
 
-  renderCommentSpacer = (from, to) => {
+  renderCommentSpacer = (from, to, isAboveCommentForm = false) => {
     if (!from || !to) {
       return null;
     }
@@ -194,7 +194,7 @@ export default class PostComments extends Component {
       return null;
     }
 
-    return <CommentSpacer from={from} to={to} />;
+    return <CommentSpacer from={from} to={to} isAboveCommentForm={isAboveCommentForm} />;
   };
 
   renderComment = (comment, index = 0, array = []) => {

--- a/test/jest/__snapshots__/post-comments.test.js.snap
+++ b/test/jest/__snapshots__/post-comments.test.js.snap
@@ -66,7 +66,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
             aria-label="Comment by author"
             class="comment-tail"
           >
-             - 
+             -
             <span
               class="comment-tail__item"
             >
@@ -84,7 +84,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
                 </a>
               </span>
             </span>
-             - 
+             -
             <span
               class="comment-tail__item comment-tail__actions"
             >
@@ -177,7 +177,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
             aria-label="Comment by other"
             class="comment-tail"
           >
-             - 
+             -
             <span
               class="comment-tail__item"
             >
@@ -195,7 +195,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
                 </a>
               </span>
             </span>
-             - 
+             -
             <span
               class="comment-tail__item comment-tail__actions"
             >
@@ -289,7 +289,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
             aria-label="Comment by author"
             class="comment-tail"
           >
-             - 
+             -
             <span
               class="comment-tail__item"
             >
@@ -307,7 +307,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
                 </a>
               </span>
             </span>
-             - 
+             -
             <span
               class="comment-tail__item comment-tail__actions"
             >
@@ -382,11 +382,6 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
           >
             Comment
           </button>
-          <span
-            class="submit-mode-hint"
-          >
-            (Enter for new line)
-          </span>
           <a
             aria-disabled="false"
             class="comment-file-button iconic-button"

--- a/test/jest/__snapshots__/post-comments.test.js.snap
+++ b/test/jest/__snapshots__/post-comments.test.js.snap
@@ -66,7 +66,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
             aria-label="Comment by author"
             class="comment-tail"
           >
-             -
+             - 
             <span
               class="comment-tail__item"
             >
@@ -84,7 +84,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
                 </a>
               </span>
             </span>
-             -
+             - 
             <span
               class="comment-tail__item comment-tail__actions"
             >
@@ -177,7 +177,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
             aria-label="Comment by other"
             class="comment-tail"
           >
-             -
+             - 
             <span
               class="comment-tail__item"
             >
@@ -195,7 +195,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
                 </a>
               </span>
             </span>
-             -
+             - 
             <span
               class="comment-tail__item comment-tail__actions"
             >
@@ -289,7 +289,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
             aria-label="Comment by author"
             class="comment-tail"
           >
-             -
+             - 
             <span
               class="comment-tail__item"
             >
@@ -307,7 +307,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
                 </a>
               </span>
             </span>
-             -
+             - 
             <span
               class="comment-tail__item comment-tail__actions"
             >
@@ -346,7 +346,7 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
       <div
         class="body"
       >
-        about 4 years later
+        about 4 years passed
       </div>
     </div>
     <div
@@ -382,6 +382,11 @@ exports[`PostComments Renders post comments and doesn't blow up 1`] = `
           >
             Comment
           </button>
+          <span
+            class="submit-mode-hint"
+          >
+            (Enter for new line)
+          </span>
           <a
             aria-disabled="false"
             class="comment-file-button iconic-button"


### PR DESCRIPTION
1. Rebased my branch onto recent `beta`
2. Changed "later" to "passed" if comment spacer is displayed above comment form


<img width="722" alt="Screenshot 2021-10-11 at 14 34 00" src="https://user-images.githubusercontent.com/632081/136858797-2feaa2c7-12ea-47b4-9ab6-dcbaa5a9dc99.png">
