### PR TITLE
Refactor post like link into a separate component

### DIFF
--- a/src/components/post-like-link.jsx
+++ b/src/components/post-like-link.jsx
@@ -1,0 +1,27 @@
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+
+import { Icon } from './fontawesome-icons';
+import { Throbber } from './throbber';
+import { ButtonLink } from './button-link';
+
+const PostLikeLink = (props) => {
+  const { didILikePost, likeError, onLikePost, onUnlikePost, isLiking } = props;
+
+  return (
+    <>
+      {likeError ? (
+        <Icon icon={faExclamationTriangle} className="post-like-fail" title={likeError} />
+      ) : null}
+      <ButtonLink className="post-action" onClick={didILikePost ? onUnlikePost : onLikePost}>
+        {didILikePost ? 'Un-like' : 'Like'}
+      </ButtonLink>
+      {isLiking ? (
+        <span className="post-like-throbber">
+          <Throbber />
+        </span>
+      ) : null}
+    </>
+  );
+};
+
+export default PostLikeLink;

--- a/src/components/post.jsx
+++ b/src/components/post.jsx
@@ -36,6 +36,7 @@ import Expandable from './expandable';
 import PieceOfText from './piece-of-text';
 import Dropzone from './dropzone';
 import PostMoreLink from './post-more-link';
+import PostLikeLink from './post-like-link';
 import TimeDisplay from './time-display';
 import LinkPreview from './link-preview/preview';
 import SendTo from './send-to';
@@ -379,24 +380,13 @@ class Post extends Component {
     const didILikePost = _.find(props.usersLikedPost, { id: props.user.id });
     const likeLink =
       amIAuthenticated && !props.isEditable ? (
-        <>
-          {props.likeError ? (
-            <Icon icon={faExclamationTriangle} className="post-like-fail" title={props.likeError} />
-          ) : null}
-          <ButtonLink
-            className="post-action"
-            onClick={didILikePost ? this.unlikePost : this.likePost}
-          >
-            {didILikePost ? 'Un-like' : 'Like'}
-          </ButtonLink>
-          {props.isLiking ? (
-            <span className="post-like-throbber">
-              <Throbber />
-            </span>
-          ) : (
-            false
-          )}
-        </>
+        <PostLikeLink
+          onLikePost={this.likePost}
+          onUnlikePost={this.unlikePost}
+          didILikePost={didILikePost}
+          likeError={props.likeError}
+          isLiking={props.isLiking}
+        />
       ) : (
         false
       );


### PR DESCRIPTION
This PR moves post like link out of post.jsx into a separate component to lower complexity (42 -> 40). No functional changes.