### PR TITLE
Add 'Mention @username' to PostMoreMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.117] - Not released
+### Added
+- New "Mention @username" item has been included to the post's dropdown menu. By
+  clicking on it, you can start a new comment and mention the person who created
+  the post or add their @username to the comment you are currently editing.
+
 ### Changed
 - The Dropzone library has been replaced with a custom file uploader.
   Attachments for posts and comments are now uploaded uniformly. The CreatePost
@@ -17,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - insert text to the cursor position using 'insertText' instance method;
   - use 'onText' attribute to handle updated text (it is necessary for
     'insertText' updates, which doesn't trigger onChange).
-  
+
   This component handles all tasks related to creating/editing posts and
   comments in a unified way.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.117] - Not released
 ### Added
-- New "Mention @username" item has been included to the post's dropdown menu. By
-  clicking on it, you can start a new comment and mention the person who created
-  the post or add their @username to the comment you are currently editing.
+- A new "Mention @username" item has been added to the post's dropdown menu.
+  By clicking on it, you can start a new comment and mention the person who
+  created the post, or add their @username to the comment you have already started creating.
 
 ### Changed
 - The Dropzone library has been replaced with a custom file uploader.

--- a/src/components/hooks/drop-down.js
+++ b/src/components/hooks/drop-down.js
@@ -18,6 +18,7 @@ export function useDropDown({
 
   const [opened, setOpened] = useState(false);
   const toggle = useCallback(() => setOpened((x) => !x), []);
+  const close = useCallback(() => setOpened(false), []);
 
   // Close menu on any click on page
   useEffect(() => {
@@ -50,7 +51,7 @@ export function useDropDown({
 
   useLayoutEffect(updPosition);
 
-  return { pivotRef, menuRef, opened, setOpened, toggle };
+  return { pivotRef, menuRef, opened, setOpened, toggle, close };
 }
 
 function updatePosition(leader, follower, { screenEdgeGap, position, fixed = false }) {

--- a/src/components/hooks/drop-down.js
+++ b/src/components/hooks/drop-down.js
@@ -18,7 +18,7 @@ export function useDropDown({
 
   const [opened, setOpened] = useState(false);
   const toggle = useCallback(() => setOpened((x) => !x), []);
-  const close = useCallback(() => setOpened(false), []);
+  const forceClose = useCallback(() => setOpened(false), []);
 
   // Close menu on any click on page
   useEffect(() => {
@@ -51,7 +51,7 @@ export function useDropDown({
 
   useLayoutEffect(updPosition);
 
-  return { pivotRef, menuRef, opened, setOpened, toggle, close };
+  return { pivotRef, menuRef, opened, setOpened, toggle, forceClose };
 }
 
 function updatePosition(leader, follower, { screenEdgeGap, position, fixed = false }) {

--- a/src/components/post/post-more-link.jsx
+++ b/src/components/post/post-more-link.jsx
@@ -16,12 +16,13 @@ import { PostMoreMenu } from './post-more-menu';
 export default function PostMoreLink({ post, user, ...props }) {
   const fixedMenu = useMediaQuery('(max-width: 450px)');
 
-  const { pivotRef, menuRef, opened, toggle } = useDropDownKbd({
+  const { pivotRef, menuRef, opened, toggle, close } = useDropDownKbd({
     closeOn: CLOSE_ON_CLICK_OUTSIDE,
     fixed: fixedMenu,
   });
 
   const doAndClose = useCallback((h) => h && ((...args) => (h(...args), toggle())), [toggle]);
+  const doAndForceClose = useCallback((h) => h && ((...args) => (h(...args), close())), [close]);
 
   const deletePost = useCallback(
     (...feedNames) => confirmFirst(props.deletePost(...feedNames)),
@@ -81,9 +82,11 @@ export default function PostMoreLink({ post, user, ...props }) {
             disableComments={props.disableComments}
             deletePost={deletePost}
             doAndClose={doAndClose}
+            doAndForceClose={doAndForceClose}
             permalink={canonicalPostURI}
             toggleSave={props.toggleSave}
             fixed={fixedMenu}
+            doMention={props.handleMentionAuthor}
           />
         </Portal>
       )}

--- a/src/components/post/post-more-link.jsx
+++ b/src/components/post/post-more-link.jsx
@@ -16,13 +16,16 @@ import { PostMoreMenu } from './post-more-menu';
 export default function PostMoreLink({ post, user, ...props }) {
   const fixedMenu = useMediaQuery('(max-width: 450px)');
 
-  const { pivotRef, menuRef, opened, toggle, close } = useDropDownKbd({
+  const { pivotRef, menuRef, opened, toggle, forceClose } = useDropDownKbd({
     closeOn: CLOSE_ON_CLICK_OUTSIDE,
     fixed: fixedMenu,
   });
 
   const doAndClose = useCallback((h) => h && ((...args) => (h(...args), toggle())), [toggle]);
-  const doAndForceClose = useCallback((h) => h && ((...args) => (h(...args), close())), [close]);
+  const doAndForceClose = useCallback(
+    (h) => h && ((...args) => (h(...args), forceClose())),
+    [forceClose],
+  );
 
   const deletePost = useCallback(
     (...feedNames) => confirmFirst(props.deletePost(...feedNames)),

--- a/src/components/post/post-more-menu.jsx
+++ b/src/components/post/post-more-menu.jsx
@@ -88,10 +88,10 @@ export const PostMoreMenu = forwardRef(function PostMoreMenu(
 
   const menuGroups = [
     [
-      !isOwnPost && (
-        <div className={styles.item} key="mention-username">
+      amIAuthenticated && !isOwnPost && (!commentsDisabled || isModeratable) && (
+        <div className={styles.item} key="mention-author">
           <ButtonLink onClick={doAndForceClose(doMention)} className={styles.link}>
-            <Iconic icon={faAt}>Mention @{postCreatedBy.username}</Iconic>
+            <Iconic icon={faAt}>Mention @{postCreatedBy?.username}</Iconic>
           </ButtonLink>
         </div>
       ),

--- a/src/components/post/post-more-menu.jsx
+++ b/src/components/post/post-more-menu.jsx
@@ -7,6 +7,7 @@ import {
   faEdit,
   faBookmark as faBookmarkSolid,
   faSignOutAlt,
+  faAt,
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faClock,
@@ -26,6 +27,7 @@ import TimeDisplay from '../time-display';
 
 import styles from '../dropdown-menu.module.scss';
 
+// eslint-disable-next-line complexity
 export const PostMoreMenu = forwardRef(function PostMoreMenu(
   {
     user,
@@ -50,9 +52,11 @@ export const PostMoreMenu = forwardRef(function PostMoreMenu(
     disableComments,
     deletePost,
     doAndClose,
+    doAndForceClose,
     permalink,
     toggleSave,
     fixed = false,
+    doMention,
   },
   ref,
 ) {
@@ -83,6 +87,15 @@ export const PostMoreMenu = forwardRef(function PostMoreMenu(
   }, [isEditable, isDeletable, canBeRemovedFrom, deletePost]);
 
   const menuGroups = [
+    [
+      !isOwnPost && (
+        <div className={styles.item} key="mention-username">
+          <ButtonLink onClick={doAndForceClose(doMention)} className={styles.link}>
+            <Iconic icon={faAt}>Mention @{postCreatedBy.username}</Iconic>
+          </ButtonLink>
+        </div>
+      ),
+    ],
     [
       isEditable && (
         <div className={styles.item} key="edit-post">

--- a/src/components/post/post.jsx
+++ b/src/components/post/post.jsx
@@ -60,7 +60,8 @@ class Post extends Component {
       text && this.context.input?.insertText(text);
     } else {
       prepareAsyncFocus();
-      this.props.toggleCommenting(this.props.id, text);
+      (!text && this.props.toggleCommenting(this.props.id)) ||
+        this.props.toggleCommenting(this.props.id, text);
     }
   };
 

--- a/src/components/post/post.jsx
+++ b/src/components/post/post.jsx
@@ -53,14 +53,24 @@ class Post extends Component {
     unHideOpened: false,
   };
 
-  handleCommentClick = () => {
+  _handleUniversalComment = (text) => {
     if (this.props.isCommenting) {
       this.context.input?.scrollIntoView({ block: 'center', behavior: 'smooth' });
       this.context.input?.focus();
+      text && this.context.input?.insertText(text);
     } else {
       prepareAsyncFocus();
-      this.props.toggleCommenting(this.props.id);
+      this.props.toggleCommenting(this.props.id, text);
     }
+  };
+
+  handleMentionAuthorClick = () => {
+    const username = this.props.createdBy?.username;
+    username && this._handleUniversalComment(`@${username} `);
+  };
+
+  handleCommentClick = () => {
+    this._handleUniversalComment();
   };
 
   handleDeletePost =
@@ -256,6 +266,7 @@ class Post extends Component {
         enableComments={this.enableComments}
         deletePost={this.handleDeletePost}
         toggleSave={this.toggleSave}
+        handleMentionAuthor={this.handleMentionAuthorClick}
       />
     );
 

--- a/test/jest/__snapshots__/post-more-menu.test.jsx.snap
+++ b/test/jest/__snapshots__/post-more-menu.test.jsx.snap
@@ -24,6 +24,35 @@ exports[`PostMoreMenu Renders a More menu for a group moderator 1`] = `
             <span
               class="iconicIcon"
             >
+              fontawesome icon at
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Mention @author
+            </span>
+          </span>
+        </a>
+      </div>
+    </div>
+    <div
+      class="group"
+    >
+      <div
+        class="item"
+      >
+        <a
+          aria-disabled="false"
+          class="link"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
               fontawesome icon comment-dots
             </span>
             <span
@@ -236,6 +265,35 @@ exports[`PostMoreMenu Renders a More menu for a logged-in reader 1`] = `
     class="list focusList"
     style="min-width: 18em;"
   >
+    <div
+      class="group"
+    >
+      <div
+        class="item"
+      >
+        <a
+          aria-disabled="false"
+          class="link"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="iconic"
+          >
+            <span
+              class="iconicIcon"
+            >
+              fontawesome icon at
+            </span>
+            <span
+              class="iconicContent"
+            >
+              Mention @author
+            </span>
+          </span>
+        </a>
+      </div>
+    </div>
     <div
       class="group"
     >

--- a/test/jest/post-more-menu.test.jsx
+++ b/test/jest/post-more-menu.test.jsx
@@ -49,8 +49,10 @@ const renderPostMoreMenu = (props = {}) => {
     disableComments: () => {},
     deletePost: () => {},
     doAndClose: () => {},
+    doAndForceClose: () => {},
     permalink: 'https://freefeed.net/post123',
     toggleSave: () => {},
+    doMention: () => {},
   };
 
   return render(

--- a/test/jest/post-more-menu.test.jsx
+++ b/test/jest/post-more-menu.test.jsx
@@ -17,6 +17,12 @@ const VIEWER = {
   },
 };
 
+const AUTHOR = {
+  ...VIEWER,
+  id: 'user-id2',
+  username: 'author',
+};
+
 const POST = {
   id: 'post123',
   isEditable: false,
@@ -29,6 +35,8 @@ const POST = {
   updatedAt: '1629668999999',
   isSaved: false,
   savePostStatus: {},
+  createdBy: AUTHOR,
+  isDirect: false,
 };
 
 const defaultState = {
@@ -93,6 +101,7 @@ describe('PostMoreMenu', () => {
         ...POST,
         isEditable: true,
         isDeletable: true,
+        createdBy: VIEWER,
       },
     });
 


### PR DESCRIPTION
New "Mention @username" item has been added to the post's dropdown menu. By clicking on it, you can start a new comment and mention the person who created the post or add their @username to the comment you are currently editing.