### PR TITLE
Fix an error inserting pictures when editing a post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.118] - Not released
+### Fixed
+- An error inserting pictures when editing a post
 
 ## [1.117.1] - 2023-04-01
 ### Fixed

--- a/src/components/post/post-edit-form.jsx
+++ b/src/components/post/post-edit-form.jsx
@@ -141,7 +141,7 @@ export function PostEditForm({ id, isDirect, recipients, createdBy, body, attach
             value={postText}
             onSubmit={handleSubmit}
             onText={setPostText}
-            onFile={chooseFiles}
+            onFile={uploadFile}
             autoFocus={true}
             minRows={2}
             maxRows={10}


### PR DESCRIPTION
When pasting a picture into the post edit form, the upload dialog was opened erroneously.