### PR TITLE
Inject start JS and custom config (if SSI is supported) to the HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.120] - Not released
+### Changed
+- The start script that initiates the configuration and sets the color scheme is
+  now injected into the HTML code. The custom configuration is also injected
+  using SSI, if possible. This allows instant access to the configuration,
+  without an additional HTTP request, and allows the correct color scheme to be
+  applied before the document body starts rendering. This, in turn, gets rid of
+  the blinking when the page loads.
+### Fixed
+- Initial layout styles, to prevent jerking while loading
 
 ## [1.119] - 2023-06-02
 ### Added

--- a/config/lib/loader-async.js
+++ b/config/lib/loader-async.js
@@ -1,7 +1,4 @@
-import base from '../default';
 import { merge } from './merge';
-
-window.CONFIG = base;
 
 export async function loadConfig(path) {
   const resp = await fetch(path, {

--- a/index.html
+++ b/index.html
@@ -39,28 +39,15 @@
       </style>
     </noscript>
 
-    <link rel="stylesheet" href="/styles/startup.scss" />
-    <script>
-      {
-        // Google Analytics stub
-        window['GoogleAnalyticsObject'] = 'ga';
-        const ga = (window['ga'] =
-          window['ga'] ||
-          function (...args) {
-            ga.q = ga.q || [];
-            ga.q.push(args);
-          });
-        ga.l = 1 * new Date();
-      }
+    <script id="config-patch" type="application/json">
+      <!--#block name="config-patch-stub" -->null<!--# endblock -->
+      <!--#include virtual="/config.json" stub="config-patch-stub" -->
     </script>
+    <script type="inline" src="./src/startup.js"></script>
+    <link rel="stylesheet" href="/styles/startup.scss" />
     <script type="module" src="/src/index.js"></script>
   </head>
   <body>
-    <script>
-      if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        document.documentElement.classList.add('dark-theme');
-      }
-    </script>
     <div id="app" class="startup">
       <h1 class="startup__logo-box">
         <a href="/" class="startup__logo-link">FreeFeed</a>

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "husky": "~8.0.3",
     "jsdom": "~22.0.0",
     "lint-staged": "~12.4.3",
+    "node-html-parser": "~6.1.5",
     "npm-run-all": "~4.1.5",
     "prettier": "~2.8.8",
     "querystring": "~0.2.1",

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -109,17 +109,13 @@ const generateRouteHooks = (callback) => ({
 
 function InitialLayout({ children }) {
   return (
-    <div className="container">
-      <div className="row header-row">
-        <div className="col-md-4">
-          <div className="header">
-            <h1 className="title">
-              <a href="/">{CONFIG.siteTitle}</a>
-            </h1>
-            <div className="jsonly">{children}</div>
-          </div>
-        </div>
-      </div>
+    <div className="startup">
+      <h1 className="startup__logo-box">
+        <a href="/" className="startup__logo-link">
+          {CONFIG.siteTitle}
+        </a>
+      </h1>
+      <div className="initial-layout__content">{children}</div>
     </div>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,12 @@ import { loadConfig } from '../config/lib/loader-async';
 
 (async () => {
   try {
-    const scriptRoot = document.currentScript
-      ? document.currentScript.src.replace(/\/[^/]+$/, '')
-      : '';
-    await loadConfig(`${scriptRoot}/config.json`);
+    if (!window.CONFIG_PATCH) {
+      const scriptRoot = document.currentScript
+        ? document.currentScript.src.replace(/\/[^/]+$/, '')
+        : '';
+      await loadConfig(`${scriptRoot}/config.json`);
+    }
 
     const { ga, CONFIG } = window;
     if (CONFIG.analytics.google) {

--- a/src/startup.js
+++ b/src/startup.js
@@ -1,0 +1,39 @@
+import base from '../config/default';
+import { merge } from '../config/lib/merge';
+window.CONFIG = base;
+window.CONFIG_PATCH = null;
+
+const configPatchElement = document.querySelector('#config-patch');
+if (configPatchElement) {
+  try {
+    window.CONFIG_PATCH = JSON.parse(configPatchElement.textContent);
+    window.CONFIG = merge(window.CONFIG, window.CONFIG_PATCH);
+  } catch {
+    // pass
+  }
+}
+
+// Dark/light themes
+try {
+  const colorScheme = localStorage.getItem(window.CONFIG.appearance.colorSchemeStorageKey);
+  if (
+    colorScheme === 'dark' ||
+    (colorScheme !== 'light' && window.matchMedia?.('(prefers-color-scheme: dark)').matches)
+  ) {
+    document.documentElement.classList.add('dark-theme');
+  }
+} catch {
+  // pass
+}
+
+// Google Analytics stub
+{
+  window['GoogleAnalyticsObject'] = 'ga';
+  const ga = (window['ga'] =
+    window['ga'] ||
+    function (...args) {
+      ga.q = ga.q || [];
+      ga.q.push(args);
+    });
+  ga.l = 1 * new Date();
+}

--- a/src/vite/inject-inline-scripts.js
+++ b/src/vite/inject-inline-scripts.js
@@ -1,0 +1,38 @@
+import { join, dirname } from 'path';
+import { parse as parseHTML } from 'node-html-parser';
+import { build } from 'vite';
+
+export function injectInlineScripts() {
+  return {
+    name: 'inject-inline-scripts',
+    /** @type import("vite").IndexHtmlTransformHook */
+    async transformIndexHtml(html, context) {
+      const doc = parseHTML(html, { comment: true });
+      const syncScripts = doc.querySelectorAll('script[src][type="inline"]');
+      for (const script of syncScripts) {
+        const scriptSrc = join(dirname(context.filename), script.getAttribute('src'));
+        const res = await build({
+          build: {
+            sourcemap: false,
+            lib: {
+              entry: scriptSrc,
+              formats: ['iife'],
+              name: 'startup',
+              fileName: 'assets/[name]-[hash]',
+            },
+            rollupOptions: {
+              output: { inlineDynamicImports: false },
+            },
+          },
+        });
+
+        const result = res[0].output.find((e) => e.isEntry);
+
+        script.removeAttribute('src');
+        script.removeAttribute('type');
+        script.textContent = result.code;
+      }
+      return doc.toString();
+    },
+  };
+}

--- a/styles/helvetica/functions.scss
+++ b/styles/helvetica/functions.scss
@@ -11,7 +11,7 @@
   @return clamp(
     #{$min-width-val + $val-unit},
     #{$min-width-val + $val-unit} + #{$max-width-val - $min-width-val} * #{'('} #{$full-width} - #{$min-width +
-      $width-unit}#{')'} / ($max-width - $min-width),
+      $width-unit}#{')'} / (#{$max-width - $min-width}),
     #{$max-width-val + $val-unit}
   );
   /* stylelint-enable */

--- a/styles/startup.scss
+++ b/styles/startup.scss
@@ -71,11 +71,12 @@ body {
   display: block;
 }
 
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
+// Dark theme
+html.dark-theme {
+  color-scheme: dark;
+}
 
+.dark-theme {
   body {
     background-color: #17191c;
   }

--- a/styles/startup.scss
+++ b/styles/startup.scss
@@ -1,9 +1,12 @@
+@import './helvetica/functions.scss';
+
 * {
   box-sizing: border-box;
 }
 
 html {
   color-scheme: light;
+  overflow-y: scroll;
 }
 
 body {
@@ -20,10 +23,16 @@ body {
   max-width: 970px;
   padding-inline: 25px;
   margin-inline: auto;
+
+  @media (max-width: 992px) {
+    max-width: 750px;
+    padding-inline: 15px;
+  }
 }
 
 .startup__logo-box {
   font-size: 36px;
+  font-size: fluid(28, 320, 36, 600);
   line-height: 40px;
   font-weight: 500;
   margin-top: 1.25rem;

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react-swc';
 import injectPreload from 'vite-plugin-inject-preload';
 import generateFile from 'vite-plugin-generate-file';
 import pkg from './package.json';
+import { injectInlineScripts } from './src/vite/inject-inline-scripts';
 
 // Move the listed node modules into separate named chunks. Format: module name
 // - chunk name.
@@ -33,19 +34,21 @@ export default defineConfig(({ mode }) => ({
         { match: /\/app-\w+\.css$/ },
       ],
     }),
-    generateFile([
-      {
-        type: 'template',
-        output: 'version.txt',
-        template: 'src/version.ejs',
-        data: {
-          name: pkg.name,
-          version: pkg.version,
-          date: new Date().toISOString(),
-          commitHash: execSync('git rev-parse --short HEAD').toString().trim(),
+    injectInlineScripts(),
+    mode === 'production' &&
+      generateFile([
+        {
+          type: 'template',
+          output: 'version.txt',
+          template: 'src/version.ejs',
+          data: {
+            name: pkg.name,
+            version: pkg.version,
+            date: new Date().toISOString(),
+            commitHash: execSync('git rev-parse --short HEAD').toString().trim(),
+          },
         },
-      },
-    ]),
+      ]),
   ],
   build: {
     outDir: '_dist',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2084,6 +2084,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"boolbase@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "boolbase@npm:1.0.0"
+  checksum: 3e25c80ef626c3a3487c73dbfc70ac322ec830666c9ad915d11b701142fab25ec1e63eff2c450c74347acfd2de854ccde865cd79ef4db1683f7c7b046ea43bb0
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -2621,10 +2628,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-select@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "css-select@npm:5.1.0"
+  dependencies:
+    boolbase: ^1.0.0
+    css-what: ^6.1.0
+    domhandler: ^5.0.2
+    domutils: ^3.0.1
+    nth-check: ^2.0.1
+  checksum: 2772c049b188d3b8a8159907192e926e11824aea525b8282981f72ba3f349cf9ecd523fdf7734875ee2cb772246c22117fc062da105b6d59afe8dcd5c99c9bda
+  languageName: node
+  linkType: hard
+
 "css-unit-converter@npm:^1.1.1":
   version: 1.1.2
   resolution: "css-unit-converter@npm:1.1.2"
   checksum: 07888033346a5128f34dbe2f72884c966d24e9f29db24416dcde92860242490617ef9a178ac193a92f730834bbeea026cdc7027701d92ba9bbbe59db7a37eb2a
+  languageName: node
+  linkType: hard
+
+"css-what@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "css-what@npm:6.1.0"
+  checksum: b975e547e1e90b79625918f84e67db5d33d896e6de846c9b584094e529f0c63e2ab85ee33b9daffd05bff3a146a1916bec664e18bb76dd5f66cbff9fc13b2bbe
   languageName: node
   linkType: hard
 
@@ -2969,10 +2996,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dom-serializer@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "dom-serializer@npm:2.0.0"
+  dependencies:
+    domelementtype: ^2.3.0
+    domhandler: ^5.0.2
+    entities: ^4.2.0
+  checksum: cd1810544fd8cdfbd51fa2c0c1128ec3a13ba92f14e61b7650b5de421b88205fd2e3f0cc6ace82f13334114addb90ed1c2f23074a51770a8e9c1273acbc7f3e6
+  languageName: node
+  linkType: hard
+
 "dom-utils@npm:^0.9.0":
   version: 0.9.0
   resolution: "dom-utils@npm:0.9.0"
   checksum: 26255fc3d23f645f5d35eb2fcbd2c4c2d94a79f8528612e0c8d555435d2907145a17d32f32da1fbbbca37dd68844f1ba938f21d53ae4eeb97e7cd5ccd5966b61
+  languageName: node
+  linkType: hard
+
+"domelementtype@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "domelementtype@npm:2.3.0"
+  checksum: ee837a318ff702622f383409d1f5b25dd1024b692ef64d3096ff702e26339f8e345820f29a68bcdcea8cfee3531776b3382651232fbeae95612d6f0a75efb4f6
   languageName: node
   linkType: hard
 
@@ -2982,6 +3027,26 @@ __metadata:
   dependencies:
     webidl-conversions: ^7.0.0
   checksum: ddbc1268edf33a8ba02ccc596735ede80375ee0cf124b30d2f05df5b464ba78ef4f49889b6391df4a04954e63d42d5631c7fcf8b1c4f12bc531252977a5f13d5
+  languageName: node
+  linkType: hard
+
+"domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "domhandler@npm:5.0.3"
+  dependencies:
+    domelementtype: ^2.3.0
+  checksum: 0f58f4a6af63e6f3a4320aa446d28b5790a009018707bce2859dcb1d21144c7876482b5188395a188dfa974238c019e0a1e610d2fc269a12b2c192ea2b0b131c
+  languageName: node
+  linkType: hard
+
+"domutils@npm:^3.0.1":
+  version: 3.1.0
+  resolution: "domutils@npm:3.1.0"
+  dependencies:
+    dom-serializer: ^2.0.0
+    domelementtype: ^2.3.0
+    domhandler: ^5.0.3
+  checksum: e5757456ddd173caa411cfc02c2bb64133c65546d2c4081381a3bafc8a57411a41eed70494551aa58030be9e58574fcc489828bebd673863d39924fb4878f416
   languageName: node
   linkType: hard
 
@@ -3072,7 +3137,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.4.0":
+"entities@npm:^4.2.0, entities@npm:^4.4.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 853f8ebd5b425d350bffa97dd6958143179a5938352ccae092c62d1267c4e392a039be1bae7d51b6e4ffad25f51f9617531fedf5237f15df302ccfb452cbf2d7
@@ -4306,6 +4371,15 @@ __metadata:
   dependencies:
     function-bind: ^1.1.1
   checksum: b9ad53d53be4af90ce5d1c38331e712522417d017d5ef1ebd0507e07c2fbad8686fffb8e12ddecd4c39ca9b9b47431afbb975b8abf7f3c3b82c98e9aad052792
+  languageName: node
+  linkType: hard
+
+"he@npm:1.2.0":
+  version: 1.2.0
+  resolution: "he@npm:1.2.0"
+  bin:
+    he: bin/he
+  checksum: 3d4d6babccccd79c5c5a3f929a68af33360d6445587d628087f39a965079d84f18ce9c3d3f917ee1e3978916fc833bb8b29377c3b403f919426f91bc6965e7a7
   languageName: node
   linkType: hard
 
@@ -5827,6 +5901,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-html-parser@npm:~6.1.5":
+  version: 6.1.5
+  resolution: "node-html-parser@npm:6.1.5"
+  dependencies:
+    css-select: ^5.1.0
+    he: 1.2.0
+  checksum: b54257b31954be17d473c86a2fede53d5e238708f3d88577c98881c28ab66013fd37044903f6f3cd662b56d882681fb511bca75a80a80b62f7111b32b39eebae
+  languageName: node
+  linkType: hard
+
 "node-releases@npm:^2.0.12":
   version: 2.0.12
   resolution: "node-releases@npm:2.0.12"
@@ -5915,6 +5999,15 @@ __metadata:
     gauge: ^4.0.3
     set-blocking: ^2.0.0
   checksum: ae238cd264a1c3f22091cdd9e2b106f684297d3c184f1146984ecbe18aaa86343953f26b9520dedd1b1372bc0316905b736c1932d778dbeb1fcf5a1001390e2a
+  languageName: node
+  linkType: hard
+
+"nth-check@npm:^2.0.1":
+  version: 2.1.1
+  resolution: "nth-check@npm:2.1.1"
+  dependencies:
+    boolbase: ^1.0.0
+  checksum: 5afc3dafcd1573b08877ca8e6148c52abd565f1d06b1eb08caf982e3fa289a82f2cae697ffb55b5021e146d60443f1590a5d6b944844e944714a5b549675bcd3
   languageName: node
   linkType: hard
 
@@ -6920,6 +7013,7 @@ __metadata:
     lru-cache: ~7.14.1
     memoize-one: ~6.0.0
     mousetrap: ~1.6.5
+    node-html-parser: ~6.1.5
     npm-run-all: ~4.1.5
     porter-stemmer: ~0.9.1
     prettier: ~2.8.8


### PR DESCRIPTION
We keep the local config in a separate, dynamic loadable file, and this creates some problems. In some cases, access to the configuration is needed immediately, before the page is fully loaded.

In particular, the config stores the localStorage key, which contains the theme selected by the user (dark or light). This theme must be applied before rendering the HTML body, otherwise, if it does not match the system theme, the screen will blink.

We used to solve this problem with a synchronous HTTP request, but it causes problems in some browsers (Brave mobile).

In this PR I use SSI (our poor man's SSR) to include the custom config in the body of the HTML page. In this way, we get an instantly available config. I also include a startup script in the HTML code, which merges the custom config with the default and sets the correct color scheme. All this happens synchronously and before the start of rendering the page body. 

If SSI is unavailable, the default config is still immediately available, and the custom part will be loaded dynamically, as before.

Inline script injection is done with a separate plugin for Vite, which compiles the required code into IIFE. It leaves a separate file, which I haven't been able to properly remove yet. But it doesn't interfere with anything.