### PR TITLE
Add native previews for Apple Music

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Not released
+### Added
+- Native previews for Apple Music
+
 ## [1.102.4] - 2021-10-22
 ### Fixed
 - Fix inverted autoplay setting for Vimeo (introduced in 1.102.3)

--- a/src/components/link-preview/apple-music.jsx
+++ b/src/components/link-preview/apple-music.jsx
@@ -1,0 +1,44 @@
+const ARTIST_RE = /https?:\/\/music\.apple\.com\/([a-z]{2})\/artist\/([^/]+)\/(\d+)\?l=en.*/;
+const ALBUM_RE = /https?:\/\/music\.apple\.com\/([a-z]{2})\/album\/([^/]+)\/(\d+)\?l=en.*/;
+const SONG_RE = /https?:\/\/music\.apple\.com\/([a-z]{2})\/album\/([^/]+)\/(\d+)\?i=(\d+)&l=en.*/;
+const PLAYLIST_RE =
+  /https?:\/\/music\.apple\.com\/([a-z]{2})\/playlist\/([^/]+)\/(pl\.\w+)\?l=en.*/;
+
+export function canShowUrl(url) {
+  return (
+    url.match(ARTIST_RE) || url.match(ALBUM_RE) || url.match(SONG_RE) || url.match(PLAYLIST_RE)
+  );
+}
+
+export default function AppleMusicPreview({ url }) {
+  let src, height;
+
+  if (url.match(ARTIST_RE)) {
+    src = url.replace(ARTIST_RE, `https://embed.music.apple.com/$1/artist/$2/$3?l=en`);
+    height = 450;
+  } else if (url.match(ALBUM_RE)) {
+    src = url.replace(ALBUM_RE, `https://embed.music.apple.com/$1/album/$2/$3?l=en`);
+    height = 450;
+  } else if (url.match(SONG_RE)) {
+    src = url.replace(SONG_RE, `https://embed.music.apple.com/$1/album/$2/$3?i=$4&l=en`);
+    height = 150;
+  } else if (url.match(PLAYLIST_RE)) {
+    src = url.replace(PLAYLIST_RE, `https://embed.music.apple.com/$1/playlist/$2/$3?l=en`);
+    height = 450;
+  } else {
+    return false;
+  }
+
+  return (
+    <div className="apple-music-preview link-preview-content">
+      <iframe
+        allow="autoplay *; encrypted-media *; fullscreen *"
+        frameBorder="0"
+        height={height}
+        style={{ width: '100%', maxWidth: '660px', overflow: 'hidden', background: 'transparent' }}
+        sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation"
+        src={src}
+      />
+    </div>
+  );
+}

--- a/src/components/link-preview/preview.js
+++ b/src/components/link-preview/preview.js
@@ -10,6 +10,7 @@ import TelegramPreview, { canShowURL as telegramCanShowURL } from './telegram';
 import TikTokPreview, { canShowURL as tikTokCanShowURL } from './tiktok';
 import SoundCloudPreview, { canShowURL as soundCloudCanShowURL } from './soundcloud';
 import SpotifyPreview, { canShowURL as spotifyCanShowURL } from './spotify';
+import AppleMusicPreview, { canShowUrl as appleMusicCanShowURL } from './apple-music';
 import EmbedlyPreview from './embedly';
 
 export default function LinkPreview({ allowEmbedly, url }) {
@@ -36,6 +37,8 @@ export default function LinkPreview({ allowEmbedly, url }) {
     return <SoundCloudPreview url={url} />;
   } else if (spotifyCanShowURL(url)) {
     return <SpotifyPreview url={url} />;
+  } else if (appleMusicCanShowURL(url)) {
+    return <AppleMusicPreview url={url} />;
   }
 
   if (allowEmbedly) {

--- a/test/jest/__snapshots__/link-preview.test.js.snap
+++ b/test/jest/__snapshots__/link-preview.test.js.snap
@@ -513,6 +513,23 @@ exports[`LinkPreview Shows a video preview for Youtube 2`] = `
 </DocumentFragment>
 `;
 
+exports[`LinkPreview Shows an Apple Music preview 1`] = `
+<DocumentFragment>
+  <div
+    class="apple-music-preview link-preview-content"
+  >
+    <iframe
+      allow="autoplay *; encrypted-media *; fullscreen *"
+      frameborder="0"
+      height="150"
+      sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation"
+      src="https://embed.music.apple.com/ru/album/dont-ask-me-why/1441018520?i=1441018529&l=en"
+      style="width: 100%; max-width: 660px; overflow: hidden; background: transparent;"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`LinkPreview Shows an Instagram preview 1`] = `
 <DocumentFragment>
   <div>

--- a/test/jest/link-preview.test.js
+++ b/test/jest/link-preview.test.js
@@ -244,4 +244,12 @@ describe('LinkPreview', () => {
 
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('Shows an Apple Music preview', () => {
+    const { asFragment } = renderLinkPreview({
+      url: 'https://music.apple.com/ru/album/dont-ask-me-why/1441018520?i=1441018529&l=en',
+    });
+
+    expect(asFragment()).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
This PR adds native iframe-based embeds for Artists, Albums, Songs and Playlists from Apple Music service.

Embeds are generated using current official embed-code provided by Apple Music

![me   Cinderella  (indeyets) - FreeFeed 2021-11-10 20-54-24](https://user-images.githubusercontent.com/13445/141166889-5629a1d4-6ff5-43ef-aebe-5fd3b2aa3725.jpg)