### PR TITLE
Update header text for memories page

### DIFF
--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -1234,12 +1234,12 @@ export function boxHeader(state = '', action) {
       return `Search`;
     }
     case request(ActionTypes.MEMORIES): {
-      return `Memories: posts from ${formatDateFromShortString(action.payload.from)} and earlier`;
+      return `Memories: posts from ${formatDateFromShortString(action.payload.from)} and older`;
     }
     case request(ActionTypes.GET_USER_MEMORIES): {
       return `${action.payload.username} memories: posts from ${formatDateFromShortString(
         action.payload.from,
-      )} and earlier`;
+      )} and older`;
     }
     case request(ActionTypes.GET_BEST_OF): {
       return `Best Of ${CONFIG.siteTitle}`;


### PR DESCRIPTION
This PR changes the word "earlier" in Memories page header to "older" to match labels on navigation buttons.

<img width="725" alt="Screenshot 2022-03-06 at 16 58 21" src="https://user-images.githubusercontent.com/632081/156950798-ceec7015-5aff-4204-93f8-76ebfb8f777f.png">

