### PR TITLE
Change update notification text

### DIFF
--- a/src/components/app-updated.jsx
+++ b/src/components/app-updated.jsx
@@ -18,7 +18,7 @@ export function AppUpdated() {
   return (
     <div className={styles.bar}>
       <div className={styles.indicator}>
-        There’s a new update for {CONFIG.siteTitle} available!{' '}
+        There’s an update for {CONFIG.siteTitle}!{' '}
         <ButtonLink className={styles.refresh} onClick={reloadPage}>
           Refresh the page
         </ButtonLink>{' '}

--- a/test/jest/__snapshots__/app-updated.test.js.snap
+++ b/test/jest/__snapshots__/app-updated.test.js.snap
@@ -8,7 +8,7 @@ exports[`AppUpdated Renders if there is an update 1`] = `
     <div
       class="indicator"
     >
-      There’s a new update for FreeFeed available! 
+      There’s an update for FreeFeed! 
       <a
         aria-disabled="false"
         class="refresh"


### PR DESCRIPTION
- Minor wordling change
- Update related to app-updated.jsx  Jest snapshot

Based on issue #1452 by @urbansheep:
In the blue update header alert there's a phrase ”There's a new update for FreeFeed available!”

“New update” is a tautology tautology.
“Update available” is also looks redundant.

Thus the phrase should rather read “There's an update for FreeFeed!”
