### PR TITLE
Add ^5 comment reference syntax, use comment seq. numbers for references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.103.0] - Not released
+### Added
+- New syntax for the distant comment ^-references. The near references uses a
+  familiar syntax ^, ^^…, but starting from five caps these references now
+  inserted as ^5, ^6 and so on.
+
+### Changed
+- The comment ^-references are now based of comments sequentional numbers. It
+  makes them stable and independent of user's appearance settings. Event if user
+  chooses to hide comments from blocked users, the ^-references will point to
+  the right places.
+
 ## [1.102.4] - 2021-10-22
 ### Fixed
 - Fix inverted autoplay setting for Vimeo (introduced in 1.102.3)

--- a/src/components/post-comment-more-menu.jsx
+++ b/src/components/post-comment-more-menu.jsx
@@ -46,7 +46,7 @@ export const PostCommentMoreMenu = forwardRef(function PostCommentMore(
   const { status, likers } = useCommentLikers(id);
   const myUsername = useSelector((state) => state.user.username);
   const bIdx = getBackwardIdx();
-  const arrows = bIdx <= 3 ? '^'.repeat(bIdx) : `^^^\u2026`;
+  const arrows = bIdx <= 4 ? '^'.repeat(bIdx) : `^${bIdx}`;
   const likersText = status.success
     ? likers.length > 0 && likersMenuText(likers, myUsername)
     : likesCount > 0 && `Show ${pluralForm(likesCount, 'like')}\u2026`;

--- a/src/components/post-comments/index.jsx
+++ b/src/components/post-comments/index.jsx
@@ -123,33 +123,20 @@ export default class PostComments extends Component {
 
   arrowsHighlightHandlers = {
     hover: (baseCommentId, nArrows) => {
-      const {
-        comments,
-        post: { omittedComments, omittedCommentsOffset },
-      } = this.props;
-      let absBaseIndex = comments.findIndex((c) => c.id === baseCommentId);
-      if (absBaseIndex === -1) {
+      const { comments } = this.props;
+      const baseComment = comments.find((c) => c.id === baseCommentId);
+      if (!baseComment) {
         // Comment not found
         return;
       }
-      if (absBaseIndex >= omittedCommentsOffset) {
-        absBaseIndex += omittedComments;
-      }
-      const absHlIndex = absBaseIndex - nArrows;
+      const refCommentNum = baseComment.seqNumber - nArrows;
+      const refComment = comments.find((c) => c.seqNumber === refCommentNum);
 
-      if (absHlIndex < 0) {
-        // Too many arrows
+      if (!refComment) {
         return;
       }
 
-      if (absHlIndex < omittedCommentsOffset) {
-        this.setState({ highlightedCommentId: comments[absHlIndex].id });
-      } else {
-        const hlIndex = absHlIndex - omittedComments;
-        if (hlIndex >= omittedCommentsOffset) {
-          this.setState({ highlightedCommentId: comments[hlIndex].id });
-        }
-      }
+      this.setState({ highlightedCommentId: refComment.id });
     },
     leave: () => this.setState({ highlightedCommentId: null }),
   };

--- a/src/components/post-comments/index.jsx
+++ b/src/components/post-comments/index.jsx
@@ -56,7 +56,7 @@ export default class PostComments extends Component {
 
   replyWithArrows = (commentId) => {
     const bIdx = this.backwardIdx(commentId);
-    const arrows = '^'.repeat(bIdx);
+    const arrows = bIdx <= 4 ? '^'.repeat(bIdx) : `^${bIdx}`;
     this._openAnsweringComment(arrows);
   };
 

--- a/src/components/post-comments/index.jsx
+++ b/src/components/post-comments/index.jsx
@@ -42,16 +42,13 @@ export default class PostComments extends Component {
   };
 
   backwardIdx = (commentId) => {
-    const { post, comments } = this.props;
-    const idx = comments.findIndex((c) => c.id === commentId);
-    if (idx < 0) {
+    const { comments } = this.props;
+    const thisComment = comments.find((c) => c.id === commentId);
+    if (!thisComment) {
       return 0;
     }
-    let backwardIdx = comments.length - idx;
-    if (idx < post.omittedCommentsOffset) {
-      backwardIdx += post.omittedComments;
-    }
-    return backwardIdx;
+    const lastComment = comments[comments.length - 1];
+    return lastComment.seqNumber - thisComment.seqNumber + 1;
   };
 
   replyWithArrows = (commentId) => {

--- a/test/jest/post-comments.test.js
+++ b/test/jest/post-comments.test.js
@@ -28,6 +28,7 @@ const COMMENT1 = {
   omitBubble: true,
   user: AUTHOR,
   createdAt: '1617727500000',
+  seqNumber: 1,
 };
 
 const COMMENT2 = {
@@ -36,6 +37,7 @@ const COMMENT2 = {
   omitBubble: true,
   user: { id: 'other-user', username: 'other' },
   createdAt: '1617727600000',
+  seqNumber: 2,
 };
 
 const COMMENT3 = {
@@ -44,6 +46,7 @@ const COMMENT3 = {
   omitBubble: true,
   user: AUTHOR,
   createdAt: '1617727700000',
+  seqNumber: 3,
 };
 
 const POST = {


### PR DESCRIPTION
### Added
- New syntax for the distant comment ^-references. The near references uses a familiar syntax ^, ^^…, but starting from five caps these references now inserted as ^5, ^6 and so on.

### Changed
- The comment ^-references are now based of comments sequential numbers. It makes them stable and independent of user's appearance settings. Event if user chooses to hide comments from blocked users, the ^-references will point to
  the right places.
