### PR TITLE
Fix the Embedly iframes background in the dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.103.0] - Not released
+### Fixed
+- In the dark theme, the Embedly iframes had a white background. For some
+  unclear reason we should 'color-scheme' CSS property for the iframe to make it
+  background transparent again.
+
 ## [1.102.4] - 2021-10-22
 ### Fixed
 - Fix inverted autoplay setting for Vimeo (introduced in 1.102.3)

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -501,6 +501,10 @@ $post-line-height: rem(20px);
     margin: 0 !important;
   }
 
+  iframe.embedly-card {
+    color-scheme: normal;
+  }
+
   .video-preview {
     max-width: 450px;
 


### PR DESCRIPTION
In the dark theme, the Embedly iframes had a white background. For some unclear reason we should 'color-scheme' CSS property for the iframe to make it background transparent again.