### PR TITLE
Display subscription requests alert box on user's own feed

### DIFF
--- a/src/components/home-aux.jsx
+++ b/src/components/home-aux.jsx
@@ -11,7 +11,8 @@ import { HomeFeedLink, homeFeedURI } from './home-feed-link';
 import PaginatedView from './paginated-view';
 import Feed from './feed';
 import { postActions } from './select-utils';
-import { SubscrRequests, TopHomeSelector } from './home';
+import { TopHomeSelector } from './home';
+import { SubscriptionRequestsAlert } from './susbscription-requests-alert';
 import { lazyComponent } from './lazy-component';
 import { useBool } from './hooks/bool';
 import { ButtonLink } from './button-link';
@@ -149,7 +150,7 @@ export function HomeAux({ router }) {
         </div>
         {isEditing && <ListEditor listId={feed.id} close={closeEditor} />}
 
-        <SubscrRequests />
+        <SubscriptionRequestsAlert className="box-message" />
 
         <PaginatedView>
           <FeedWithProps

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -1,15 +1,15 @@
-import { memo, useCallback } from 'react';
+import { useCallback } from 'react';
 import { connect, useSelector, useDispatch } from 'react-redux';
-import { Link, withRouter } from 'react-router';
+import { withRouter } from 'react-router';
 
 import { createPost, resetPostCreateForm, expandSendTo, home } from '../redux/action-creators';
-import { pluralForm } from '../utils';
 import { postActions } from './select-utils';
 import CreatePost from './create-post';
 import Feed from './feed';
 import PaginatedView from './paginated-view';
 import FeedOptionsSwitch from './feed-options-switch';
 import Welcome from './welcome';
+import { SubscriptionRequestsAlert } from './susbscription-requests-alert';
 import ErrorBoundary from './error-boundary';
 import { ButtonLink } from './button-link';
 import { useBool } from './hooks/bool';
@@ -71,7 +71,7 @@ const FeedHandler = (props) => {
         </div>
         {isEditing && <ListEditor listId={feedId} close={closeEditor} />}
 
-        <SubscrRequests />
+        <SubscriptionRequestsAlert className="box-message" />
 
         <PaginatedView firstPageHead={createPostComponent} {...props}>
           <Feed {...props} isInHomeFeed={!props.feedIsLoading} />
@@ -111,44 +111,6 @@ function selectActions(dispatch) {
 }
 
 export default connect(selectState, selectActions)(FeedHandler);
-
-export const SubscrRequests = memo(function SubscrRequests() {
-  const userRequestsCount = useSelector((state) => state.userRequestsCount);
-  const groupRequestsCount = useSelector((state) => state.groupRequestsCount);
-
-  const uLink = userRequestsCount && (
-    <Link key="uLink" to="/friends?show=requests">
-      {pluralForm(userRequestsCount, 'subscription request')}
-    </Link>
-  );
-
-  const gLink = groupRequestsCount && (
-    <Link key="gLink" to="/friends?show=requests">
-      {pluralForm(groupRequestsCount, 'group subscription request')}
-    </Link>
-  );
-
-  const links = [uLink, gLink].filter(Boolean);
-  if (links.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="box-message alert alert-info">
-      <span className="message">
-        <span>
-          <span>You have </span>
-          {links.map((link, i) => (
-            <span key={link.key}>
-              {i > 0 && ' and '}
-              {link}
-            </span>
-          ))}
-        </span>
-      </span>
-    </div>
-  );
-});
 
 export const TopHomeSelector = withRouter(function TopHomeSelector({ router, id, feedLabelId }) {
   const homeFeeds = useSelector((state) => state.homeFeeds);

--- a/src/components/susbscription-requests-alert.jsx
+++ b/src/components/susbscription-requests-alert.jsx
@@ -1,0 +1,42 @@
+import React, { memo } from 'react';
+import classNames from 'classnames';
+import { useSelector } from 'react-redux';
+import { Link } from 'react-router';
+
+import { pluralForm } from '../utils';
+
+export const SubscriptionRequestsAlert = memo(function SubscriptionRequestsAlert({ className }) {
+  const userRequestsCount = useSelector((state) => state.userRequestsCount);
+  const groupRequestsCount = useSelector((state) => state.groupRequestsCount);
+
+  const uLink = userRequestsCount && (
+    <Link key="uLink" to="/friends?show=requests">
+      {pluralForm(userRequestsCount, 'subscription request')}
+    </Link>
+  );
+
+  const gLink = groupRequestsCount && (
+    <Link key="gLink" to="/friends?show=requests">
+      {pluralForm(groupRequestsCount, 'group subscription request')}
+    </Link>
+  );
+
+  const links = [uLink, gLink].filter(Boolean);
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={classNames(className, 'subscriptions-request-alert')}>
+      <span className="message">
+        You have{' '}
+        {links.map((link, i) => (
+          <React.Fragment key={link.key}>
+            {i > 0 && ' and '}
+            {link}
+          </React.Fragment>
+        ))}
+      </span>
+    </div>
+  );
+});

--- a/src/components/user-profile.jsx
+++ b/src/components/user-profile.jsx
@@ -5,6 +5,7 @@ import { pluralForm } from '../utils';
 import CreatePost from './create-post';
 import ErrorBoundary from './error-boundary';
 import { UserProfileHead } from './user-profile-head';
+import { SubscriptionRequestsAlert } from './susbscription-requests-alert';
 
 export default function UserProfile(props) {
   const authenticated = useSelector((state) => state.authenticated);
@@ -16,9 +17,10 @@ export default function UserProfile(props) {
   return (
     <div>
       <ErrorBoundary>
-        <UserProfileHead />
+        {props.isItMe && !props.isLoading ? <SubscriptionRequestsAlert /> : false}
+
         {groupRequestsCount > 0 && (
-          <p className="alert alert-info">
+          <p className="subscriptions-request-alert">
             <span className="message">
               You have{' '}
               <Link to="/groups">{pluralForm(groupRequestsCount, 'subscription request')}</Link> to
@@ -26,6 +28,8 @@ export default function UserProfile(props) {
             </span>
           </p>
         )}
+
+        <UserProfileHead />
 
         {props.canIPostHere && (
           <CreatePost

--- a/styles/helvetica/boxes.scss
+++ b/styles/helvetica/boxes.scss
@@ -222,3 +222,11 @@
   vertical-align: rem(1px);
   margin-left: 0.5em;
 }
+
+.subscriptions-request-alert {
+  padding: 0.3125rem 0.625rem;
+  border: 1px solid #bce8f1;
+  border-radius: 4px;
+  background-color: #d9edf7;
+  color: #31708f;
+}


### PR DESCRIPTION
This PR adds subscription requests alert box to user's own profile feed:

No changes in homefeed:
<img width="702" alt="Screenshot 2022-01-11 at 21 34 24" src="https://user-images.githubusercontent.com/632081/149073018-01a74f23-dc19-4628-aeab-f0fa7e7960b8.png">

New box in own profile feed:
<img width="709" alt="Screenshot 2022-01-11 at 21 34 10" src="https://user-images.githubusercontent.com/632081/149073016-7a97d8e2-85ca-4fdf-86e9-f751dd68d756.png">
