### PR TITLE
Show live users in subscriber lists in blue color

### DIFF
--- a/src/components/tile-user-list.jsx
+++ b/src/components/tile-user-list.jsx
@@ -147,6 +147,7 @@ export const tileUserListFactory = (config) => (props) => {
         'profilePictureUrl',
         'profilePictureLargeUrl',
         'profilePictureMediumUrl',
+        'isGone',
       ]),
       largePicture: config.size === 'large',
       ...pickActions(config.type, props),

--- a/styles/shared/lists.scss
+++ b/styles/shared/lists.scss
@@ -19,7 +19,6 @@ ul.tile-list {
     .avatar > a {
       line-height: 130%;
       font-size: 12px;
-      color: #4c4c4c;
     }
 
     .user-actions {


### PR DESCRIPTION
This PR changes colors of usernames in subscribers and subscriptions lists so that live users are displayed in blue color, and "gone" users are in grey.

Before:

<img width="307" alt="Screenshot 2022-04-06 at 21 52 03" src="https://user-images.githubusercontent.com/632081/162123073-8deb4bf3-07ea-4c2e-b091-2c66702b289c.png">


After:
<img width="307" alt="Screenshot 2022-04-06 at 21 51 46" src="https://user-images.githubusercontent.com/632081/162123094-a8193f3a-bd73-4095-a5d0-57467128696e.png">

