### PR TITLE
Hide banned replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.107.0] - Not released
+### Added
+- New frontend setting: comments.hideRepliesToBanned (false by default, can be
+  adjusted on Settings / Appearance page). If it is set to true, comments that
+  starts with a @-mention of banned user are replaced by placeholder ('Comment
+  with reply to blocked user'). Comments authored by the current user are always
+  visible.
 
 ## [1.106.1] - 2022-02-03
 ### Fixed

--- a/config/default.js
+++ b/config/default.js
@@ -64,6 +64,7 @@ export default {
         omitRepeatedBubbles: true,
         highlightComments: true,
         showTimestamps: false,
+        hideRepliesToBanned: false,
       },
       allowLinksPreview: false,
       readMoreStyle: 'modern',

--- a/src/components/settings/forms/appearance.jsx
+++ b/src/components/settings/forms/appearance.jsx
@@ -81,6 +81,7 @@ export default function AppearanceForm() {
   const omitBubbles = useField('omitBubbles', form.form);
   const highlightComments = useField('highlightComments', form.form);
   const hideBannedComments = useField('hideBannedComments', form.form);
+  const hideRepliesToBanned = useField('hideRepliesToBanned', form.form);
   const allowLinksPreview = useField('allowLinksPreview', form.form);
   const hideNSFWContent = useField('hideNSFWContent', form.form);
   const commentsTimestamps = useField('commentsTimestamps', form.form);
@@ -342,15 +343,24 @@ export default function AppearanceForm() {
 
           <div className="checkbox">
             <label>
+              <CheckboxInput field={commentsTimestamps} />
+              Show timestamps for comments
+            </label>
+          </div>
+        </div>
+        <h5>Comments from blocked users:</h5>
+        <div className="form-group">
+          <div className="checkbox">
+            <label>
               <CheckboxInput field={hideBannedComments} />
-              Hide comments from blocked users (don&#x2019;t show placeholder)
+              Hide comments from blocked users (don&#x2019;t even show placeholder)
             </label>
           </div>
 
           <div className="checkbox">
             <label>
-              <CheckboxInput field={commentsTimestamps} />
-              Show timestamps for comments
+              <CheckboxInput field={hideRepliesToBanned} />
+              Hide text of replies to blocked users (show placeholders instead)
             </label>
           </div>
         </div>
@@ -466,6 +476,7 @@ function initialValues({
   submitMode,
   uiScale,
 }) {
+  console.log(frontend.comments);
   return {
     useYou: frontend.displayNames.useYou,
     displayNames: frontend.displayNames.displayOption.toString(),
@@ -475,6 +486,7 @@ function initialValues({
     omitBubbles: frontend.comments.omitRepeatedBubbles,
     highlightComments: frontend.comments.highlightComments,
     hideBannedComments: backend?.hideCommentsOfTypes.includes(COMMENT_HIDDEN_BANNED),
+    hideRepliesToBanned: frontend.comments.hideRepliesToBanned,
     allowLinksPreview: frontend.allowLinksPreview,
     hideNSFWContent: !isNSFWVisible,
     commentsTimestamps: frontend.comments.showTimestamps,
@@ -522,6 +534,7 @@ function prefUpdaters(values) {
           omitRepeatedBubbles: values.omitBubbles,
           highlightComments: values.highlightComments,
           showTimestamps: values.commentsTimestamps,
+          hideRepliesToBanned: values.hideRepliesToBanned,
         },
         allowLinksPreview: values.allowLinksPreview,
         timeDisplay: {

--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -865,6 +865,7 @@ export const initialWhoamiMiddleware = (store) => (next) => (action) => {
   if (action.type === response(ActionTypes.INITIAL_WHO_AM_I)) {
     // Fire the WHO_AM_I response first to properly fill state by current user data
     store.dispatch({ ...action, type: response(ActionTypes.WHO_AM_I) });
+    setTimeout(() => store.dispatch(ActionCreators.blockedByMe()), 0);
   }
   next(action);
 };

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -2034,3 +2034,5 @@ export function submitMode(state = loadSubmitMode(), action) {
   }
   return state;
 }
+
+export { bannedUsernames } from './reducers/banned';

--- a/src/redux/reducers/banned.js
+++ b/src/redux/reducers/banned.js
@@ -1,0 +1,41 @@
+import { BAN, BLOCKED_BY_ME, UNBAN, REALTIME_INCOMING_EVENT } from '../action-types';
+import { response } from '../async-helpers';
+
+export function bannedUsernames(state = [], action) {
+  if (action.type === response(BLOCKED_BY_ME)) {
+    return action.payload.map((u) => u.username);
+  }
+  if (action.type === response(UNBAN)) {
+    const { username } = action.request;
+    if (state.includes(username)) {
+      return state.filter((name) => name !== username);
+    }
+    return state;
+  }
+  if (action.type === response(BAN)) {
+    const { username } = action.request;
+    if (!state.includes(username)) {
+      return [...state, username];
+    }
+    return state;
+  }
+  if (action.type === REALTIME_INCOMING_EVENT && action.payload.event === 'event:new') {
+    const { Notifications, users } = action.payload.data;
+    for (const note of Notifications) {
+      if (note.event_type === 'banned_user') {
+        const { username } = users.find((u) => u.id === note.affected_user_id);
+        if (!state.includes(username)) {
+          state = [...state, username];
+        }
+      }
+      if (note.event_type === 'unbanned_user') {
+        const { username } = users.find((u) => u.id === note.affected_user_id);
+        if (state.includes(username)) {
+          state = state.filter((name) => name !== username);
+        }
+      }
+    }
+    return state;
+  }
+  return state;
+}


### PR DESCRIPTION
### Added
- New frontend setting: comments.hideRepliesToBanned (false by default, can be adjusted on Settings / Appearance page). If it is set to true, comments that  starts with a @-mention of banned user are replaced by placeholder ('Comment  with reply to blocked user'). Comments authored by the current user are always  visible.

![image](https://user-images.githubusercontent.com/132120/158808695-38f74203-42a3-4c85-abe7-8be95b8402ff.png)
