### PR TITLE
Make TikTok previews lighter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.114] - Not released
+### Changed
+- TikTok previews now display as static images and load a full-featured embed
+  only after a click.
+
 ## [1.113] - 2022-12-25
 ### Added
 - Email verification support. If verification is supported by server, the new

--- a/src/components/link-preview/tiktok.jsx
+++ b/src/components/link-preview/tiktok.jsx
@@ -1,7 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as Sentry from '@sentry/react';
-
+import { faPlayCircle } from '@fortawesome/free-solid-svg-icons';
+import _ from 'lodash';
+import { Icon } from '../fontawesome-icons';
+import * as aspectRatio from './helpers/size-cache';
 import cachedFetch from './helpers/cached-fetch';
+import FoldableContent from './helpers/foldable-content';
 
 const TIKTOK_VIDEO_RE = /^https?:\/\/(?:www\.)?tiktok\.com\/@.+?\/video\/(\d+)/i;
 
@@ -10,16 +14,21 @@ export function canShowURL(url) {
 }
 
 export default function TikTokVideoPreview({ url }) {
-  const [id, setId] = useState(() => TIKTOK_VIDEO_RE.exec(url)?.[1]);
   const [isError, setIsError] = useState(false);
-  const [byline, setByline] = useState(null);
+  const [oData, setOData] = useState(null);
+  const [isStatic, setIsStatic] = useState(true);
+  const iframeName = useMemo(() => `__tt_embed__v${Math.round(Math.random() * 10000)}`, []);
+
+  const goDynamic = useCallback(() => {
+    startEventListening();
+    setIsStatic(false);
+  }, []);
 
   useEffect(() => {
     cachedFetch(`https://www.tiktok.com/oembed?url=${encodeURIComponent(url)}`)
       .then((data) => {
         if ('title' in data) {
-          setByline(`${data.title || 'Untitled'} by ${data.author_name}`);
-          setId(/data-video-id="(\d+)"/.exec(data.html)?.[1]);
+          setOData(data);
         } else {
           setIsError(true);
         }
@@ -36,13 +45,24 @@ export default function TikTokVideoPreview({ url }) {
       });
   }, [url]);
 
+  const iframe = useRef();
+
+  useLayoutEffect(() => {
+    if (isStatic) {
+      return;
+    }
+
+    const r = aspectRatio.get(url, 2);
+    iframe.current.style.height = `${iframe.current.offsetWidth * r}px`;
+  }, [isStatic, url]);
+
   if (isError) {
     return (
       <div className="link-preview-content">Cannot load TikTok data, probably link is broken.</div>
     );
   }
 
-  if (!id) {
+  if (!oData) {
     return (
       <div className="link-preview-content">
         <div className="tiktok-video-preview">Loading preview data…</div>
@@ -50,27 +70,77 @@ export default function TikTokVideoPreview({ url }) {
     );
   }
 
+  const byline = `${oData.title || 'Untitled'} by ${oData.author_name}`;
+  const r = aspectRatio.get(url, 2);
+
   return (
-    <div className="link-preview-content">
-      <div className="tiktok-video-preview" aria-label="TikTok preview">
-        <iframe
-          src={`https://www.tiktok.com/embed/${id}?referrer=https://tiktok.com/`}
-          frameBorder="0"
-          allowFullScreen
-          scrolling="no"
-          referrerPolicy="no-referrer"
-          importance="low"
-          loading="lazy"
-          className="tiktok-video-iframe"
-        />
-      </div>
-      {byline && (
-        <div className="info">
-          <a href={url} target="_blank" title={byline}>
-            {byline}
-          </a>
+    <FoldableContent>
+      <div className="link-preview-content">
+        <div className="tiktok-video-preview" aria-label="TikTok preview">
+          {isStatic ? (
+            <button className="tiktok-static-btn" onClick={goDynamic}>
+              <svg viewBox={`0 0 1 ${r}`} />
+              <img
+                src={oData.thumbnail_url}
+                width={oData.thumbnail_width}
+                height={oData.thumbnail_height}
+                className="tiktok-static-img"
+              />
+              <Icon icon={faPlayCircle} className="tiktok-static-play-icon" />
+            </button>
+          ) : (
+            <iframe
+              ref={iframe}
+              name={iframeName}
+              src={`https://www.tiktok.com/embed/v2/${
+                oData.embed_product_id
+              }?referrer=${encodeURIComponent(location.href)}`}
+              frameBorder="0"
+              sandbox="allow-scripts allow-same-origin allow-popups"
+              data-url={url}
+              allowFullScreen
+              scrolling="no"
+              referrerPolicy="no-referrer"
+              importance="low"
+              loading="lazy"
+              className="tiktok-video-iframe"
+            />
+          )}
         </div>
-      )}
-    </div>
+        {byline && (
+          <div className="info">
+            <a href={url} target="_blank" title={byline}>
+              {byline}
+            </a>
+          </div>
+        )}
+      </div>
+    </FoldableContent>
   );
+}
+
+const startEventListening = _.once(() => window.addEventListener('message', onMessage));
+
+function onMessage(e) {
+  if (e.origin !== 'https://www.tiktok.com') {
+    return;
+  }
+
+  let data = null;
+  try {
+    data = JSON.parse(e.data);
+  } catch {
+    return;
+  }
+
+  if (typeof data !== 'object' || typeof data.signalSource !== 'string') {
+    return;
+  }
+
+  const frames = document.querySelectorAll('iframe.tiktok-video-iframe');
+  const frame = [...frames].find((fr) => fr.contentWindow === e.source);
+  if (frame && typeof data.height === 'number' && data.height > 100) {
+    frame.style.height = `${data.height}px`;
+    aspectRatio.set(frame.dataset['url'], data.height / frame.offsetWidth);
+  }
 }

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -696,26 +696,50 @@ $post-line-height: rem(20px);
 
   .tiktok-video-preview {
     position: relative;
-    width: 300px;
+    width: 325px;
     max-width: 100%;
     margin-bottom: 10px;
   }
 
-  .tiktok-video-preview::before {
-    content: '';
-    display: block;
+  .tiktok-static-btn {
+    overflow: hidden;
     width: 100%;
+    background-color: transparent;
+    padding: 0;
+    border: none;
+    cursor: pointer;
+    display: flex;
+  }
 
-    // Assuming that aspect ratio is constant
-    padding-bottom: 200%;
+  .tiktok-static-img {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    object-fit: cover;
+    border-radius: 8px;
+  }
+
+  .tiktok-static-play-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 64px;
+    font-size: 100px;
+    color: #fff;
+    opacity: 0.66;
+    text-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+    transition: opacity 0.3s;
+  }
+
+  .tiktok-static-btn:hover .tiktok-static-play-icon {
+    opacity: 1;
   }
 
   .tiktok-video-iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
     width: 100%;
-    height: 100%;
   }
 }
 

--- a/test/jest/__snapshots__/link-preview.test.js.snap
+++ b/test/jest/__snapshots__/link-preview.test.js.snap
@@ -140,12 +140,57 @@ exports[`LinkPreview Shows a Telegram preview 1`] = `
 exports[`LinkPreview Shows a Tiktok preview 1`] = `
 <DocumentFragment>
   <div
-    class="link-preview-content"
+    class="folder-container"
   >
     <div
-      class="tiktok-video-preview"
+      class="content-wrapper"
+      style="height: 1px;"
     >
-      Loading preview data…
+      <div>
+        <div
+          class="link-preview-content"
+        >
+          <div
+            aria-label="TikTok preview"
+            class="tiktok-video-preview"
+          >
+            <button
+              class="tiktok-static-btn"
+            >
+              <svg
+                viewBox="0 0 1 2"
+              />
+              <img
+                class="tiktok-static-img"
+              />
+              <svg
+                aria-hidden="true"
+                class="tiktok-static-play-icon fa-icon fa-icon-fas-play-circle"
+                focusable="false"
+                role="img"
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm115.7 272l-176 101c-15.8 8.8-35.7-2.5-35.7-21V152c0-18.4 19.8-29.8 35.7-21l176 107c16.4 9.2 16.4 32.9 0 42z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="info"
+          >
+            <a
+              href="https://www.tiktok.com/@nathanevanss/video/6910995345421962498"
+              target="_blank"
+              title="The Wellerman. #seashanty #sea #shanty #viral #singing #acoustic #pirate #new #original #fyp #foryou #foryoupage #singer #scottishsinger #scottish by N A T H A N E V A N S S"
+            >
+              The Wellerman. #seashanty #sea #shanty #viral #singing #acoustic #pirate #new #original #fyp #foryou #foryoupage #singer #scottishsinger #scottish by N A T H A N E V A N S S
+            </a>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
TikTok previews have the following problems:
1. they automatically start in the feed;
2. they load a lot of data (about 10 Mb), even if the user doesn't interact with them.

With this PR TikTok previews display as static images and load a full-featured embed only after a click.