### PR TITLE
 Add "more details" block to profile head with registration date

### DIFF
--- a/src/components/user-profile-head-stats.jsx
+++ b/src/components/user-profile-head-stats.jsx
@@ -1,0 +1,89 @@
+import { Link } from 'react-router';
+import cn from 'classnames';
+
+import { pluralForm } from '../utils';
+import styles from './user-profile-head.module.scss';
+
+export const UserProfileHeadStats = ({ user, canFollowStatLinks }) => {
+  const isNotGroup = user.type === 'user';
+
+  const { username } = user;
+
+  const subscriptions = parseInt(user.statistics.subscriptions);
+  const subscribers = parseInt(user.statistics.subscribers);
+  const comments = parseInt(user.statistics.comments);
+  const likes = parseInt(user.statistics.likes);
+
+  return (
+    <div className={styles.stats}>
+      {!user.isGone && user.statistics && (
+        <ul className={styles.statsItems}>
+          {isNotGroup && (
+            <StatLink
+              value={subscriptions}
+              title="subscription"
+              linkTo={`/${username}/subscriptions`}
+              canFollow={canFollowStatLinks}
+            />
+          )}
+
+          <StatLink
+            value={subscribers}
+            title="subscriber"
+            linkTo={`/${username}/subscribers`}
+            canFollow={canFollowStatLinks}
+          />
+
+          {isNotGroup && (
+            <>
+              <StatLink
+                title="All posts"
+                linkTo={`/search?q=${encodeURIComponent(`from:${username}`)}`}
+                canFollow={canFollowStatLinks}
+                className={styles.allPosts}
+              />
+              <StatLink
+                value={comments}
+                title="comment"
+                linkTo={`/${username}/comments`}
+                canFollow={canFollowStatLinks}
+              />
+              <StatLink
+                value={likes}
+                title="like"
+                linkTo={`/${username}/likes`}
+                canFollow={canFollowStatLinks}
+              />
+            </>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+function StatLink({ value, title, linkTo, canFollow, className }) {
+  let content;
+
+  if (typeof value === 'undefined') {
+    content = title;
+  } else if (typeof value === 'number') {
+    if (value < 0) {
+      return null;
+    }
+
+    content = pluralForm(value, title);
+  }
+
+  if (canFollow) {
+    content = (
+      <Link to={linkTo} className={styles.statlinkText}>
+        {content}
+      </Link>
+    );
+  } else {
+    content = <span className={styles.statlinkText}>{content}</span>;
+  }
+
+  return <li className={cn(styles.statlink, className)}>{content}</li>;
+}

--- a/src/components/user-profile-head-stats.jsx
+++ b/src/components/user-profile-head-stats.jsx
@@ -1,63 +1,97 @@
+import { useState, useCallback } from 'react';
 import { Link } from 'react-router';
 import cn from 'classnames';
 
 import { pluralForm } from '../utils';
 import styles from './user-profile-head.module.scss';
+import TimeDisplay from './time-display';
 
 export const UserProfileHeadStats = ({ user, canFollowStatLinks }) => {
-  const isNotGroup = user.type === 'user';
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleDetails = useCallback(() => setIsOpen(!isOpen), [isOpen]);
 
-  const { username } = user;
+  if (user.isGone || !user.statistics) {
+    return null;
+  }
 
-  const subscriptions = parseInt(user.statistics.subscriptions);
-  const subscribers = parseInt(user.statistics.subscribers);
-  const comments = parseInt(user.statistics.comments);
-  const likes = parseInt(user.statistics.likes);
+  const { username, createdAt, statistics, type } = user;
+  const isUser = type === 'user';
 
-  return (
-    <div className={styles.stats}>
-      {!user.isGone && user.statistics && (
+  const subscriptions = parseInt(statistics.subscriptions);
+  const subscribers = parseInt(statistics.subscribers);
+  const comments = parseInt(statistics.comments);
+  const likes = parseInt(statistics.likes);
+
+  if (!isUser) {
+    return (
+      <div className={styles.stats}>
         <ul className={styles.statsItems}>
-          {isNotGroup && (
-            <StatLink
-              value={subscriptions}
-              title="subscription"
-              linkTo={`/${username}/subscriptions`}
-              canFollow={canFollowStatLinks}
-            />
-          )}
-
           <StatLink
             value={subscribers}
             title="subscriber"
             linkTo={`/${username}/subscribers`}
             canFollow={canFollowStatLinks}
           />
-
-          {isNotGroup && (
-            <>
-              <StatLink
-                title="All posts"
-                linkTo={`/search?q=${encodeURIComponent(`from:${username}`)}`}
-                canFollow={canFollowStatLinks}
-                className={styles.allPosts}
-              />
-              <StatLink
-                value={comments}
-                title="comment"
-                linkTo={`/${username}/comments`}
-                canFollow={canFollowStatLinks}
-              />
-              <StatLink
-                value={likes}
-                title="like"
-                linkTo={`/${username}/likes`}
-                canFollow={canFollowStatLinks}
-              />
-            </>
-          )}
         </ul>
-      )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.stats}>
+      <ul className={styles.statsItems}>
+        <StatLink
+          value={subscriptions}
+          title="subscription"
+          linkTo={`/${username}/subscriptions`}
+          canFollow={canFollowStatLinks}
+        />
+        <StatLink
+          value={subscribers}
+          title="subscriber"
+          linkTo={`/${username}/subscribers`}
+          canFollow={canFollowStatLinks}
+        />
+        {isOpen ? (
+          <>
+            <StatLink
+              title="All posts"
+              linkTo={`/search?q=${encodeURIComponent(`from:${username}`)}`}
+              canFollow={canFollowStatLinks}
+              className={styles.allPosts}
+            />
+            <StatLink
+              value={comments}
+              title="comment"
+              linkTo={`/${username}/comments`}
+              canFollow={canFollowStatLinks}
+            />
+            <StatLink
+              value={likes}
+              title="like"
+              linkTo={`/${username}/likes`}
+              canFollow={canFollowStatLinks}
+            />
+            <li className={styles.statlink}>
+              <span className={styles.statlinkText}>
+                <span className={styles.registeredOn}>Since</span>{' '}
+                <TimeDisplay inline timeStamp={parseInt(createdAt)} />
+              </span>
+            </li>
+            <li className={styles.statlink}>
+              <Link className={styles.moreDetails} onClick={toggleDetails}>
+                Less details
+              </Link>
+            </li>
+          </>
+        ) : (
+          <li className={styles.statlink}>
+            <Link className={styles.moreDetails} onClick={toggleDetails}>
+              More details...
+            </Link>
+          </li>
+        )}
+      </ul>
     </div>
   );
 };

--- a/src/components/user-profile-head.jsx
+++ b/src/components/user-profile-head.jsx
@@ -1,9 +1,8 @@
 /* global CONFIG */
 import { useEffect, useMemo, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Link, withRouter } from 'react-router';
+import { withRouter } from 'react-router';
 import { Portal } from 'react-portal';
-import cn from 'classnames';
 import {
   faGlobeAmericas,
   faUserFriends,
@@ -15,7 +14,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { faSmile, faCheckCircle as faCheckCircleO } from '@fortawesome/free-regular-svg-icons';
 
-import { pluralForm } from '../utils';
 import { initialAsyncState } from '../redux/async-helpers';
 import {
   getUserInfo,
@@ -40,64 +38,7 @@ import styles from './user-profile-head.module.scss';
 import { UserSubscriptionEditPopup } from './user-subscription-edit-popup';
 import { HomeFeedLink } from './home-feed-link';
 import { UserProfileHeadActions } from './user-profile-head-actions';
-
-const UserStats = ({ user, canFollowStatLinks }) => {
-  const isNotGroup = user.type === 'user';
-
-  const { username } = user;
-
-  const subscriptions = parseInt(user.statistics.subscriptions);
-  const subscribers = parseInt(user.statistics.subscribers);
-  const comments = parseInt(user.statistics.comments);
-  const likes = parseInt(user.statistics.likes);
-
-  return (
-    <div className={styles.stats}>
-      {!user.isGone && user.statistics && (
-        <ul className={styles.statsItems}>
-          {isNotGroup && (
-            <StatLink
-              value={subscriptions}
-              title="subscription"
-              linkTo={`/${username}/subscriptions`}
-              canFollow={canFollowStatLinks}
-            />
-          )}
-
-          <StatLink
-            value={subscribers}
-            title="subscriber"
-            linkTo={`/${username}/subscribers`}
-            canFollow={canFollowStatLinks}
-          />
-
-          {isNotGroup && (
-            <>
-              <StatLink
-                title="All posts"
-                linkTo={`/search?q=${encodeURIComponent(`from:${username}`)}`}
-                canFollow={canFollowStatLinks}
-                className={styles.allPosts}
-              />
-              <StatLink
-                value={comments}
-                title="comment"
-                linkTo={`/${username}/comments`}
-                canFollow={canFollowStatLinks}
-              />
-              <StatLink
-                value={likes}
-                title="like"
-                linkTo={`/${username}/likes`}
-                canFollow={canFollowStatLinks}
-              />
-            </>
-          )}
-        </ul>
-      )}
-    </div>
-  );
-};
+import { UserProfileHeadStats } from './user-profile-head-stats';
 
 export const UserProfileHead = withRouter(
   withKey(({ router }) => router.params.userName)(function UserProfileHead({ router }) {
@@ -349,7 +290,7 @@ export const UserProfileHead = withRouter(
           </>
         )}
 
-        <UserStats user={user} canFollowStatLinks={canFollowStatLinks} />
+        <UserProfileHeadStats user={user} canFollowStatLinks={canFollowStatLinks} />
 
         {subscrFormOpened && (
           <Portal>
@@ -467,30 +408,4 @@ function RelationshipIndicator({
       {label}
     </span>
   );
-}
-
-function StatLink({ value, title, linkTo, canFollow, className }) {
-  let content;
-
-  if (typeof value === 'undefined') {
-    content = title;
-  } else if (typeof value === 'number') {
-    if (value < 0) {
-      return null;
-    }
-
-    content = pluralForm(value, title);
-  }
-
-  if (canFollow) {
-    content = (
-      <Link to={linkTo} className={styles.statlinkText}>
-        {content}
-      </Link>
-    );
-  } else {
-    content = <span className={styles.statlinkText}>{content}</span>;
-  }
-
-  return <li className={cn(styles.statlink, className)}>{content}</li>;
 }

--- a/src/components/user-profile-head.module.scss
+++ b/src/components/user-profile-head.module.scss
@@ -8,12 +8,12 @@ $actions-padding: 0.75em;
   --text-dim-color: #777;
 
   display: grid;
-  grid-template-columns: min-content 1fr min-content;
+  grid-template-columns: min-content 1fr 140px;
   grid-template-rows: min-content 1fr;
   grid-template-areas:
     'avatar info stats'
     'avatar description stats'
-    'lists lists lists'
+    'lists lists stats'
     'actions actions actions'
     'errors errors errors';
   grid-gap: 0 1em;
@@ -143,6 +143,11 @@ $actions-padding: 0.75em;
 
     .allPosts {
       margin-top: 0;
+      text-transform: lowercase;
+    }
+
+    .registeredOn,
+    .moreDetails {
       text-transform: lowercase;
     }
   }

--- a/test/jest/__snapshots__/user-profile-head.test.js.snap
+++ b/test/jest/__snapshots__/user-profile-head.test.js.snap
@@ -160,30 +160,12 @@ exports[`UserProfileHead Correctly displays that we are mutually subscribed 1`] 
           </a>
         </li>
         <li
-          class="statlink allPosts"
-        >
-          <a
-            class="statlinkText"
-          >
-            All posts
-          </a>
-        </li>
-        <li
           class="statlink"
         >
           <a
-            class="statlinkText"
+            class="moreDetails"
           >
-            5 comments
-          </a>
-        </li>
-        <li
-          class="statlink"
-        >
-          <a
-            class="statlinkText"
-          >
-            4 likes
+            More details...
           </a>
         </li>
       </ul>
@@ -337,30 +319,12 @@ exports[`UserProfileHead Renders my own header and doesn't blow up 1`] = `
           </a>
         </li>
         <li
-          class="statlink allPosts"
-        >
-          <a
-            class="statlinkText"
-          >
-            All posts
-          </a>
-        </li>
-        <li
           class="statlink"
         >
           <a
-            class="statlinkText"
+            class="moreDetails"
           >
-            5 comments
-          </a>
-        </li>
-        <li
-          class="statlink"
-        >
-          <a
-            class="statlinkText"
-          >
-            4 likes
+            More details...
           </a>
         </li>
       </ul>


### PR DESCRIPTION
This PR adds "more details" block to profile head with registration date.

## Wide screen

| Before | After (closed) | After (open) |
|--|--|--|
| ![before-wide-Screenshot 2022-03-10 at 00-01-50 FreeFeed ❤️ (freefeed) - FreeFeed](https://user-images.githubusercontent.com/632081/157617569-aebd1cf6-d707-48b8-8a78-c3ea446d313c.png) | ![after-wide-closed-Screenshot 2022-03-09 at 23-58-51 FreeFeed ❤️ (freefeed) - FreeFeed](https://user-images.githubusercontent.com/632081/157617559-4754d88e-b621-48fe-af90-49ab292463f7.png) | ![after-wide-open-Screenshot 2022-03-09 at 23-59-27 FreeFeed ❤️ (freefeed) - FreeFeed](https://user-images.githubusercontent.com/632081/157617567-eddbe199-6710-4813-a198-82d59b22df73.png) |


## Narrow screen


| Before | After (closed) | After (open) |
|--|--|--|
| ![before-narrow-Screenshot 2022-03-10 at 00-02-03 FreeFeed ❤️ (freefeed) - FreeFeed](https://user-images.githubusercontent.com/632081/157617627-7c3bdaca-880d-474c-b681-152f675ec670.png) | ![after-narrow-closed-Screenshot 2022-03-10 at 00-00-56 FreeFeed ❤️ (freefeed) - FreeFeed](https://user-images.githubusercontent.com/632081/157617612-7dbae6db-0d6e-4152-a3e5-f53d44be8bc8.png) | ![after-narrow-open-Screenshot 2022-03-10 at 00-01-10 FreeFeed ❤️ (freefeed) - FreeFeed](https://user-images.githubusercontent.com/632081/157617618-88de8a4a-ac9e-42f3-b956-35ad06203cfb.png) |








