### PR TITLE
Change "screen name" to "display name" in all public texts

### DIFF
--- a/src/components/group-settings-form.jsx
+++ b/src/components/group-settings-form.jsx
@@ -164,7 +164,7 @@ function validate(values) {
   errors.screenName = shouldBe(
     /^.{3,25}$/i.test(values.screenName.trim()),
     <>
-      {values.screenName.trim()} is not a valid displayname.
+      {values.screenName.trim()} is not a valid display name.
       <br /> The length should be from 3 to 25 characters.
     </>,
   );

--- a/src/components/settings/forms/profile.jsx
+++ b/src/components/settings/forms/profile.jsx
@@ -38,7 +38,7 @@ export default function ProfileForm() {
         <label htmlFor="screenname-input">Display name</label>
         <input
           id="screenname-input"
-          className="form-control wider-input"
+          className="form-control narrow-input"
           type="text"
           autoComplete="name"
           {...screenName.input}
@@ -50,7 +50,7 @@ export default function ProfileForm() {
         <label htmlFor="email-input">Email</label>
         <input
           id="email-input"
-          className="form-control narrow-input"
+          className="form-control wider-input"
           type="email"
           autoComplete="email"
           inputMode="email"
@@ -106,7 +106,7 @@ function validate(values) {
   errors.screenName = shouldBe(
     /^.{3,25}$/i.test(values.screenName.trim()),
     <>
-      {values.screenName.trim()} is not a valid displayname.
+      {values.screenName.trim()} is not a valid display name.
       <br /> The length should be from 3 to 25 characters.
     </>,
   );

--- a/src/components/signup-form.jsx
+++ b/src/components/signup-form.jsx
@@ -184,7 +184,7 @@ export default memo(function SignupForm({ invitationId = null, lang = 'en' }) {
           {username.meta.error && <p className="help-block">{username.meta.error}</p>}
         </div>
         <div className={groupErrClass(screenname)}>
-          <label htmlFor="screenname-input">{enRu('Screen Name', 'Имя')}</label>
+          <label htmlFor="screenname-input">{enRu('Display name', 'Имя')}</label>
           <input
             id="screenname-input"
             className="form-control narrow-input"


### PR DESCRIPTION
This PR changes "display name" to "screen name" in all public texts for consistency. 

UPD: nope, now it's the other way around