### PR TITLE
Fix some destination feeds showing bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.104.0] - Not released
+### Fixed
+- Internal bugs related to the showing of direct post destination feeds during
+  and after editing
+
 ## [1.103.1] - 2021-11-12
 ### Fixed
 - Accept Apple-music urls without ?l= parameter

--- a/src/components/send-to.jsx
+++ b/src/components/send-to.jsx
@@ -69,16 +69,14 @@ class SendTo extends Component {
         defaultFeeds.push(props.defaultFeed);
       }
     }
-    const values = options.filter((opt) => defaultFeeds.includes(opt.value));
-    if (values.length === 0 && defaultFeeds.length > 0) {
-      values.push(...defaultFeeds.map((f) => ({ label: f, value: f })));
-    }
+    let values = [];
     if (props.isDirects && props.isEditing) {
-      // freeze default values
-      for (const val of values) {
-        if (defaultFeeds.includes(val.value)) {
-          val.clearableValue = false;
-        }
+      // Set and freeze default values
+      values.push(...defaultFeeds.map((f) => ({ label: f, value: f, clearableValue: false })));
+    } else {
+      values = options.filter((opt) => defaultFeeds.includes(opt.value));
+      if (values.length === 0 && defaultFeeds.length > 0) {
+        values.push(...defaultFeeds.map((f) => ({ label: f, value: f })));
       }
     }
     return {

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -1124,7 +1124,8 @@ export function subscriptions(state = {}, action) {
     case response(ActionTypes.WHO_AM_I):
     case response(ActionTypes.GET_SINGLE_POST):
     case response(ActionTypes.COMPLETE_POST_COMMENTS):
-    case response(ActionTypes.CREATE_POST): {
+    case response(ActionTypes.CREATE_POST):
+    case response(ActionTypes.SAVE_EDITING_POST): {
       return mergeByIds(state, action.payload.subscriptions);
     }
     case ActionTypes.REALTIME_POST_NEW: {


### PR DESCRIPTION
1. In some situations, when editing a direct post, not all of its recipients were shown;
2. After adding a recipient to direct, he did not show up in the list of recipients until the page refreshes.