### PR TITLE
Fix minor issues on public groups list

### DIFF
--- a/src/components/all-groups.jsx
+++ b/src/components/all-groups.jsx
@@ -156,7 +156,7 @@ function GroupsList({ pageSize, routerReplace }) {
                 Authors variety
               </SortHeader>
               <SortHeader mode={SORT_BY_DATE} currentMode={sort}>
-                Creation date
+                Created
               </SortHeader>
             </tr>
           </thead>
@@ -191,7 +191,7 @@ function SortHeader({ children, mode, currentMode }) {
     <th
       className={cn(
         styles.sortableHeader,
-        mode === currentMode && styles.inactive,
+        mode !== currentMode && styles.inactive,
         styles[`${mode}Column`],
       )}
     >
@@ -215,8 +215,8 @@ const GroupRow = memo(function GroupRow({ g }) {
           <UserName user={u}>{u.username}</UserName>
           {u.username !== u.screenName && <div className="small">{u.screenName}</div>}
           {u.isProtected === '1' && (
-            <div className="muted-text small">
-              <Icon icon={faUserFriends} title="Protected group" />
+            <div className="text-muted small">
+              <Icon icon={faUserFriends} /> Protected group
             </div>
           )}
         </div>

--- a/src/components/all-groups.module.scss
+++ b/src/components/all-groups.module.scss
@@ -6,6 +6,7 @@
 
   &:hover {
     background-color: #ffc;
+
     :global(.dark-theme) & {
       background-color: $bg-color-lighter;
     }
@@ -14,6 +15,7 @@
   a {
     color: inherit;
     text-decoration: none;
+
     :global(.dark-theme) & {
       color: $text-color;
     }
@@ -36,20 +38,23 @@
 }
 
 .mainColumn {
-  width: 180px;
+  width: 200px;
 }
 
 .subscribersColumn {
   width: 110px;
 }
+
 .postsColumn {
   width: 140px;
 }
+
 .varietyColumn {
   width: 130px;
 }
+
 .dateColumn {
-  width: 120px;
+  width: 100px;
 }
 
 .groupRow {
@@ -58,6 +63,7 @@
     padding-left: 1em;
     border-bottom: 1px solid #ccc;
     text-align: right;
+
     &:first-child {
       padding-left: 0;
       text-align: left;
@@ -76,6 +82,7 @@
     padding-left: 1em;
     border-bottom: 2px solid #ccc;
     text-align: right;
+
     &:first-child {
       padding-left: 0;
       text-align: left;


### PR DESCRIPTION
This PR fixes several minor issues on "Public groups" page:

1. wrong color of active/inactive sorting indicator
2. wrong "muted text" classname
3. shortened "Created date" header to "Created"
4. gave extra 20 pixels to main column so that more group names can fit without word-break (e.g. `gamesgamesgames`)

Before:
<img width="721" alt="Screenshot 2022-01-02 at 12 43 38" src="https://user-images.githubusercontent.com/632081/147889137-7441114e-7503-4237-aae9-8a717ef02c61.png">

After:
<img width="713" alt="Screenshot 2022-01-02 at 12 43 02" src="https://user-images.githubusercontent.com/632081/147889134-d013fe76-1582-41b6-ae53-3cd7eecf8930.png">

