### PR TITLE
Fix incorrect date string parsing

### DIFF
--- a/src/components/calendar/calendar-header-nav.jsx
+++ b/src/components/calendar/calendar-header-nav.jsx
@@ -14,7 +14,12 @@ function getDateLabel(date, mode) {
 }
 
 function parseDateString(string) {
-  return new Date(string);
+  const [yyyy, MM, dd] = string.split('-');
+  const d = new Date();
+  d.setFullYear(parseInt(yyyy, 10));
+  d.setMonth(parseInt(MM, 10) - 1);
+  d.setDate(parseInt(dd, 10));
+  return d;
 }
 
 function CalendarHeaderNav(props) {


### PR DESCRIPTION
This PR fixes a bug where calendar navigation is showing incorrect dates in PST timezone.

Before:

<img width="765" alt="Screenshot 2023-07-16 at 22 41 07" src="https://github.com/FreeFeed/freefeed-react-client/assets/632081/a6dd6b61-6787-4192-9162-a02cf8457d2c">

After:

<img width="762" alt="Screenshot 2023-07-16 at 22 40 46" src="https://github.com/FreeFeed/freefeed-react-client/assets/632081/5a41d6cc-4b77-40fd-8365-d744b9cbdcd4">
