### PR TITLE
Replace custom pseudo-buttons with ButtonLink components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Use explicit import() statements in the index.jsx
   - Use relative css imports for styles from node_modules
   - Update stylelint calls and fix styles issues
+- All "a" links without the "href" attribute and some other pseudo-buttons have
+  been replaced by the ButtonLink component. This improves the keyboard
+  accessibility of the site because ButtonLink is able to focus and click from
+  the keyboard.
 
 ## [1.118] - 2023-05-05
 ### Added

--- a/src/components/button-link.jsx
+++ b/src/components/button-link.jsx
@@ -2,13 +2,16 @@ import { useCallback, memo, forwardRef, useMemo } from 'react';
 
 // Inspired by https://www.w3.org/TR/wai-aria-practices/examples/button/button.html
 export const ButtonLink = memo(
-  forwardRef(function ButtonLink({ onClick: click, disabled = false, ...props }, ref) {
+  forwardRef(function ButtonLink(
+    { tag: Tag = 'a', onClick: click, disabled = false, ...props },
+    ref,
+  ) {
     const kbdHandlers = useKeyboardEvents(
       useCallback((event) => disabled || click(event), [click, disabled]),
     );
 
     return (
-      <a
+      <Tag
         role="button"
         aria-disabled={disabled}
         tabIndex={0}
@@ -19,6 +22,8 @@ export const ButtonLink = memo(
     );
   }),
 );
+
+ButtonLink.displayName = 'ButtonLink';
 
 export function useKeyboardEvents(onClick) {
   return useMemo(

--- a/src/components/comment-icon.jsx
+++ b/src/components/comment-icon.jsx
@@ -16,6 +16,7 @@ import { Throbber } from './throbber';
 import { useWaiting } from './hooks/waiting';
 import { useCommentLikers } from './comment-likers';
 import { useLongTapHandlers } from './hooks/long-tap';
+import { ButtonLink } from './button-link';
 
 // Do not show clikes list for this interval if data is not available yet
 const CLIKES_LIST_DELAY = 250;
@@ -67,23 +68,23 @@ export default memo(function CommentIcon({ id, omitBubble = false, reply, mentio
       {/* Heart & likes count */}
       <div className={heartClass}>
         {likes ? (
-          <div
+          <ButtonLink
+            tag="div"
             className="comment-count"
             onClick={likesListToggle}
             ref={countRef}
-            role="button"
             aria-label={pluralForm(likes, 'comment like')}
           >
             {likes}
-          </div>
+          </ButtonLink>
         ) : (
           false
         )}
         {canLike ? (
-          <div
+          <ButtonLink
+            tag="div"
             className="comment-heart"
             onClick={heartClick}
-            role="button"
             aria-label={hasOwnLike ? 'Un-like this comment' : 'Like this comment'}
           >
             <Icon
@@ -91,7 +92,7 @@ export default memo(function CommentIcon({ id, omitBubble = false, reply, mentio
               className={cn('icon', hasOwnLike ? 'liked' : false)}
               title={hasOwnLike ? 'Un-like' : 'Like'}
             />
-          </div>
+          </ButtonLink>
         ) : (
           <div className="comment-heart">
             <Icon icon={faHeartO} className="icon" title="Your own comment" />

--- a/src/components/expandable.jsx
+++ b/src/components/expandable.jsx
@@ -5,6 +5,7 @@ import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 import { Icon } from './fontawesome-icons';
 
 import ErrorBoundary from './error-boundary';
+import { ButtonLink } from './button-link';
 
 const DEFAULT_MAX_LINES = 8;
 const DEFAULT_ABOVE_FOLD_LINES = 5;
@@ -42,9 +43,9 @@ export default class Expandable extends Component {
           {!expanded && (
             <div className="expand-panel">
               <div className="expand-button">
-                <i onClick={this.userExpand} role="button" aria-hidden>
+                <ButtonLink tag="i" onClick={this.userExpand} aria-hidden>
                   <Icon icon={faChevronDown} className="expand-icon" /> Read more
-                </i>{' '}
+                </ButtonLink>{' '}
                 {this.props.bonusInfo}
               </div>
             </div>

--- a/src/components/feed-options-switch.jsx
+++ b/src/components/feed-options-switch.jsx
@@ -21,6 +21,7 @@ import { faEllipsis } from './fontawesome-custom-icons';
 import menuStyles from './dropdown-menu.module.scss';
 import styles from './feed-options-switch.module.scss';
 import { useDropDown, BOTTOM_LEFT } from './hooks/drop-down';
+import { ButtonLink } from './button-link';
 
 export default function FeedOptionsSwitch() {
   const { pivotRef, menuRef, opened, toggle } = useDropDown({ position: BOTTOM_LEFT });
@@ -61,8 +62,10 @@ export default function FeedOptionsSwitch() {
   }, [dispatch, frontendPreferences, userId]);
 
   return (
-    <div className={styles.switchIcon} role="button" aria-label="Feed ordering options">
-      <Icon icon={faEllipsis} className="dots-icon" onClick={toggle} ref={pivotRef} />
+    <>
+      <ButtonLink className={styles.switchIcon} aria-label="Feed ordering options" onClick={toggle}>
+        <Icon icon={faEllipsis} className="dots-icon" ref={pivotRef} />
+      </ButtonLink>
       {opened && (
         <Portal>
           <ul className={menuStyles.list} ref={menuRef}>
@@ -98,7 +101,7 @@ export default function FeedOptionsSwitch() {
           </ul>
         </Portal>
       )}
-    </div>
+    </>
   );
 }
 
@@ -112,10 +115,10 @@ function DropOption({ children, value, current, clickHandler, checkbox = false }
 
   return (
     <li className={menuStyles.item}>
-      <a className={className} onClick={onClick}>
+      <ButtonLink className={className} onClick={onClick}>
         <Icon className={styles.icon} icon={value === current ? iconOn : iconOff} />
         {children}
-      </a>
+      </ButtonLink>
     </li>
   );
 }

--- a/src/components/feed.jsx
+++ b/src/components/feed.jsx
@@ -9,6 +9,7 @@ import { PostRecentlyHidden } from './post/post-hides-ui';
 import { joinPostData } from './select-utils';
 import { isMediaAttachment } from './media-viewer';
 import { PostContextProvider } from './post/post-context';
+import { ButtonLink } from './button-link';
 
 const HiddenEntriesToggle = (props) => {
   const entriesForm = props.count > 1 ? 'entries' : 'entry';
@@ -22,7 +23,7 @@ const HiddenEntriesToggle = (props) => {
 
   return (
     <div className="hidden-posts-toggle">
-      <a onClick={props.toggle}>{label}</a>
+      <ButtonLink onClick={props.toggle}>{label}</ButtonLink>
     </div>
   );
 };

--- a/src/components/link-preview/helpers/foldable-content.jsx
+++ b/src/components/link-preview/helpers/foldable-content.jsx
@@ -3,6 +3,7 @@ import { faMinusSquare, faPlusSquare } from '@fortawesome/free-regular-svg-icons
 import classnames from 'classnames';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Icon } from '../../fontawesome-icons';
+import { ButtonLink } from '../../button-link';
 
 const resizeHandlers = new Map();
 
@@ -61,7 +62,7 @@ export default function FoldableContent({ maxUnfoldedHeight = 550, foldedHeight 
             className="preview-expand-icon"
             onClick={toggleExpanded}
           />{' '}
-          <a onClick={toggleExpanded}>{expanded ? 'Fold' : 'Expand'} preview</a>
+          <ButtonLink onClick={toggleExpanded}>{expanded ? 'Fold' : 'Expand'} preview</ButtonLink>
         </div>
       )}
     </div>

--- a/src/components/piece-of-text.jsx
+++ b/src/components/piece-of-text.jsx
@@ -7,6 +7,7 @@ import { parseText } from '../utils/parse-text';
 
 import Spoiler from './spoiler';
 import Linkify from './linkify';
+import { ButtonLink } from './button-link';
 
 // Texts longer than thresholdTextLength should be cut to shortenedTextLength
 const thresholdTextLength = 800;
@@ -85,9 +86,9 @@ const getCollapsedText = (text, expandText) => {
         {normalizedText}
       </span>,
       ' ',
-      <a key="read-more" className="read-more" onClick={expandText}>
+      <ButtonLink key="read-more" className="read-more" onClick={expandText}>
         Expand
-      </a>,
+      </ButtonLink>,
     ];
   }
 
@@ -99,9 +100,9 @@ const getCollapsedText = (text, expandText) => {
       {shortenedText}
     </span>,
     ' ',
-    <a key="read-more" className="read-more" onClick={expandText}>
+    <ButtonLink key="read-more" className="read-more" onClick={expandText}>
       Read more
-    </a>,
+    </ButtonLink>,
   ];
 };
 

--- a/src/components/post/post-comments/index.jsx
+++ b/src/components/post/post-comments/index.jsx
@@ -11,6 +11,7 @@ import { SignInLink } from '../../sign-in-link';
 import PostComment from '../post-comment';
 import { prepareAsyncFocus } from '../../../utils/prepare-async-focus';
 import { PostContext } from '../post-context';
+import { ButtonLink } from '../../button-link';
 import { CollapseComments } from './collapse-comments';
 import ExpandComments from './expand-comments';
 import { LoadingComments } from './loading-comments';
@@ -120,16 +121,12 @@ export default class PostComments extends Component {
     if (props.comments.length > 2 && !props.post.omittedComments) {
       return (
         <div className="comment">
-          <a
-            className="comment-icon fa-stack"
-            onClick={preventDefault(toggleCommenting)}
-            role="button"
-          >
+          <span className="comment-icon fa-stack">
             <Icon icon={faCommentPlus} />
-          </a>
-          <a className="add-comment-link" onClick={preventDefault(toggleCommenting)} role="button">
+          </span>
+          <ButtonLink className="add-comment-link" onClick={preventDefault(toggleCommenting)}>
             Add comment
-          </a>
+          </ButtonLink>
           {disabledForOthers ? <i> - disabled for others</i> : false}
         </div>
       );

--- a/src/components/post/post-edit-form.jsx
+++ b/src/components/post/post-edit-form.jsx
@@ -196,7 +196,6 @@ export function PostEditForm({ id, isDirect, recipients, createdBy, body, attach
             <ButtonLink
               className="post-edit-attachments"
               disabled={!canUploadMore}
-              role="button"
               onClick={chooseFiles}
             >
               <Icon icon={faPaperclip} className="upload-icon" /> Add photos or files

--- a/src/components/post/post-hides-ui.jsx
+++ b/src/components/post/post-hides-ui.jsx
@@ -13,6 +13,7 @@ import { safeScrollBy } from '../../services/unscroll';
 import { Icon } from '../fontawesome-icons';
 import { Throbber } from '../throbber';
 import { hasCriterion, isEqual, USERNAME } from '../../utils/hide-criteria';
+import { ButtonLink } from '../button-link';
 
 export function PostRecentlyHidden({
   id,
@@ -49,13 +50,18 @@ export function PostRecentlyHidden({
   return (
     <div className="post recently-hidden-post">
       <div className="post-body">
-        <a className="recently-hidden-post__close" onClick={doRemove} title="Remove this block">
+        <ButtonLink
+          className="recently-hidden-post__close"
+          onClick={doRemove}
+          title="Remove this block"
+        >
           <Icon icon={faTimes} />
-        </a>
+        </ButtonLink>
         <p ref={firstLine}>
           {isHidden ? (
             <>
-              Post hidden from your Home feed - <a onClick={doUnhidePost}>Un-hide</a>
+              Post hidden from your Home feed -{' '}
+              <ButtonLink onClick={doUnhidePost}>Un-hide</ButtonLink>
             </>
           ) : (
             <>Post still not visible because {hideReason}:</>
@@ -79,10 +85,10 @@ export function PostRecentlyHidden({
           const hidden = hasCriterion(hiddenByCriteria || [], crit);
           return (
             <p key={`${crit.type}:${crit.value}`}>
-              <a onClick={doHideByCriterion(crit, !hidden)}>
+              <ButtonLink onClick={doHideByCriterion(crit, !hidden)}>
                 {hidden ? 'Show' : 'Hide all'} posts{' '}
                 {crit.type === USERNAME ? `from @${crit.value}` : `with ${crit.value}`}
-              </a>
+              </ButtonLink>
             </p>
           );
         })}
@@ -125,9 +131,9 @@ export function HideLink({
   }
 
   return (
-    <a className="post-action" onClick={handler} role="button">
+    <ButtonLink className="post-action" onClick={handler}>
       {text}
-    </a>
+    </ButtonLink>
   );
 }
 
@@ -149,7 +155,7 @@ export function UnhideOptions({
       }
     }
     // eslint-disable-next-line react/jsx-key
-    lines.push(['_post', <a onClick={handleFullUnhide}>{title}</a>]);
+    lines.push(['_post', <ButtonLink onClick={handleFullUnhide}>{title}</ButtonLink>]);
   }
 
   if (hiddenByCriteria) {
@@ -161,7 +167,7 @@ export function UnhideOptions({
         return [
           `${crit.type}:${crit.value}`,
           // eslint-disable-next-line react/jsx-key
-          <a onClick={handleUnhideByCriteria(crit)}>{text}</a>,
+          <ButtonLink onClick={handleUnhideByCriteria(crit)}>{text}</ButtonLink>,
         ];
       }),
     );

--- a/src/components/post/post-likes.jsx
+++ b/src/components/post/post-likes.jsx
@@ -4,15 +4,16 @@ import { preventDefault, pluralForm } from '../../utils';
 import UserName from '../user-name';
 import ErrorBoundary from '../error-boundary';
 import { Icon } from '../fontawesome-icons';
+import { ButtonLink } from '../button-link';
 
 const renderLike = (item, i, items) => (
   <li key={item.id} className="post-like">
     {item.id !== 'more-likes' ? (
       <UserName user={item} />
     ) : (
-      <a className="more-post-likes-link" onClick={preventDefault(item.showMoreLikes)}>
+      <ButtonLink className="more-post-likes-link" onClick={preventDefault(item.showMoreLikes)}>
         {item.omittedLikes} other people
-      </a>
+      </ButtonLink>
     )}
 
     {i < items.length - 2 ? ', ' : i === items.length - 2 ? ' and ' : ' liked this '}

--- a/src/components/post/post-via.jsx
+++ b/src/components/post/post-via.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import * as _ from 'lodash-es';
 import UserName from '../user-name';
+import { ButtonLink } from '../button-link';
 
 // props types
 const userType = PropTypes.shape({
@@ -80,9 +81,9 @@ export default class PostVia extends Component {
           <span>
             {' '}
             and{' '}
-            <a className="post-via-more" onClick={this.expand}>
+            <ButtonLink className="post-via-more" onClick={this.expand}>
               {foldedCount} more
-            </a>
+            </ButtonLink>
           </span>
         ) : (
           false

--- a/src/components/post/post.jsx
+++ b/src/components/post/post.jsx
@@ -276,28 +276,28 @@ class Post extends Component {
         <div className="post-footer">
           <div className="post-footer-icon">
             {isPrivate ? (
-              <Icon
+              <ButtonLink
+                tag={Icon}
                 icon={faLock}
                 className="post-lock-icon post-private-icon"
                 title="This entry is private"
                 onClick={this.toggleTimestamps}
-                role="button"
               />
             ) : isProtected ? (
-              <Icon
+              <ButtonLink
+                tag={Icon}
                 icon={faUserFriends}
                 className="post-lock-icon post-protected-icon"
                 title={`This entry is only visible to ${CONFIG.siteTitle} users`}
                 onClick={this.toggleTimestamps}
-                role="button"
               />
             ) : (
-              <Icon
+              <ButtonLink
+                tag={Icon}
                 icon={faGlobeAmericas}
                 className="post-lock-icon post-public-icon"
                 title="This entry is public"
                 onClick={this.toggleTimestamps}
-                role="button"
               />
             )}
           </div>

--- a/src/components/settings/app-tokens/scopes-list.jsx
+++ b/src/components/settings/app-tokens/scopes-list.jsx
@@ -5,6 +5,7 @@ import snarkdown from 'snarkdown';
 import { faCaretRight, faCaretDown } from '@fortawesome/free-solid-svg-icons';
 import { getAppTokensScopes } from '../../../redux/action-creators';
 import { Icon } from '../../fontawesome-icons';
+import { ButtonLink } from '../../button-link';
 import { descriptions } from './scopes-descriptions';
 import styles from './scopes-list.module.scss';
 import { withLayout } from './layout';
@@ -69,9 +70,9 @@ function APIList({ children }) {
   return (
     <div className={styles.apiList}>
       <div>
-        <a onClick={toggle}>
+        <ButtonLink onClick={toggle}>
           <Icon icon={opened ? faCaretDown : faCaretRight} /> Allowed API methods
-        </a>{' '}
+        </ButtonLink>{' '}
         (for developers)
       </div>
       {opened && <div className={styles.apiListMethods}>{children}</div>}

--- a/src/components/settings/app-tokens/token-form-fields.jsx
+++ b/src/components/settings/app-tokens/token-form-fields.jsx
@@ -5,6 +5,7 @@ import { uniq, without } from 'lodash-es';
 import { faCaretRight } from '@fortawesome/free-solid-svg-icons';
 import { getAppTokensScopes } from '../../../redux/action-creators';
 import { Icon } from '../../fontawesome-icons';
+import { ButtonLink } from '../../button-link';
 
 export const initialFormData = {
   title: '',
@@ -119,9 +120,9 @@ export default function TokenForm({ initialData = initialFormData, onChange }) {
         </>
       ) : (
         <div className="form-group help-block">
-          <a onClick={showRestrictionsClick}>
+          <ButtonLink onClick={showRestrictionsClick}>
             <Icon icon={faCaretRight} /> Set additional restrictions
-          </a>{' '}
+          </ButtonLink>{' '}
           (optional)
         </div>
       )}

--- a/src/components/settings/app-tokens/token-row.jsx
+++ b/src/components/settings/app-tokens/token-row.jsx
@@ -12,6 +12,7 @@ import {
 } from '../../../redux/action-creators';
 import { Icon } from '../../fontawesome-icons';
 import TimeDisplay from '../../time-display';
+import { ButtonLink } from '../../button-link';
 import { TextCopier } from './text-copier';
 
 import styles from './token-row.module.scss';
@@ -72,7 +73,7 @@ export default function TokenRow({ id }) {
       </div>
 
       <p>
-        <strong>{token.title}</strong> (<a onClick={onEdit}>rename</a>)
+        <strong>{token.title}</strong> (<ButtonLink onClick={onEdit}>rename</ButtonLink>)
       </p>
       <div className="small text-muted">
         <p className={styles.allowsBlock}>{scopesTexts.join(', ')}</p>

--- a/src/components/tile-user-list.jsx
+++ b/src/components/tile-user-list.jsx
@@ -6,6 +6,7 @@ import { confirmFirst } from '../utils';
 import UserName from './user-name';
 import { UserPicture } from './user-picture';
 import { Separated } from './separated';
+import { ButtonLink } from './button-link';
 
 class UserTile extends PureComponent {
   handleAcceptClick = () => {
@@ -59,9 +60,9 @@ class UserTile extends PureComponent {
 
         {type == WITH_REQUEST_HANDLES ? (
           <div className="user-actions">
-            <a onClick={this.handleAcceptClick}>Accept</a>
+            <ButtonLink onClick={this.handleAcceptClick}>Accept</ButtonLink>
             <span> - </span>
-            <a onClick={this.handleRejectClick}>Reject</a>
+            <ButtonLink onClick={this.handleRejectClick}>Reject</ButtonLink>
           </div>
         ) : (
           false
@@ -71,17 +72,20 @@ class UserTile extends PureComponent {
           <div className="user-actions">
             {!user.isGone ? (
               <>
-                <a onClick={this.handlePromoteClick} title="Promote user to admin">
+                <ButtonLink onClick={this.handlePromoteClick} title="Promote user to admin">
                   Promote
-                </a>
+                </ButtonLink>
                 <span> - </span>
               </>
             ) : (
               false
             )}
-            <a onClick={this.handleUnsubscribeClick} title="Unsubscribe user from the group">
+            <ButtonLink
+              onClick={this.handleUnsubscribeClick}
+              title="Unsubscribe user from the group"
+            >
               Unsub
-            </a>
+            </ButtonLink>
           </div>
         ) : (
           false
@@ -89,9 +93,9 @@ class UserTile extends PureComponent {
 
         {type == WITH_REMOVE_ADMIN_RIGHTS ? (
           <div className="user-actions">
-            <a onClick={this.handleDemoteClick} title="Demote user from admin">
+            <ButtonLink onClick={this.handleDemoteClick} title="Demote user from admin">
               Demote
-            </a>
+            </ButtonLink>
           </div>
         ) : (
           false
@@ -99,9 +103,9 @@ class UserTile extends PureComponent {
 
         {type == WITH_REVOKE_SENT_REQUEST ? (
           <div className="user-actions">
-            <a onClick={this.handleRevokeClick} title="Revoke sent request">
+            <ButtonLink onClick={this.handleRevokeClick} title="Revoke sent request">
               Revoke
-            </a>
+            </ButtonLink>
           </div>
         ) : (
           false
@@ -111,9 +115,9 @@ class UserTile extends PureComponent {
           <div className="user-actions">
             <Separated separator=" - ">
               {actions.map((a) => (
-                <a onClick={a.handler} key={a.title}>
+                <ButtonLink onClick={a.handler} key={a.title}>
                   {a.title}
-                </a>
+                </ButtonLink>
               ))}
             </Separated>
           </div>

--- a/src/components/user-card.jsx
+++ b/src/components/user-card.jsx
@@ -12,6 +12,7 @@ import ErrorBoundary from './error-boundary';
 import { userActions } from './select-utils';
 import { UserPicture } from './user-picture';
 import { useShowBanDialog } from './dialog/ban-dialog';
+import { ButtonLink } from './button-link';
 
 class UserCard extends Component {
   constructor(props) {
@@ -159,7 +160,7 @@ class UserCard extends Component {
               {props.blocked ? (
                 <div className="user-card-actions">
                   <span>Blocked user - </span>
-                  <a onClick={this.handleUnblockClick}>Un-block</a>
+                  <ButtonLink onClick={this.handleUnblockClick}>Un-block</ButtonLink>
                 </div>
               ) : !props.isItMe ? (
                 <div className="user-card-actions">
@@ -183,9 +184,9 @@ class UserCard extends Component {
 
                   {!props.user.isGone && (
                     <span className="user-card-action">
-                      <a onClick={this.handleShowOrHideClick}>
+                      <ButtonLink onClick={this.handleShowOrHideClick}>
                         {props.hidden ? 'Show' : 'Hide'} posts
-                      </a>
+                      </ButtonLink>
                     </span>
                   )}
                 </div>
@@ -270,5 +271,5 @@ function BlockLink({ user, setOpened }) {
     () => (showBanDialog(), setOpened(false)),
     [setOpened, showBanDialog],
   );
-  return <a onClick={onClick}>Block</a>;
+  return <ButtonLink onClick={onClick}>Block</ButtonLink>;
 }

--- a/styles/shared/comment-likes.scss
+++ b/styles/shared/comment-likes.scss
@@ -64,9 +64,12 @@
     margin-right: rem(6px);
   }
 
-  &:not(.liked) {
-    opacity: 0;
-    transition: opacity 0.25s;
+  opacity: 0;
+  transition: opacity 0.2s;
+
+  &.liked,
+  &:focus-within {
+    opacity: 1;
   }
 
   .comment-heart {

--- a/test/jest/__snapshots__/piece-of-text.test.jsx.snap
+++ b/test/jest/__snapshots__/piece-of-text.test.jsx.snap
@@ -14,7 +14,10 @@ exports[`PieceOfText > Renders a short piece of text 1`] = `
     </span>
      
     <a
+      aria-disabled="false"
       class="read-more"
+      role="button"
+      tabindex="0"
     >
       Expand
     </a>
@@ -64,7 +67,10 @@ exports[`PieceOfText > Renders a very long piece of text 1`] = `
     </span>
      
     <a
+      aria-disabled="false"
       class="read-more"
+      role="button"
+      tabindex="0"
     >
       Read more
     </a>

--- a/test/jest/__snapshots__/post-comments.test.jsx.snap
+++ b/test/jest/__snapshots__/post-comments.test.jsx.snap
@@ -34,9 +34,11 @@ exports[`PostComments > Renders post comments and doesn't blow up 1`] = `
           class="comment-likes"
         >
           <div
+            aria-disabled="false"
             aria-label="Like this comment"
             class="comment-heart"
             role="button"
+            tabindex="0"
           >
             fontawesome-icon heart
           </div>
@@ -123,9 +125,11 @@ exports[`PostComments > Renders post comments and doesn't blow up 1`] = `
           class="comment-likes"
         >
           <div
+            aria-disabled="false"
             aria-label="Like this comment"
             class="comment-heart"
             role="button"
+            tabindex="0"
           >
             fontawesome-icon heart
           </div>
@@ -249,9 +253,11 @@ exports[`PostComments > Renders post comments and doesn't blow up 1`] = `
           class="comment-likes"
         >
           <div
+            aria-disabled="false"
             aria-label="Like this comment"
             class="comment-heart"
             role="button"
+            tabindex="0"
           >
             fontawesome-icon heart
           </div>

--- a/test/jest/__snapshots__/post.test.jsx.snap
+++ b/test/jest/__snapshots__/post.test.jsx.snap
@@ -81,8 +81,10 @@ exports[`Post > Renders a post and doesn't blow up 1`] = `
             class="post-footer-icon"
           >
             <svg
+              aria-disabled="false"
               class="post-lock-icon post-public-icon fa-icon fa-icon-fas-globe-americas"
               role="button"
+              tabindex="0"
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>

--- a/test/unit/components/piece-of-text.jsx
+++ b/test/unit/components/piece-of-text.jsx
@@ -5,6 +5,7 @@ import unexpectedReact from 'unexpected-react';
 import PieceOfText from '../../../src/components/piece-of-text';
 import Spoiler from '../../../src/components/spoiler';
 import Linkify from '../../../src/components/linkify';
+import { ButtonLink } from '../../../src/components/button-link';
 
 const expect = unexpected.clone().use(unexpectedReact);
 
@@ -19,7 +20,7 @@ describe('<PieceOfText>', () => {
       'to have rendered with all children',
       <Linkify>
         <span>First paragraph Second paragraph, first line Second paragraph, second line</span>{' '}
-        <a className="read-more">Expand</a>
+        <ButtonLink className="read-more">Expand</ButtonLink>
       </Linkify>,
     );
 
@@ -60,7 +61,7 @@ describe('<PieceOfText>', () => {
           ПЕРВАЯ 516 И жить торопится и чувствовать спешит. К. 562 Вяземский. I. {`"`}Мой дядя
           самых...
         </span>{' '}
-        <a className="read-more">Read more</a>
+        <ButtonLink className="read-more">Read more</ButtonLink>
       </Linkify>,
     );
 


### PR DESCRIPTION
### Changed
- All "a" links without the "href" attribute and some other pseudo-buttons have been replaced by the ButtonLink component. This improves the keyboard accessibility of the site because ButtonLink is able to focus and click from the keyboard.
