### PR TITLE
Fix focusing of "Add comment" field on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.116] - Not released
+### Fixed
+- The "Add comment" input on iOS in the feed view is now correctly focused
+  after creation.
+### Changed
+- The "Comment" link now always opened and focus the "Add comment" input.
+  Previously, a second click closed the input field.
+
 ## [1.115] - 2023-02-10
 ### Added
 - Confirmation with short info on click on every "Block user" button.

--- a/src/components/comment-edit-form.jsx
+++ b/src/components/comment-edit-form.jsx
@@ -20,6 +20,8 @@ export const CommentEditForm = forwardRef(function CommentEditForm(
     initialText = '',
     // Persistent form is always on page so we don't need to show Cancel button
     isPersistent = false,
+    // Adding new comment form
+    isAddingComment = false,
     onSubmit = () => {},
     onCancel = () => {},
     submitStatus = initialAsyncState,
@@ -66,10 +68,10 @@ export const CommentEditForm = forwardRef(function CommentEditForm(
 
   // Set input context if persistent form
   useEffect(() => {
-    if (isPersistent) {
+    if (isAddingComment) {
       setInput(input.current);
     }
-  }, [isPersistent, input, setInput]);
+  }, [setInput, isAddingComment]);
 
   const insText = (insertion) => {
     const [text, selStart, selEnd] = insertText(

--- a/src/components/feed.jsx
+++ b/src/components/feed.jsx
@@ -8,6 +8,7 @@ import Post from './post/post';
 import { PostRecentlyHidden } from './post/post-hides-ui';
 import { joinPostData } from './select-utils';
 import { isMediaAttachment } from './media-viewer';
+import { PostContextProvider } from './post/post-context';
 
 const HiddenEntriesToggle = (props) => {
   const entriesForm = props.count > 1 ? 'entries' : 'entry';
@@ -164,32 +165,34 @@ function FeedEntry({ post, section, ...props }) {
       hiddenByCriteria={post.hiddenByCriteria}
     />
   ) : (
-    <Post
-      {...post}
-      user={props.user}
-      isInHomeFeed={props.isInHomeFeed}
-      isInUserFeed={props.isInUserFeed}
-      showMoreComments={props.showMoreComments}
-      showMoreLikes={props.showMoreLikes}
-      toggleEditingPost={props.toggleEditingPost}
-      cancelEditingPost={props.cancelEditingPost}
-      saveEditingPost={props.saveEditingPost}
-      deletePost={props.deletePost}
-      addAttachmentResponse={props.addAttachmentResponse}
-      showMedia={props.showMedia}
-      toggleCommenting={props.toggleCommenting}
-      addComment={props.addComment}
-      likePost={props.likePost}
-      unlikePost={props.unlikePost}
-      hidePost={props.hidePost}
-      unhidePost={props.unhidePost}
-      toggleModeratingComments={props.toggleModeratingComments}
-      disableComments={props.disableComments}
-      enableComments={props.enableComments}
-      commentEdit={props.commentEdit}
-      highlightTerms={props.highlightTerms}
-      setFinalHideLinkOffset={onPostUnmount}
-      hideEnabled={props.separateHiddenEntries}
-    />
+    <PostContextProvider>
+      <Post
+        {...post}
+        user={props.user}
+        isInHomeFeed={props.isInHomeFeed}
+        isInUserFeed={props.isInUserFeed}
+        showMoreComments={props.showMoreComments}
+        showMoreLikes={props.showMoreLikes}
+        toggleEditingPost={props.toggleEditingPost}
+        cancelEditingPost={props.cancelEditingPost}
+        saveEditingPost={props.saveEditingPost}
+        deletePost={props.deletePost}
+        addAttachmentResponse={props.addAttachmentResponse}
+        showMedia={props.showMedia}
+        toggleCommenting={props.toggleCommenting}
+        addComment={props.addComment}
+        likePost={props.likePost}
+        unlikePost={props.unlikePost}
+        hidePost={props.hidePost}
+        unhidePost={props.unhidePost}
+        toggleModeratingComments={props.toggleModeratingComments}
+        disableComments={props.disableComments}
+        enableComments={props.enableComments}
+        commentEdit={props.commentEdit}
+        highlightTerms={props.highlightTerms}
+        setFinalHideLinkOffset={onPostUnmount}
+        hideEnabled={props.separateHiddenEntries}
+      />
+    </PostContextProvider>
   );
 }

--- a/src/components/post/post-comment.jsx
+++ b/src/components/post/post-comment.jsx
@@ -280,6 +280,7 @@ class PostComment extends Component {
           ref={this.registerCommentForm}
           initialText={this.props.isAddingComment ? this.props.editText : this.props.body}
           isPersistent={this.props.isSinglePost && this.props.isAddingComment}
+          isAddingComment={this.props.isAddingComment}
           onSubmit={this.saveComment}
           onCancel={this.handleEditOrCancel}
           submitStatus={this.props.saveStatus}

--- a/src/components/post/post.jsx
+++ b/src/components/post/post.jsx
@@ -40,6 +40,7 @@ import { UserPicture } from '../user-picture';
 import { SubmitModeHint } from '../submit-mode-hint';
 import { SubmittableTextarea } from '../submittable-textarea';
 
+import { prepareAsyncFocus } from '../../utils/prepare-async-focus';
 import { UnhideOptions, HideLink } from './post-hides-ui';
 import PostMoreLink from './post-more-link';
 import PostLikeLink from './post-like-link';
@@ -122,6 +123,7 @@ class Post extends Component {
     if (this.props.isCommenting) {
       this.context.input?.focus();
     } else {
+      prepareAsyncFocus();
       this.props.toggleCommenting(this.props.id);
     }
   };

--- a/src/components/post/post.jsx
+++ b/src/components/post/post.jsx
@@ -119,12 +119,11 @@ class Post extends Component {
   attLoadingCompleted = () => this.setState({ attLoading: false });
 
   handleCommentClick = () => {
-    if (this.props.isSinglePost) {
+    if (this.props.isCommenting) {
       this.context.input?.focus();
-      return;
+    } else {
+      this.props.toggleCommenting(this.props.id);
     }
-
-    this.props.toggleCommenting(this.props.id);
   };
 
   handleDeletePost =

--- a/src/components/post/post.jsx
+++ b/src/components/post/post.jsx
@@ -121,6 +121,7 @@ class Post extends Component {
 
   handleCommentClick = () => {
     if (this.props.isCommenting) {
+      this.context.input?.scrollIntoView({ block: 'center', behavior: 'smooth' });
       this.context.input?.focus();
     } else {
       prepareAsyncFocus();

--- a/src/utils/prepare-async-focus.js
+++ b/src/utils/prepare-async-focus.js
@@ -1,0 +1,30 @@
+/**
+ * iOS doesn't allow to properly .focus() text inputs outside of event handler.
+ * Input is focusing, but the mobile keyboard doesn't pop up. Proper focusing
+ * only occurs if .focus() is called synchronously in the handler of an event
+ * triggered by the user. Asynchronous nature of React does not always allow
+ * this.
+ *
+ * But there is a workaround. iOS allows you to _move_ the focus if it's already
+ * set on some text input (see https://stackoverflow.com/a/45703019).
+ *
+ * So this function is for such cases. It creates invisible input and sets focus
+ * on it. It also positions this at the center of screen to prevent scrolling
+ * due the focus change.
+ *
+ * Call this function in the event handler, and then you can asynchronously call
+ * .focus() on any text element. The invisible input will be auto-removed after
+ * 1 sec.
+ */
+export function prepareAsyncFocus() {
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'sr-only';
+  input.style.position = 'fixed';
+  input.style.left = '50%';
+  input.style.top = '50%';
+  document.body.appendChild(input);
+  input.focus();
+  // Clean up
+  setTimeout(() => input.remove(), 1000);
+}


### PR DESCRIPTION
### Changed
- The "Comment" link now always opened and focus the "Add comment" input. Previously, a second click closed the input field.
### Fixed
- The "Add comment" input on iOS in the feed view is now correctly focused after creation.
