### PR TITLE
Make new users protected by default

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -111,6 +111,9 @@ export default {
     minFolded: 3,
   },
 
+  // if false, new users are public by default
+  newUsersProtected: false,
+
   registrationsLimit: {
     emailFormIframeSrc: null,
   },

--- a/src/components/settings/forms/privacy.jsx
+++ b/src/components/settings/forms/privacy.jsx
@@ -1,3 +1,4 @@
+/* global CONFIG */
 import { useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useField, useForm } from 'react-final-form-hooks';
@@ -45,12 +46,14 @@ export default (function PrivacyForm() {
             <label>
               <RadioInput field={privacy} value={PUBLIC} />
               Public &mdash; anyone can see your posts
+              {CONFIG.newUsersProtected ? '' : <em> (default)</em>}
             </label>
           </div>
           <div className="radio">
             <label>
               <RadioInput field={privacy} value={PROTECTED} />
               Protected &mdash; anonymous users and search engines cannot see your posts
+              {CONFIG.newUsersProtected ? <em> (default)</em> : ''}
             </label>
           </div>
           <div className="radio">

--- a/src/components/signup-form.jsx
+++ b/src/components/signup-form.jsx
@@ -53,6 +53,7 @@ const onSubmit =
       username: values.username.trim(),
       screenName: values.screenname.trim(),
       email: values.email.trim(),
+      isProtected: Boolean(CONFIG.newUsersProtected),
     };
 
     if (externalProfileKey && values.connectExtProfile) {


### PR DESCRIPTION
This PR adds a client-side setting that controls whether all new users are protected or public by default, and sets it to "protected".

<img width="571" alt="Screenshot 2022-03-20 at 14 42 36" src="https://user-images.githubusercontent.com/632081/159187171-3f2d3904-5695-4104-af42-141757e9f0f5.png">

