### PR TITLE
Enable hides at non-Home pages

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -57,6 +57,7 @@ export default {
       homeFeedSort: ACTIVITY,
       homeFeedMode: HOMEFEED_MODE_CLASSIC,
       homefeed: { hideUsers: [] },
+      hidesInNonHomeFeeds: false,
       pinnedGroups: [],
       hideUnreadNotifications: false,
       timeDisplay: {

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -2,13 +2,7 @@ import { memo, useCallback } from 'react';
 import { connect, useSelector, useDispatch } from 'react-redux';
 import { Link, withRouter } from 'react-router';
 
-import {
-  createPost,
-  resetPostCreateForm,
-  expandSendTo,
-  toggleHiddenPosts,
-  home,
-} from '../redux/action-creators';
+import { createPost, resetPostCreateForm, expandSendTo, home } from '../redux/action-creators';
 import { pluralForm } from '../utils';
 import { postActions } from './select-utils';
 import CreatePost from './create-post';
@@ -113,7 +107,6 @@ function selectActions(dispatch) {
       dispatch(createPost(feeds, postText, attachmentIds, more)),
     resetPostCreateForm: (...args) => dispatch(resetPostCreateForm(...args)),
     expandSendTo: () => dispatch(expandSendTo()),
-    toggleHiddenPosts: () => dispatch(toggleHiddenPosts()),
   };
 }
 

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -672,7 +672,7 @@ class Post extends Component {
                 <span className="post-footer-block" role="region">
                   <span className="post-footer-item">{commentLink}</span>
                   <span className="post-footer-item">{likeLink}</span>
-                  {props.isInHomeFeed && (
+                  {props.hideEnabled && (
                     <span className="post-footer-item" ref={this.hideLink}>
                       {this.renderHideLink()}
                     </span>

--- a/src/components/settings/forms/appearance.jsx
+++ b/src/components/settings/forms/appearance.jsx
@@ -88,6 +88,7 @@ export default function AppearanceForm() {
   const enableBeta = useField('enableBeta', form.form);
   const uiScaleField = useField('uiScale', form.form);
   const submitModeF = useField('submitMode', form.form);
+  const hidesInNonHomeFeeds = useField('hidesInNonHomeFeeds', form.form);
 
   return (
     <form onSubmit={form.handleSubmit}>
@@ -100,7 +101,7 @@ export default function AppearanceForm() {
           <div className="checkbox">
             <label>
               <CheckboxInput field={useYou} />
-              Show your own name as &quot;You&quot;
+              Show your own name as &ldquo;You&rdquo;
             </label>
           </div>
         </div>
@@ -154,6 +155,24 @@ export default function AppearanceForm() {
               <RadioInput field={homeFeedMode} value={HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY} />
               Also your friends&#x2019; activity in groups you are not subscribed to
             </label>
+          </div>
+
+          <p>Apply posts and users hides:</p>
+          <div className="form-group">
+            <div className="radio">
+              <label>
+                <RadioInput field={hidesInNonHomeFeeds} value="0" />
+                At the &ldquo;Home&rdquo; page only
+              </label>
+            </div>
+
+            <div className="radio">
+              <label>
+                <RadioInput field={hidesInNonHomeFeeds} value="1" />
+                At the &ldquo;Home&rdquo;, &ldquo;Everything&rdquo;, &ldquo;Best of&hellip;&rdquo;
+                and your friend lists pages
+              </label>
+            </div>
           </div>
 
           <div className="form-group">
@@ -455,6 +474,7 @@ function initialValues({
     useCtrlEnter: frontend.submitByEnter ? '0' : '1',
     uiScale,
     submitMode,
+    hidesInNonHomeFeeds: frontend.hidesInNonHomeFeeds ? '1' : '0',
   };
 }
 
@@ -485,6 +505,7 @@ function prefUpdaters(values) {
           ...prefs.homefeed,
           hideUsers: values.hiddenUsers.toLowerCase().match(/[\w-]+/g) || [],
         },
+        hidesInNonHomeFeeds: values.hidesInNonHomeFeeds === '1',
         readMoreStyle: values.readMoreStyle,
         comments: {
           ...prefs.comments,

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -25,6 +25,7 @@ import {
   initialAsyncState,
   successAsyncState,
   keyFromRequestPayload,
+  baseType,
 } from './async-helpers';
 
 const frontendPrefsConfig = CONFIG.frontendPreferences;
@@ -191,10 +192,10 @@ const initFeed = {
   entries: [],
   timeline: null,
   recentlyHiddenEntries: {},
-  separateHiddenEntries: false,
   isHiddenRevealed: false,
   isLastPage: true,
   feedError: null,
+  feedRequestType: null,
 };
 
 export function feedViewState(state = initFeed, action) {
@@ -202,9 +203,6 @@ export function feedViewState(state = initFeed, action) {
     return state;
   }
   if (ActionHelpers.isFeedResponse(action)) {
-    // Separate hidden entries only in 'RiverOfNews' feed
-    const separateHiddenEntries = action.type === response(ActionTypes.HOME);
-
     const entries = (action.payload.posts || []).map((post) => post.id);
     const recentlyHiddenEntries = {};
     const isHiddenRevealed = false;
@@ -212,14 +210,16 @@ export function feedViewState(state = initFeed, action) {
     const timeline = action.payload.timelines
       ? _.pick(action.payload.timelines, ['id', 'name', 'user'])
       : null;
+    const feedRequestType = baseType(action.type);
+
     return {
       ...initFeed,
       entries,
       recentlyHiddenEntries,
       timeline,
-      separateHiddenEntries,
       isHiddenRevealed,
       isLastPage,
+      feedRequestType,
     };
   }
   if (ActionHelpers.isFeedFail(action)) {

--- a/test/jest/post.test.js
+++ b/test/jest/post.test.js
@@ -384,6 +384,7 @@ describe('Post', () => {
     renderPost({
       user: someOtherUser,
       isInHomeFeed: true,
+      hideEnabled: true,
       isHidden: false,
       hidePost,
     });
@@ -398,6 +399,7 @@ describe('Post', () => {
     renderPost({
       user: someOtherUser,
       isInHomeFeed: true,
+      hideEnabled: true,
       isHidden: true,
       hiddenByNames: false,
       unhidePost,


### PR DESCRIPTION
User can enable posts and users hides at the Home page only or at the Home, Everything, Best of and friend lists pages