### PR TITLE
Do not open the home feed selector window on subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.109] - Not released
+### Changed
+- The 'Subscribe' and 'Request a subscription' links no longer open the home
+  feed selection window. The subscription is always made to the main Home feed,
+  and then the user can change the feed.
+
 ## [1.108.2] - 2022-04-20
 ### Fixed
 - Restored "url" and "querystring" polyfills required by webpack.

--- a/src/components/user-profile-head-actions.jsx
+++ b/src/components/user-profile-head-actions.jsx
@@ -9,28 +9,26 @@ import { Icon } from './fontawesome-icons';
 import styles from './user-profile-head.module.scss';
 
 // eslint-disable-next-line complexity
-export function UserProfileHeadActions(props) {
-  const {
-    user,
-    currentUser,
-    isBanned,
-    toggleBanned,
-    inSubscriptions,
-    isCurrentUserAdmin,
-    doUnsubscribe,
-    subscrFormPivotRef,
-    subscrFormToggle,
-    requestSent,
-    doRevokeRequest,
-    acceptsDirects,
-    inSubscribers,
-    unsubFromMe,
-    togglePinned,
-    isPinned,
-    toggleHidden,
-    isHidden,
-  } = props;
-
+export function UserProfileHeadActions({
+  user,
+  currentUser,
+  isBanned,
+  toggleBanned,
+  inSubscriptions,
+  isCurrentUserAdmin,
+  doUnsubscribe,
+  doSubscribe,
+  doSendSubscriptionRequest,
+  requestSent,
+  doRevokeRequest,
+  acceptsDirects,
+  inSubscribers,
+  unsubFromMe,
+  togglePinned,
+  isPinned,
+  toggleHidden,
+  isHidden,
+}) {
   return (
     <div className={styles.actions}>
       {isBanned ? (
@@ -54,9 +52,7 @@ export function UserProfileHeadActions(props) {
             )}
             {!user.isGone && !inSubscriptions && user.isPrivate === '0' && (
               <li>
-                <ButtonLink ref={subscrFormPivotRef} onClick={subscrFormToggle}>
-                  Subscribe
-                </ButtonLink>
+                <ActionLink {...doSubscribe}>Subscribe</ActionLink>
               </li>
             )}
             {!user.isGone && !inSubscriptions && user.isPrivate === '1' && (
@@ -67,9 +63,7 @@ export function UserProfileHeadActions(props) {
                     <ActionLink {...doRevokeRequest}>revoke</ActionLink>)
                   </>
                 ) : (
-                  <ButtonLink ref={subscrFormPivotRef} onClick={subscrFormToggle}>
-                    Request a subscription
-                  </ButtonLink>
+                  <ActionLink {...doSendSubscriptionRequest}>Request a subscription</ActionLink>
                 )}
               </li>
             )}

--- a/src/components/user-profile-head.jsx
+++ b/src/components/user-profile-head.jsx
@@ -26,6 +26,8 @@ import {
   unsubscribeFromMe,
   listHomeFeeds,
   revokeSentRequest,
+  sendSubscriptionRequest,
+  subscribe,
 } from '../redux/action-creators';
 import { withKey } from './with-key';
 import { UserPicture } from './user-picture';
@@ -107,6 +109,19 @@ export const UserProfileHead = withRouter(
 
     // Actions & statuses
     const doShowMedia = useCallback((arg) => dispatch(showMedia(arg)), [dispatch]);
+
+    const doSubscribe = {
+      onClick: useCallback(() => dispatch(subscribe(user)), [dispatch, user]),
+      status:
+        useSelector((state) => state.userActionsStatuses.subscribing)[user?.username] ||
+        initialAsyncState,
+    };
+    const doSendSubscriptionRequest = {
+      onClick: useCallback(() => dispatch(sendSubscriptionRequest(user)), [dispatch, user]),
+      status:
+        useSelector((state) => state.userActionsStatuses.subscribing)[user?.username] ||
+        initialAsyncState,
+    };
 
     const doUnsubscribe = {
       onClick: useCallback(() => {
@@ -268,8 +283,8 @@ export const UserProfileHead = withRouter(
               inSubscriptions={inSubscriptions}
               isCurrentUserAdmin={isCurrentUserAdmin}
               doUnsubscribe={doUnsubscribe}
-              subscrFormPivotRef={subscrFormPivotRef}
-              subscrFormToggle={subscrFormToggle}
+              doSubscribe={doSubscribe}
+              doSendSubscriptionRequest={doSendSubscriptionRequest}
               requestSent={requestSent}
               doRevokeRequest={doRevokeRequest}
               acceptsDirects={acceptsDirects}


### PR DESCRIPTION
The 'Subscribe' and 'Request a subscription' links no longer open the home feed selection window. The subscription is always made to the main Home feed, and then the user can change the feed.