### PR TITLE
Correctly focus feed selector on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the keyboard.
 ### Fixed
 - The backlink click now doesn't reload a full page.
+- On iOS, the feed selector doesn't focus properly after clicking the Add/Edit
+  button.
 
 ## [1.118] - 2023-05-05
 ### Added

--- a/src/components/feeds-selector/selector.jsx
+++ b/src/components/feeds-selector/selector.jsx
@@ -1,7 +1,7 @@
 import cn from 'classnames';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { ButtonLink } from '../button-link';
-import { useBool } from '../hooks/bool';
+import { prepareAsyncFocus } from '../../utils/prepare-async-focus';
 import { DisplayOption, useSelectedOptions } from './options';
 
 // Local styles
@@ -72,7 +72,12 @@ export function Selector({ className, mode, feedNames, fixedFeedNames = [], onCh
   }, [groupOptions, isDirect, meOption, mode, userOptions]);
 
   const startStatic = useMemo(() => isEditing(mode) || values.length > 0, [mode, values.length]);
-  const [showStatic, toggleSelector] = useBool(startStatic);
+  const [showStatic, setShowStatic] = useState(startStatic);
+
+  const toggleSelector = useCallback(() => {
+    prepareAsyncFocus();
+    setShowStatic(false);
+  }, []);
 
   const handleChange = useCallback(
     (opts, action) => {


### PR DESCRIPTION
iOS requires the prepareAsyncFocus hack when focus is not set in the event listener.