### PR TITLE
Lock in the 'now' date for the tests of PostComments component

### DIFF
--- a/src/components/post/post-comments/index.jsx
+++ b/src/components/post/post-comments/index.jsx
@@ -73,7 +73,7 @@ export default class PostComments extends Component {
     const { props } = this;
     const { post } = props;
 
-    const now = new Date();
+    const now = props.nowDate || new Date();
     let spacer = null;
 
     if (post.comments?.length > 0) {

--- a/test/jest/post-comments.test.js
+++ b/test/jest/post-comments.test.js
@@ -95,6 +95,7 @@ const renderPostComments = (props = {}, options = {}) => {
     isLoadingComments: false,
     addComment: () => {},
     toggleCommenting: () => {},
+    nowDate: new Date('2022-01-01'),
   };
 
   const rendered = render(


### PR DESCRIPTION
The test of PostComments component depends on the current date, it displays the "... passed" string above the new comment form. The current date is changes over time, so this PR allows to pass it for the test explicitly as a fixed property.