### PR TITLE
Add a GitHub workflow for creating a PR preview on surge.sh

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,6 +21,6 @@ jobs:
             yarn build-prod
             cp _dist/index.html _dist/200.html
             rm _dist/stats.json
-            echo "{}" > _dist/config.json
+            echo \"{}\" > _dist/config.json
       - name: Get the preview_url
         run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,5 +21,6 @@ jobs:
             yarn build-prod
             cp _dist/index.html _dist/200.html
             rm _dist/stats.json
+            echo "{}" > _dist/config.json
       - name: Get the preview_url
         run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,8 +19,8 @@ jobs:
           build: |
             yarn
             yarn build-prod
+            yarn create_config_json
             cp _dist/index.html _dist/200.html
             rm _dist/stats.json
-            echo \"{}\" > _dist/config.json
       - name: Get the preview_url
         run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,25 @@
+name: Surge PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: afc163/surge-preview@v1
+        id: preview_step
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: _dist
+          teardown: 'true'
+          build: |
+            yarn
+            yarn build-prod
+            cp _dist/index.html _dist/200.html
+            rm _dist/stats.json
+      - name: Get the preview_url
+        run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.104] - Not released
+### Added
+- GitHub workflow for creating PR preview on surge.sh
+
 ## [1.103.1] - 2021-11-12
 ### Fixed
 - Accept Apple-music urls without ?l= parameter

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "_webpack": "webpack --config webpack.config.babel.js --output-path ./_dist",
     "_webpack:bookmarklet": "webpack --config webpack.bookmarklet.config.babel.js --output-path ./_dist",
     "analyze-webpack": "webpack-bundle-analyzer _dist/stats.json",
+    "create_config_json": "echo \"{}\" > ./_dist/config.json",
     "postinstall": "husky install"
   },
   "author": "FreeFeed contributors",


### PR DESCRIPTION
Uses https://github.com/marketplace/actions/surge-pr-preview action. Needs a Surge access token as SURGE_TOKEN in repo's secrets.