### PR TITLE
Enable hides at non-Home pages

### DIFF
--- a/src/components/feed.jsx
+++ b/src/components/feed.jsx
@@ -1,7 +1,7 @@
 import { PureComponent, useState, useCallback } from 'react';
 import { connect } from 'react-redux';
 
-import { GET_EVERYTHING, GET_SUMMARY, HOME, HOME_AUX } from '../redux/action-types';
+import { DISCUSSIONS, GET_EVERYTHING, GET_SUMMARY, HOME, HOME_AUX } from '../redux/action-types';
 import { toggleHiddenPosts } from '../redux/action-creators';
 import ErrorBoundary from './error-boundary';
 import Post from './post';
@@ -122,7 +122,7 @@ export default connect(
     let hiddenPosts = [];
 
     const hideInFeeds = state.user.frontendPreferences.hidesInNonHomeFeeds
-      ? [HOME, HOME_AUX, GET_EVERYTHING, GET_SUMMARY]
+      ? [HOME, HOME_AUX, GET_EVERYTHING, GET_SUMMARY, DISCUSSIONS]
       : [HOME];
 
     const separateHiddenEntries = hideInFeeds.includes(feedRequestType);

--- a/src/components/settings/forms/appearance.jsx
+++ b/src/components/settings/forms/appearance.jsx
@@ -169,8 +169,8 @@ export default function AppearanceForm() {
             <div className="radio">
               <label>
                 <RadioInput field={hidesInNonHomeFeeds} value="1" />
-                At the &ldquo;Home&rdquo;, &ldquo;Everything&rdquo;, &ldquo;Best of&hellip;&rdquo;
-                and your friend lists pages
+                At the &ldquo;Home&rdquo;, &ldquo;Discussions&rdquo;, &ldquo;Everything&rdquo;,
+                &ldquo;Best of&hellip;&rdquo; and your friend lists pages
               </label>
             </div>
           </div>


### PR DESCRIPTION
User can enable posts and users hides at the Home page only or at the Home, Everything, Best of and friend lists pages