### PR TITLE
Hide "Everything", "Search" and "Best of" from anonymous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.113] - Not released
+### Changed
+- "Everything", "Search" and "Best of" pages are not available for
+  non-authorized users.
+
 ## [1.112] - 2022-11-25
 ### Added
 - Group administrators can now block users in their managed groups. A blocked

--- a/src/components/layout-header.jsx
+++ b/src/components/layout-header.jsx
@@ -134,7 +134,7 @@ export const LayoutHeader = withRouter(function LayoutHeader({ router }) {
     >
       {searchExpanded ? (
         <div className={styles.searchExpandedCont}>
-          {searchForm}
+          {authenticated && searchForm}
           {sidebarButton}
         </div>
       ) : (
@@ -150,9 +150,9 @@ export const LayoutHeader = withRouter(function LayoutHeader({ router }) {
             )}
           </h1>
           <div className={styles.activeElements}>
-            {!collapsibleSearchForm && searchForm}
+            {authenticated && !collapsibleSearchForm && searchForm}
             <span className={styles.buttons}>
-              {collapsibleSearchForm && (
+              {authenticated && collapsibleSearchForm && (
                 <button
                   type="button"
                   aria-label="Open search form"

--- a/src/components/search-feed.jsx
+++ b/src/components/search-feed.jsx
@@ -10,6 +10,7 @@ import { useSearchQuery } from './hooks/search-query';
 import { useBool } from './hooks/bool';
 import { ButtonLink } from './button-link';
 import { Icon } from './fontawesome-icons';
+import { SignInLink } from './sign-in-link';
 
 const SearchFormAdvanced = lazyComponent(
   () => import('./search-form-advanced').then((m) => ({ default: m.SearchFormAdvanced })),
@@ -23,11 +24,27 @@ function FeedHandler(props) {
   const queryString = useSearchQuery();
   const pageIsLoading = useSelector((state) => state.routeLoadingState);
   const [advFormVisible, setAdvFormVisible] = useBool(!queryString);
+  const authenticated = useSelector((state) => state.authenticated);
 
   useEffect(
     () => void (pageIsLoading && setAdvFormVisible(false)),
     [pageIsLoading, setAdvFormVisible],
   );
+
+  if (!authenticated) {
+    return (
+      <div className="box">
+        <div className="box-header-timeline" role="heading">
+          Search
+        </div>
+        <div className="box-body" style={{ marginTop: '1em' }}>
+          <p>
+            Please <SignInLink>Sign In</SignInLink> to use the search.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="box">

--- a/src/redux/action-creators.js
+++ b/src/redux/action-creators.js
@@ -777,7 +777,6 @@ export function getSearch(search, offset) {
   return {
     type: ActionTypes.GET_SEARCH,
     apiRequest: Api.getSearch,
-    nonAuthRequest: true,
     payload: { search, offset },
   };
 }
@@ -786,7 +785,6 @@ export function getBestOf(offset) {
   return {
     type: ActionTypes.GET_BEST_OF,
     apiRequest: Api.getBestOf,
-    nonAuthRequest: true,
     payload: { offset },
   };
 }
@@ -795,7 +793,6 @@ export function getEverything(offset) {
   return {
     type: ActionTypes.GET_EVERYTHING,
     apiRequest: Api.getEverything,
-    nonAuthRequest: true,
     payload: { offset },
   };
 }


### PR DESCRIPTION
Make "Everything", "Search" and "Best of" pages not available for non-authorized users. Hide Search form in header for non-authorized users.