### PR TITLE
Fix crash when selector is not valid

### DIFF
--- a/src/components/settings/forms/appearance.jsx
+++ b/src/components/settings/forms/appearance.jsx
@@ -49,8 +49,10 @@ export default function AppearanceForm() {
     if (!hash) {
       return;
     }
-    const anchor = hash.slice(1);
-    const element = document.querySelector(`#${anchor}`);
+    const anchor = encodeURIComponent(hash.slice(1));
+    // eslint-disable-next-line unicorn/prefer-query-selector
+    const element = document.getElementById(`${anchor}`);
+
     if (element) {
       const { top } = element.getBoundingClientRect();
       safeScrollTo(0, top);

--- a/src/components/settings/forms/appearance.jsx
+++ b/src/components/settings/forms/appearance.jsx
@@ -49,9 +49,9 @@ export default function AppearanceForm() {
     if (!hash) {
       return;
     }
-    const anchor = encodeURIComponent(hash.slice(1));
+    const anchor = decodeURIComponent(hash.slice(1));
     // eslint-disable-next-line unicorn/prefer-query-selector
-    const element = document.getElementById(`${anchor}`);
+    const element = document.getElementById(anchor);
 
     if (element) {
       const { top } = element.getBoundingClientRect();


### PR DESCRIPTION
Fixes UI crash that happens if URL anchor is an invalid querySelector (e.g. https://freefeed.net/settings/appearance#beta=). 

<img width="616" alt="Screenshot 2022-03-26 at 15 34 04" src="https://user-images.githubusercontent.com/632081/160300168-a5f3c2ea-fe46-4350-818d-e7568289a0c6.png">
 