### PR TITLE
Add support for cross-platform usernames like user@lj, user@tw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.103.0] - Not released
+### Added
+- Support for cross-platform usernames, i.e. user@mokum, user@lj and so on. The
+  services shortcodes and formats should be defined in the config.json (see
+  textFormatter.foreignMentionServices in config/default.js).
+
 ## [1.102.4] - 2021-10-22
 ### Fixed
 - Fix inverted autoplay setting for Vimeo (introduced in 1.102.3)

--- a/config/default.js
+++ b/config/default.js
@@ -32,7 +32,18 @@ export default {
 
   attachments: { maxCount: 20 },
 
-  textFormatter: { tldList: TLDs },
+  textFormatter: {
+    tldList: TLDs,
+    /**
+     * The format is:
+     * [
+     *  { title: "Telegram", linkTpl: "https://t.me/{}", shortCodes: ["tg", "telegram"] },
+     *  { title: "Twitter", linkTpl: "https://twitter.com/{}", shortCodes: ["tw", "twitter"] },
+     *  ...
+     * ]
+     */
+    foreignMentionServices: [],
+  },
 
   sentry: {
     publicDSN: null,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "redux": "~4.1.1",
     "semver": "~7.3.5",
     "snarkdown": "~1.2.2",
-    "social-text-tokenizer": "~2.1.5",
+    "social-text-tokenizer": "~2.2.0",
     "socket.io-client": "~2.3.1",
     "tabbable": "~5.2.1",
     "ua-parser-js": "~0.7.28",

--- a/src/components/linkify.jsx
+++ b/src/components/linkify.jsx
@@ -1,13 +1,13 @@
 /* global CONFIG */
 import { isValidElement, cloneElement, Component } from 'react';
 import { Link } from 'react-router';
-import { Mention, Email, HashTag } from 'social-text-tokenizer';
+import { Mention, Email, HashTag, ForeignMention } from 'social-text-tokenizer';
 import { faImage } from '@fortawesome/free-regular-svg-icons';
 import { faFilm as faVideo } from '@fortawesome/free-solid-svg-icons';
 import { faInstagram, faYoutube, faVimeo } from '@fortawesome/free-brands-svg-icons';
 import classnames from 'classnames';
 
-import { Arrows, Link as TLink, parseText } from '../utils/parse-text';
+import { Arrows, Link as TLink, parseText, shortCodeToService } from '../utils/parse-text';
 import { highlightString } from '../utils/search-highlighter';
 import { FRIENDFEED_POST } from '../utils/link-types';
 import { getMediaType } from './media-viewer';
@@ -115,6 +115,14 @@ export default class Linkify extends Component {
         return anchorEl(token.href, token.shorten(MAX_URL_LENGTH));
       }
 
+      if (token instanceof ForeignMention) {
+        const srv = shortCodeToService[token.service];
+        if (srv) {
+          const url = srv.linkTpl.replace(/{}/g, token.username);
+          return anchorEl(url, token.text, `${srv.title} link`);
+        }
+      }
+
       return token.text;
     });
   };
@@ -192,9 +200,9 @@ function showMediaWithKey(showMedia) {
 }
 
 function anchorElWithKey(key) {
-  return function (href, content) {
+  return function (href, content, title = null) {
     return (
-      <a href={href} target="_blank" dir="ltr" key={key}>
+      <a href={href} target="_blank" dir="ltr" key={key} title={title}>
         {content}
       </a>
     );
@@ -202,9 +210,9 @@ function anchorElWithKey(key) {
 }
 
 function linkElWithKey(key) {
-  return function (to, content) {
+  return function (to, content, title = null) {
     return (
-      <Link to={to} dir="ltr" key={key}>
+      <Link to={to} dir="ltr" key={key} title={title}>
         {content}
       </Link>
     );

--- a/src/utils/parse-text.js
+++ b/src/utils/parse-text.js
@@ -5,6 +5,7 @@ import {
   hashTags,
   emails,
   mentions,
+  foreignMentions,
   links,
   arrows,
   Link as TLink,
@@ -19,7 +20,7 @@ import {
 } from './spoiler-tokens';
 
 const {
-  textFormatter: { tldList },
+  textFormatter: { tldList, foreignMentionServices },
   siteDomains,
 } = CONFIG;
 
@@ -131,6 +132,7 @@ const tokenize = withText(
       hashTags(),
       emails(),
       mentions(),
+      foreignMentions(),
       links({ tldRe }),
       arrows(/\u2191+|\^([1-9]\d*|\^*)/g),
       tokenizerStartSpoiler,
@@ -172,4 +174,11 @@ export function getFirstLinkToEmbed(text) {
   });
 
   return firstLink ? firstLink.href : undefined;
+}
+
+export const shortCodeToService = {};
+for (const srv of foreignMentionServices) {
+  for (const code of srv.shortCodes) {
+    shortCodeToService[code] = srv;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12561,7 +12561,7 @@ fsevents@^1.2.7:
     semver: ~7.3.5
     sinon: ~11.1.2
     snarkdown: ~1.2.2
-    social-text-tokenizer: ~2.1.5
+    social-text-tokenizer: ~2.2.0
     socket.io-client: ~2.3.1
     style-loader: ~3.2.1
     stylelint: ~13.13.1
@@ -13721,14 +13721,14 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"social-text-tokenizer@npm:~2.1.5":
-  version: 2.1.5
-  resolution: "social-text-tokenizer@npm:2.1.5"
+"social-text-tokenizer@npm:~2.2.0":
+  version: 2.2.0
+  resolution: "social-text-tokenizer@npm:2.2.0"
   dependencies:
     lodash.escaperegexp: ^4.1.2
     punycode: ^2.1.1
     tslib: ^2.3.1
-  checksum: 5ce7c99eae252cf9e0a7f26616a55caf1005862e7c49fbe799cb5e1a338bbedca98ee770da0f00382118d04457719ba6ad46d9fdfb332244917aa50058dde3de
+  checksum: 10f5e8836743512121aff72b124dfa4f3fde580762b7f82fdf0675bfa88dbafae16934207ebae530725de59aa8a1d28ee64f39568ebb15c35897d61dba538414
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The services shortcodes and formats should be defined in the config.json (see textFormatter.foreignMentionServices in config/default.js).