### PR TITLE
Update "privacy" cookie if it is already set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.107.0] - Not released
+### Fixed
+- Update "privacy" cookie if it is already set. It should prevent 2-weeks cookie
+  expiration in Safari.
 
 ## [1.106.1] - 2022-02-03
 ### Fixed

--- a/index.jade
+++ b/index.jade
@@ -111,7 +111,8 @@ html(lang='en')
 
     script.
       (function(w,d){
-        var PRIVACY_COOKIE_NAME = 'privacy'
+        var PRIVACY_COOKIE_NAME = 'privacy';
+        var PRIVACY_COOKIE_DAYS = 730;
         function parseCookies() {
           return (d.cookie || '').split(';').reduce(function(res, cookieStr){
             var cookieData = cookieStr.trim().split('=')
@@ -146,7 +147,7 @@ html(lang='en')
           acceptButton.innerText = 'Accept'
           acceptButton.classList.add('privacy-button')
           acceptButton.addEventListener('click', function(){
-            setCookie(PRIVACY_COOKIE_NAME, 'true',  730)
+            setCookie(PRIVACY_COOKIE_NAME, 'true',  PRIVACY_COOKIE_DAYS)
             document.body.removeChild(privacyPopup)
           })
           privacyPopup.appendChild(privacyText)
@@ -156,6 +157,8 @@ html(lang='en')
         var privacyCookie = getCookie(PRIVACY_COOKIE_NAME)
         if (!privacyCookie) {
           showPrivacyPopup()
+        } else {
+          setCookie(PRIVACY_COOKIE_NAME, 'true',  PRIVACY_COOKIE_DAYS)
         }
       })(window, document);
 


### PR DESCRIPTION
It should prevent 2-weeks cookie expiration in Safari