### PR TITLE
Update @testing-library/user-event to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@testing-library/jest-dom": "~5.16.4",
     "@testing-library/react": "~12.1.5",
     "@testing-library/react-hooks": "~7.0.2",
-    "@testing-library/user-event": "~13.5.0",
+    "@testing-library/user-event": "~14.1.0",
     "@types/semver": "~7.3.9",
     "babel-eslint": "~10.1.0",
     "babel-loader": "~8.2.5",

--- a/src/components/submittable-textarea.jsx
+++ b/src/components/submittable-textarea.jsx
@@ -1,4 +1,4 @@
-import { KEY_RETURN } from 'keycode-js';
+import { CODE_ENTER } from 'keycode-js';
 import { forwardRef, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import Textarea from 'react-textarea-autosize';
@@ -21,7 +21,7 @@ export const SubmittableTextarea = forwardRef(function SubmittableTextarea(
   useEffect(() => {
     const el = ref.current;
     const h = (event) => {
-      if (event.keyCode !== KEY_RETURN) {
+      if (event.key !== CODE_ENTER) {
         return;
       }
 

--- a/test/jest/list-editor.test.jsx
+++ b/test/jest/list-editor.test.jsx
@@ -77,21 +77,21 @@ describe('ListEditor', () => {
     expect(listEditor).toMatchSnapshot();
   });
 
-  it('Add a user to the list by clicking on it', () => {
+  it('Add a user to the list by clicking on it', async () => {
     renderListEditor();
-    userEvent.click(screen.getByText(/Not in the list/));
+    await userEvent.click(screen.getByText(/Not in the list/));
     expect(screen.getByText('Homeless')).toBeDefined();
     expect(screen.getByText('In Some Other List')).toBeDefined();
     expect(screen.getByText(/not in any of your friend lists/)).toBeDefined();
     expect(screen.queryByText('In list')).toBeNull();
-    userEvent.click(screen.getByText('Homeless'));
+    await userEvent.click(screen.getByText('Homeless'));
     expect(screen.queryByText('Homeless')).toBeNull();
     expect(screen.queryByText(/not in any of your friend lists/)).toBeNull();
   });
 
-  it('Searches for users', () => {
+  it('Searches for users', async () => {
     renderListEditor();
-    userEvent.type(screen.getByRole('searchbox'), 'LIST');
+    await userEvent.type(screen.getByRole('searchbox'), 'LIST');
     expect(screen.getByRole('list')).toMatchSnapshot();
   });
 });

--- a/test/jest/post-comments.test.js
+++ b/test/jest/post-comments.test.js
@@ -118,7 +118,7 @@ describe('PostComments', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('Renders omitted comments and expands them', () => {
+  it('Renders omitted comments and expands them', async () => {
     const showMoreComments = jest.fn();
     const { rerender } = renderPostComments({
       post: {
@@ -130,7 +130,7 @@ describe('PostComments', () => {
       showMoreComments,
     });
     expect(screen.getByLabelText(/15 comments/)).toBeInTheDocument();
-    userEvent.click(screen.getByText('12 more comments with 34 likes', { role: 'button' }));
+    await userEvent.click(screen.getByText('12 more comments with 34 likes', { role: 'button' }));
     expect(showMoreComments).toHaveBeenCalledWith('post-id');
 
     expect(screen.queryByLabelText('Loading comments...')).not.toBeInTheDocument();
@@ -147,7 +147,7 @@ describe('PostComments', () => {
     expect(screen.queryByLabelText('Loading comments...')).toBeInTheDocument();
   });
 
-  it('Renders add comment link which toggles comment form', () => {
+  it('Renders add comment link which toggles comment form', async () => {
     const toggleCommenting = jest.fn();
     renderPostComments({
       user: VIEWER,
@@ -158,14 +158,14 @@ describe('PostComments', () => {
       },
       toggleCommenting,
     });
-    userEvent.click(screen.getByText('Add comment', { role: 'button' }));
+    await userEvent.click(screen.getByText('Add comment', { role: 'button' }));
     expect(toggleCommenting).toHaveBeenCalledWith('post-id');
   });
 
-  it('Highlights a comment when arrow is hovered', () => {
+  it('Highlights a comment when arrow is hovered', async () => {
     renderPostComments();
     expect(document.querySelectorAll('.highlighted').length).toBe(0);
-    userEvent.hover(screen.getByText('^'));
+    await userEvent.hover(screen.getByText('^'));
     expect(document.querySelectorAll('.highlighted').length).toBe(1);
     expect(document.querySelector('.highlighted').getAttribute('data-author')).toBe('other');
   });

--- a/test/jest/post.test.js
+++ b/test/jest/post.test.js
@@ -186,12 +186,12 @@ describe('Post', () => {
     expect(screen.getByLabelText(/Link preview/)).toBeInTheDocument();
   });
 
-  it('Renders a post as public and toggles timestamps if post visibility icon is clicked', () => {
+  it('Renders a post as public and toggles timestamps if post visibility icon is clicked', async () => {
     renderPost();
     expect(screen.getByLabelText(/Public post/)).toBeInTheDocument();
     expect(screen.getByTitle(/This entry is public/, { role: 'button' })).toBeInTheDocument();
     expect(screen.getByText('Mar 14, 2021')).toBeInTheDocument();
-    userEvent.click(screen.getByTitle(/This entry is public/, { role: 'button' }));
+    await userEvent.click(screen.getByTitle(/This entry is public/, { role: 'button' }));
     expect(screen.getByText('Mar 14, 2021 03:23')).toBeInTheDocument();
   });
 
@@ -248,11 +248,11 @@ describe('Post', () => {
     expect(screen.getByTitle(/This is a direct message/)).toBeInTheDocument();
   });
 
-  it('Renders a comment button which opens the comment form if this is not a single post', () => {
+  it('Renders a comment button which opens the comment form if this is not a single post', async () => {
     const toggleCommenting = jest.fn();
     renderPost({ toggleCommenting, isSinglePost: false });
     expect(screen.getByText('Comment', { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText('Comment', { role: 'button' }));
+    await userEvent.click(screen.getByText('Comment', { role: 'button' }));
     expect(toggleCommenting).toHaveBeenCalledWith('post-id');
   });
 
@@ -268,16 +268,16 @@ describe('Post', () => {
     expect(screen.getByText('Comments disabled (not for you)')).toBeInTheDocument();
   });
 
-  it('Renders a like button which likes the post', () => {
+  it('Renders a like button which likes the post', async () => {
     const someOtherUser = { id: 'other-id' };
     const likePost = jest.fn();
     renderPost({ likePost, isEditable: false, user: someOtherUser });
     expect(screen.getByText('Like', { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText('Like', { role: 'button' }));
+    await userEvent.click(screen.getByText('Like', { role: 'button' }));
     expect(likePost).toHaveBeenCalledWith('post-id', 'other-id');
   });
 
-  it('Renders an un-like button which un-likes the post if this post is already liked', () => {
+  it('Renders an un-like button which un-likes the post if this post is already liked', async () => {
     const someOtherUser = { id: 'other-id' };
     const unlikePost = jest.fn();
     renderPost({
@@ -287,7 +287,7 @@ describe('Post', () => {
       user: someOtherUser,
     });
     expect(screen.getByText('Un-like', { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText('Un-like', { role: 'button' }));
+    await userEvent.click(screen.getByText('Un-like', { role: 'button' }));
     expect(unlikePost).toHaveBeenCalledWith('post-id', 'other-id');
   });
 
@@ -297,7 +297,7 @@ describe('Post', () => {
     expect(screen.queryByText('Un-like', { role: 'button' })).not.toBeInTheDocument();
   });
 
-  it('Renders a more button if this is a post that I can edit (e.g. my own post) which toggles a "more action" menu', () => {
+  it('Renders a more button if this is a post that I can edit (e.g. my own post) which toggles a "more action" menu', async () => {
     const confirmMock = jest.spyOn(global, 'confirm').mockReturnValueOnce(true);
 
     const toggleEditingPost = jest.fn();
@@ -315,29 +315,29 @@ describe('Post', () => {
     });
     expect(screen.getByText(/More/, { role: 'button' })).toBeInTheDocument();
 
-    userEvent.click(screen.getByText(/More/, { role: 'button' }));
+    await userEvent.click(screen.getByText(/More/, { role: 'button' }));
     expect(screen.getByText('Edit', { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText('Edit', { role: 'button' }));
+    await userEvent.click(screen.getByText('Edit', { role: 'button' }));
     expect(toggleEditingPost).toHaveBeenCalledWith('post-id');
 
-    userEvent.click(screen.getByText(/More/, { role: 'button' }));
+    await userEvent.click(screen.getByText(/More/, { role: 'button' }));
     expect(screen.getByText('Moderate comments', { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText('Moderate comments', { role: 'button' }));
+    await userEvent.click(screen.getByText('Moderate comments', { role: 'button' }));
     expect(toggleModeratingComments).toHaveBeenCalledWith('post-id');
 
-    userEvent.click(screen.getByText(/More/, { role: 'button' }));
+    await userEvent.click(screen.getByText(/More/, { role: 'button' }));
     expect(screen.getByText('Disable comments', { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText('Disable comments', { role: 'button' }));
+    await userEvent.click(screen.getByText('Disable comments', { role: 'button' }));
     expect(disableComments).toHaveBeenCalledWith('post-id');
 
-    userEvent.click(screen.getByText(/More/, { role: 'button' }));
+    await userEvent.click(screen.getByText(/More/, { role: 'button' }));
     expect(screen.getByText('Delete', { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText('Delete', { role: 'button' }));
+    await userEvent.click(screen.getByText('Delete', { role: 'button' }));
     expect(confirmMock).toHaveBeenCalledWith('Are you sure?');
     expect(deletePost).toHaveBeenCalledWith('post-id', []);
   });
 
-  it('Renders a more button if this is a post that I can moderati (e.g. post in my groups) which toggles a "more action" menu', () => {
+  it('Renders a more button if this is a post that I can moderati (e.g. post in my groups) which toggles a "more action" menu', async () => {
     const confirmMock = jest.spyOn(global, 'confirm').mockReturnValueOnce(true);
 
     const toggleEditingPost = jest.fn();
@@ -355,15 +355,15 @@ describe('Post', () => {
       deletePost,
     });
     expect(screen.getByText(/More/, { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText(/More/, { role: 'button' }));
+    await userEvent.click(screen.getByText(/More/, { role: 'button' }));
 
     expect(screen.getByText('Remove from @celestials', { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText(/Remove/, { role: 'button' }));
+    await userEvent.click(screen.getByText(/Remove/, { role: 'button' }));
     expect(confirmMock).toHaveBeenCalledWith('Are you sure?');
     expect(deletePost).toHaveBeenCalledWith('post-id', ['celestials']);
   });
 
-  it('Lets me enable comments under my post if they are disabled', () => {
+  it('Lets me enable comments under my post if they are disabled', async () => {
     const enableComments = jest.fn();
     renderPost({
       isEditable: true,
@@ -371,14 +371,14 @@ describe('Post', () => {
       enableComments,
     });
     expect(screen.getByText(/More/, { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText(/More/, { role: 'button' }));
+    await userEvent.click(screen.getByText(/More/, { role: 'button' }));
 
     expect(screen.getByText('Enable comments', { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText('Enable comments', { role: 'button' }));
+    await userEvent.click(screen.getByText('Enable comments', { role: 'button' }));
     expect(enableComments).toHaveBeenCalledWith('post-id');
   });
 
-  it('Renders a hide button which hides the post', () => {
+  it('Renders a hide button which hides the post', async () => {
     const someOtherUser = { id: 'other-id' };
     const hidePost = jest.fn();
     renderPost({
@@ -389,11 +389,11 @@ describe('Post', () => {
       hidePost,
     });
     expect(screen.getByText('Hide', { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText('Hide', { role: 'button' }));
+    await userEvent.click(screen.getByText('Hide', { role: 'button' }));
     expect(hidePost).toHaveBeenCalledWith('post-id');
   });
 
-  it('Renders a un-hide button which unhides the post', () => {
+  it('Renders a un-hide button which unhides the post', async () => {
     const someOtherUser = { id: 'other-id' };
     const unhidePost = jest.fn();
     renderPost({
@@ -405,25 +405,25 @@ describe('Post', () => {
       unhidePost,
     });
     expect(screen.getByText('Un-hide', { role: 'button' })).toBeInTheDocument();
-    userEvent.click(screen.getByText('Un-hide', { role: 'button' }));
+    await userEvent.click(screen.getByText('Un-hide', { role: 'button' }));
     expect(unhidePost).toHaveBeenCalledWith('post-id');
   });
 
-  it('Renders a textarea with post text when editing the post', () => {
+  it('Renders a textarea with post text when editing the post', async () => {
     const cancelEditingPost = jest.fn();
     const { rerender } = renderPost({ isEditable: true, cancelEditingPost });
 
-    userEvent.click(screen.getByText(/More/, { role: 'button' }));
-    userEvent.click(screen.getByText('Edit', { role: 'button' }));
+    await userEvent.click(screen.getByText(/More/, { role: 'button' }));
+    await userEvent.click(screen.getByText('Edit', { role: 'button' }));
     rerender({ isEditing: true, isEditable: true, cancelEditingPost });
 
     expect(screen.getByLabelText('Post body')).toMatchSnapshot();
 
-    userEvent.click(screen.getByText('Cancel'));
+    await userEvent.click(screen.getByText('Cancel'));
     expect(cancelEditingPost).toHaveBeenCalledWith('post-id');
   });
 
-  it('Lets me edit text of my post by typing with Shift+Enter when "submitMode" is "enter"', () => {
+  it('Lets me edit text of my post by typing with Shift+Enter when "submitMode" is "enter"', async () => {
     const saveEditingPost = jest.fn();
     renderPost({
       isEditing: true,
@@ -431,7 +431,7 @@ describe('Post', () => {
       saveEditingPost,
     });
 
-    userEvent.type(screen.getByRole('textbox'), 'Hello,{shift}{enter}{/shift}World!{enter}');
+    await userEvent.type(screen.getByRole('textbox'), 'Hello,{shift>}{enter}{/shift}World!{enter}');
     expect(screen.getByRole('textbox')).toHaveValue('Hello,\nWorld!');
     expect(saveEditingPost).toHaveBeenCalledWith('post-id', {
       attachments: [],
@@ -440,7 +440,7 @@ describe('Post', () => {
     });
   });
 
-  it('Lets me edit text of my post by typing with Alt+Enter when "submitMode" is "enter"', () => {
+  it('Lets me edit text of my post by typing with Alt+Enter when "submitMode" is "enter"', async () => {
     const saveEditingPost = jest.fn();
     renderPost({
       isEditing: true,
@@ -448,7 +448,7 @@ describe('Post', () => {
       saveEditingPost,
     });
 
-    userEvent.type(screen.getByRole('textbox'), 'Hello,{alt}{enter}{/alt}World!{enter}');
+    await userEvent.type(screen.getByRole('textbox'), 'Hello,{alt>}{enter}{/alt}World!{enter}');
     expect(screen.getByRole('textbox')).toHaveValue('Hello,\nWorld!');
     expect(saveEditingPost).toHaveBeenCalledWith('post-id', {
       attachments: [],
@@ -457,7 +457,7 @@ describe('Post', () => {
     });
   });
 
-  it('Lets me submit text of my post by Ctrl+Enter typing when "submitMode" is "ctrl+enter"', () => {
+  it('Lets me submit text of my post by Ctrl+Enter typing when "submitMode" is "ctrl+enter"', async () => {
     const saveEditingPost = jest.fn();
     renderPost(
       {
@@ -468,7 +468,10 @@ describe('Post', () => {
       { submitMode: 'ctrl+enter' },
     );
 
-    userEvent.type(screen.getByRole('textbox'), 'Hello,{enter}World!{ctrl}{enter}{/ctrl}');
+    await userEvent.type(
+      screen.getByRole('textbox'),
+      'Hello,{enter}World!{control>}{enter}{/control}',
+    );
     expect(screen.getByRole('textbox')).toHaveValue('Hello,\nWorld!');
     expect(saveEditingPost).toHaveBeenCalledWith('post-id', {
       attachments: [],
@@ -477,7 +480,7 @@ describe('Post', () => {
     });
   });
 
-  it('Lets me submit text of my post by Meta+Enter typing when "submitMode" is "ctrl+enter"', () => {
+  it('Lets me submit text of my post by Meta+Enter typing when "submitMode" is "ctrl+enter"', async () => {
     const saveEditingPost = jest.fn();
     renderPost(
       {
@@ -488,7 +491,7 @@ describe('Post', () => {
       { submitMode: 'ctrl+enter' },
     );
 
-    userEvent.type(screen.getByRole('textbox'), 'Hello,{enter}World!{meta}{enter}{/meta}');
+    await userEvent.type(screen.getByRole('textbox'), 'Hello,{enter}World!{meta>}{enter}{/meta}');
     expect(screen.getByRole('textbox')).toHaveValue('Hello,\nWorld!');
     expect(saveEditingPost).toHaveBeenCalledWith('post-id', {
       attachments: [],

--- a/test/jest/sign-in-page.test.js
+++ b/test/jest/sign-in-page.test.js
@@ -50,17 +50,17 @@ describe('SignInPage', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('Updates user password', () => {
+  it('Updates user password', async () => {
     const currentPassword = 'current';
     const newPassword = 'newpassword123';
 
     const updatePasswordMock = jest.spyOn(actionCreators, 'updatePassword');
     renderSignInPage();
 
-    userEvent.type(screen.getByLabelText('Current password'), currentPassword);
-    userEvent.type(screen.getByLabelText('New password'), newPassword);
-    userEvent.type(screen.getByLabelText('Confirm password'), newPassword);
-    userEvent.click(screen.getByText('Update password'));
+    await userEvent.type(screen.getByLabelText('Current password'), currentPassword);
+    await userEvent.type(screen.getByLabelText('New password'), newPassword);
+    await userEvent.type(screen.getByLabelText('Confirm password'), newPassword);
+    await userEvent.click(screen.getByText('Update password'));
     expect(updatePasswordMock).toHaveBeenCalledTimes(1);
     expect(updatePasswordMock).toHaveBeenCalledWith({
       currentPassword,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2069,14 +2069,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/user-event@npm:~13.5.0":
-  version: 13.5.0
-  resolution: "@testing-library/user-event@npm:13.5.0"
-  dependencies:
-    "@babel/runtime": ^7.12.5
+"@testing-library/user-event@npm:~14.1.0":
+  version: 14.1.1
+  resolution: "@testing-library/user-event@npm:14.1.1"
   peerDependencies:
     "@testing-library/dom": ">=7.21.4"
-  checksum: 16319de685fbb7008f1ba667928f458b2d08196918002daca56996de80ef35e6d9de26e9e1ece7d00a004692b95a597cf9142fff0dc53f2f51606a776584f549
+  checksum: dd02aecbde64002aa3c58392137672156101fc3bb821f43db99e3c652e6a6d34b3eb29b2524eb41ad2a317cfdff6ab2e88d7027605d88dccaacf4f07a08dc7a9
   languageName: node
   linkType: hard
 
@@ -11510,7 +11508,7 @@ __metadata:
     "@testing-library/jest-dom": ~5.16.4
     "@testing-library/react": ~12.1.5
     "@testing-library/react-hooks": ~7.0.2
-    "@testing-library/user-event": ~13.5.0
+    "@testing-library/user-event": ~14.1.0
     "@types/semver": ~7.3.9
     autotrack: ~2.4.1
     babel-eslint: ~10.1.0


### PR DESCRIPTION
This PR updates `@testing-library/user-event` to v14. The following breaking changes are addressed:

1. all calls are now asynchronous
2. support for `.keyCode` in keyboard events is dropped (as it is a deprecated property)
3. syntax for "press a key and hold it" has changed
4. Control key is now `{control}`

Fixes #1527