### PR TITLE
Update startup.scss

### DIFF
--- a/styles/startup.scss
+++ b/styles/startup.scss
@@ -10,7 +10,7 @@ html {
 }
 
 body {
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: Vazir, 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.4286;
   margin: 0;


### PR DESCRIPTION
Injecting start JS and custom configuration into HTML seems to cause problems in Persian style. Fixing the problem by adding "Vazir" fonts to the startup style 
<img width="638" alt="Screenshot 2023-06-14 at 15 52 02" src="https://github.com/FreeFeed/freefeed-react-client/assets/2767887/61b6b821-31b7-4693-adba-2f15e166b9f7">
