### PR TITLE
Remove extra "saving/unsaving" indicator

### DIFF
--- a/src/components/post-more-link.jsx
+++ b/src/components/post-more-link.jsx
@@ -10,7 +10,6 @@ import { useMediaQuery } from './hooks/media-query';
 import { useServerInfo } from './hooks/server-info';
 import { PostMoreMenu } from './post-more-menu';
 import { MoreWithTriangle } from './more-with-triangle';
-import { TimedMessage } from './timed-message';
 import { ButtonLink } from './button-link';
 
 export default function PostMoreLink({ post, user, ...props }) {
@@ -32,19 +31,6 @@ export default function PostMoreLink({ post, user, ...props }) {
   const perGroupDeleteEnabled = serverInfoStatus.success && serverInfo.features.perGroupsPostDelete;
 
   const canonicalPostURI = canonicalURI(post);
-
-  const { isSaved, savePostStatus } = post;
-
-  let label = 'More';
-  if (savePostStatus.loading) {
-    label = isSaved ? 'Un-saving...' : 'Saving...';
-  }
-  if (savePostStatus.success) {
-    label = <TimedMessage message={isSaved ? 'Saved!' : 'Un-saved!'}>More</TimedMessage>;
-  }
-  if (savePostStatus.error) {
-    label = <TimedMessage message="Error!">More</TimedMessage>;
-  }
 
   useEffect(() => {
     if (fixedMenu && opened) {
@@ -70,7 +56,7 @@ export default function PostMoreLink({ post, user, ...props }) {
         aria-haspopup
         aria-expanded={opened}
       >
-        <MoreWithTriangle>{label}</MoreWithTriangle>
+        <MoreWithTriangle>More</MoreWithTriangle>
       </ButtonLink>
       {opened && (
         <Portal>

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -141,7 +141,6 @@ $post-line-height: rem(20px);
 
   @media (max-width: 500px) {
     display: block;
-    margin: 0;
   }
 }
 
@@ -160,12 +159,6 @@ $post-line-height: rem(20px);
     display: inline-block;
     width: 1em;
     text-align: center;
-  }
-
-  @media (max-width: 500px) {
-    &:first-child::before {
-      display: none;
-    }
   }
 }
 


### PR DESCRIPTION
Removed extra "saving/unsaving" indicator that I forgot to remove after moving "Save" out of "More" menu, and fixed a style bug with post actions on narrow screens.


<img width="148" alt="Screenshot 2021-11-14 at 16 55 16" src="https://user-images.githubusercontent.com/632081/141706822-d242db4f-72b3-425c-baab-9d0d3693863e.png">


