### PR TITLE
Check that iframe ref is not null before changing its style

### DIFF
--- a/src/components/link-preview/instagram.jsx
+++ b/src/components/link-preview/instagram.jsx
@@ -29,8 +29,10 @@ export default function InstagramPreview({ url }) {
   useEffect(() => {
     startEventListening();
     // set default frame height
-    const r = aspectRatio.get(url, 470 / 400);
-    iframeRef.current.style.height = `${iframeRef.current.offsetWidth * r}px`;
+    if (iframeRef.current) {
+      const r = aspectRatio.get(url, 470 / 400);
+      iframeRef.current.style.height = `${iframeRef.current.offsetWidth * r}px`;
+    }
   }, [url]);
 
   if (isPrivate) {


### PR DESCRIPTION
This PR fixes (?) a rare case when instagram preview throws an exception: https://freefeed.net/support/c30f53b2-e78e-4ba3-a9aa-121a499bc723. I wasn't able to reproduce the bug.