### PR TITLE
Remove extra whitespace around post actions list

### DIFF
--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -151,6 +151,7 @@ $post-line-height: rem(20px);
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
+  vertical-align: bottom;
 
   &:empty {
     display: none;


### PR DESCRIPTION
This PR removes extra whitespace around post actions list (cause: `display: inline-block` + `overflow: hidden`, see https://stackoverflow.com/a/22425601/155336). 

### Narrow:

Before:
<img width="491" alt="before-narrow-Screenshot 2021-11-16 at 23 47 13" src="https://user-images.githubusercontent.com/632081/142158254-60325494-7b32-4dd7-86b8-381c0be736a5.png"> 

After:
<img width="490" alt="after-narrow-Screenshot 2021-11-16 at 23 46 58" src="https://user-images.githubusercontent.com/632081/142158239-005cd4b9-4e03-4cf7-9e1b-5c65568835b1.png">

### Wide

Before:
<img width="745" alt="before-wide-Screenshot 2021-11-16 at 23 46 09" src="https://user-images.githubusercontent.com/632081/142158259-d58489ef-9770-4a69-ab9a-faf5a7a1f01d.png">

After:
<img width="729" alt="after-wide-Screenshot 2021-11-16 at 23 46 24" src="https://user-images.githubusercontent.com/632081/142158249-c2c05fe8-0c55-4b06-9bd9-ee3e20ab711c.png">
