### PR TITLE
Fix photoswipe icons not loading

### DIFF
--- a/webpack/rules.js
+++ b/webpack/rules.js
@@ -181,9 +181,9 @@ class RuleGenerator {
 
     return {
       test: /photoswipe.+\.(png|svg|gif)$/,
-      loader: `file-loader`,
-      options: {
-        name: `assets/images/photoswipe/${fileName}`,
+      type: 'asset/resource',
+      generator: {
+        filename: `assets/images/photoswipe/${fileName}`,
       },
     };
   }


### PR DESCRIPTION
This CR fixes photoswipe icons not showing (caused by a recent upgrade of css-loader)