### PR TITLE
Add mutual links to hide- and blocklists (#1463)

### DIFF
--- a/src/components/friends-page/blocked.jsx
+++ b/src/components/friends-page/blocked.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useCallback } from 'react';
+import { Link } from 'react-router';
 import cn from 'classnames';
 import { useSelector, useDispatch } from 'react-redux';
 import { Helmet } from 'react-helmet';
@@ -61,6 +62,11 @@ export function Blocked() {
       ) : (
         <p>You have no blocked users.</p>
       )}
+
+      <p>
+        Alternatively, you can hide posts from users or groups in the{' '}
+        <Link to="/settings/appearance#hide-list">Appearance settings</Link>.
+      </p>
     </>
   );
 }

--- a/src/components/settings/forms/appearance.jsx
+++ b/src/components/settings/forms/appearance.jsx
@@ -1,5 +1,6 @@
 /* global CONFIG */
 import { useMemo, useEffect } from 'react';
+import { Link } from 'react-router';
 import { useDispatch, useSelector } from 'react-redux';
 import { useForm, useField } from 'react-final-form-hooks';
 import { without, uniq } from 'lodash';
@@ -133,7 +134,7 @@ export default function AppearanceForm() {
       </section>
 
       <section className={settingsStyles.formSection}>
-        <h4 id="home">Your Home feed content</h4>
+        <h4 id="home">Your Home feed</h4>
 
         <div className="form-group">
           <div className="radio">
@@ -156,7 +157,12 @@ export default function AppearanceForm() {
               Also your friends&#x2019; activity in groups you are not subscribed to
             </label>
           </div>
+        </div>
+      </section>
 
+      <section className={settingsStyles.formSection}>
+        <h4 id="hide-list">Hidden content</h4>
+        <div className="form-group">
           <p>Apply posts and users hides:</p>
           <div className="form-group">
             <div className="radio">
@@ -184,6 +190,10 @@ export default function AppearanceForm() {
               {...hiddenUsers.input}
             />
             <p className="help-block">Comma-separated list of usernames and group names</p>
+            <p className="help-block">
+              To view the “Blocked users” list, visit{' '}
+              <Link to="/friends?show=blocked">this page</Link>.
+            </p>
           </div>
         </div>
       </section>


### PR DESCRIPTION
PR addresses issue https://github.com/FreeFeed/freefeed-react-client/issues/1463

Done:
/settings/appearance page:
- split "Your Home feed content" into 2 sections: "Your Home feed" and "Hidden content"
- added the link to `/friends?show=blocked` at the bottom of the new section

/friends?show=blocked page:
- added the link to the "Hidden content" in the settings

How to test:
- open the /settings/appearance page, click on the link
- open the /friends?show=blocked page, click on the link
