### PR TITLE
Redirect from the current user's Subscr* pages to her Friends page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.109] - Not released
+### Changed
+- The `/CURRENT_USERNAME/subscribers` and `/CURRENT_USERNAME/subscriptions`
+  addresses now redirects to the corresponding tabs of the `/friends` page.
 ## [1.108.2] - 2022-04-20
 ### Fixed
 - Restored "url" and "querystring" polyfills required by webpack.

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -69,8 +69,15 @@ const inviteActions = () => {
 };
 
 // needed to display mutual friends
-const subscribersSubscriptionsActions = (next) => {
+const subscribersSubscriptionsActions = (next, replace) => {
   const { userName } = next.params;
+
+  if (userName === store.getState().user.username) {
+    const route = next.routes[next.routes.length - 1];
+    replace(`/friends?show=${route.name}`);
+    return;
+  }
+
   store.dispatch(ActionCreators.subscribers(userName));
   store.dispatch(ActionCreators.subscriptions(userName));
 };


### PR DESCRIPTION
The `/CURRENT_USERNAME/subscribers` and `/CURRENT_USERNAME/subscriptions` addresses now redirects to the corresponding tabs of the `/friends` page.
