### PR TITLE
Fix the "Manage Subscribers" group's page behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.109] - Not released
+### Fixed
+- On the "Manage Subscribers" group's page, the list of administrators changed
+  as the cursor moved over the group members.
+
 ## [1.108.2] - 2022-04-20
 ### Fixed
 - Restored "url" and "querystring" polyfills required by webpack.

--- a/src/components/manage-subscribers.jsx
+++ b/src/components/manage-subscribers.jsx
@@ -85,8 +85,9 @@ class ManageSubscribersHandler extends PureComponent {
   }
 }
 function selectState(state, ownProps) {
-  const { boxHeader, groupAdmins, user } = state;
+  const { boxHeader, groupAdmins: allGroupAdmins, user } = state;
   const groupName = ownProps.params.userName;
+  const groupAdmins = allGroupAdmins[groupName] || [];
   const usersWhoAreNotAdmins = _.filter(state.usernameSubscribers.payload, (user) => {
     return groupAdmins.find((u) => u.username == user.username) == null;
   });

--- a/test/unit/redux/reducers/group-admins.js
+++ b/test/unit/redux/reducers/group-admins.js
@@ -1,0 +1,97 @@
+import { describe, it, before } from 'mocha';
+import expect from 'unexpected';
+import {
+  GET_USER_INFO,
+  MAKE_GROUP_ADMIN,
+  UNADMIN_GROUP_ADMIN,
+} from '../../../../src/redux/action-types';
+import { response } from '../../../../src/redux/async-helpers';
+
+import { groupAdmins } from '../../../../src/redux/reducers';
+import { userParser } from '../../../../src/utils';
+
+describe('Group admins', () => {
+  let zeroState, filledState, fillAction;
+
+  before(() => {
+    zeroState = groupAdmins(undefined, { type: 'init' });
+    fillAction = {
+      type: response(GET_USER_INFO),
+      payload: {
+        users: { username: 'somegroup', type: 'group' },
+        admins: [
+          { id: 'id1', username: 'admin1' },
+          { id: 'id2', username: 'admin2' },
+        ],
+      },
+    };
+    filledState = groupAdmins(zeroState, fillAction);
+  });
+
+  it('should fill admins on _group_ GET_USER_INFO response', () => {
+    const newState = groupAdmins(zeroState, fillAction);
+    expect(newState, 'to equal', { somegroup: fillAction.payload.admins.map(userParser) });
+  });
+
+  it('should not fill admins on _user_ GET_USER_INFO response', () => {
+    const newState = groupAdmins(zeroState, {
+      type: response(GET_USER_INFO),
+      payload: {
+        users: { username: 'someuser', type: 'user' },
+        admins: [
+          { id: 'id1', username: 'admin1' },
+          { id: 'id2', username: 'admin2' },
+        ],
+      },
+    });
+    expect(newState, 'to be', zeroState);
+  });
+
+  it('should promote user to admin', () => {
+    const newState = groupAdmins(filledState, {
+      type: response(MAKE_GROUP_ADMIN),
+      request: {
+        groupName: 'somegroup',
+        user: { id: 'id3', username: 'admin3' },
+      },
+    });
+    expect(newState, 'to satisfy', {
+      somegroup: [{ username: 'admin1' }, { username: 'admin2' }, { username: 'admin3' }],
+    });
+  });
+
+  it('should not promote user to admin of untracked group', () => {
+    const newState = groupAdmins(filledState, {
+      type: response(MAKE_GROUP_ADMIN),
+      request: {
+        groupName: 'someothergroup',
+        user: { id: 'id3', username: 'admin3' },
+      },
+    });
+    expect(newState, 'to be', filledState);
+  });
+
+  it('should remove user from group admins', () => {
+    const newState = groupAdmins(filledState, {
+      type: response(UNADMIN_GROUP_ADMIN),
+      request: {
+        groupName: 'somegroup',
+        user: { id: 'id2', username: 'admin2' },
+      },
+    });
+    expect(newState, 'to satisfy', {
+      somegroup: [{ username: 'admin1' }],
+    });
+  });
+
+  it('should not remove user from admins of untracked group', () => {
+    const newState = groupAdmins(filledState, {
+      type: response(UNADMIN_GROUP_ADMIN),
+      request: {
+        groupName: 'someothergroup',
+        user: { id: 'id2', username: 'admin2' },
+      },
+    });
+    expect(newState, 'to be', filledState);
+  });
+});


### PR DESCRIPTION
On the "Manage Subscribers" group's page, the list of administrators changed as the cursor moved over the group members.