### PR TITLE
Allow line feeds inside the Spoiler tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.123.0] - Not released
+### Changed
+- Spoiler tag can now contain line feeds. In addition, user text formatting
+  utilizes simpler HTML, with fewer wrappers. Visually, the output for the user
+  is not changed (except for line translations in spoilers).
 
 ## [1.122.0] - 2023-07-31
 ### Added

--- a/src/components/linkify-elements.jsx
+++ b/src/components/linkify-elements.jsx
@@ -1,0 +1,153 @@
+/* global CONFIG */
+import { Fragment } from 'react';
+import { Arrows, Email, ForeignMention, HashTag, Mention } from 'social-text-tokenizer';
+
+import { FRIENDFEED_POST } from '../utils/link-types';
+import { LineBreak, ParagraphBreak, shortCodeToService, Link as TLink } from '../utils/parse-text';
+import { InitialCheckbox as InitialCheckboxToken } from '../utils/initial-checkbox';
+import UserName from './user-name';
+import { getMediaType } from './media-viewer';
+import { MediaOpener } from './media-opener';
+import { InitialCheckbox } from './initial-checkbox';
+import { Anchor, Link } from './linkify-links';
+
+const { searchEngine } = CONFIG.search;
+const MAX_URL_LENGTH = 50;
+
+export function tokenToElement(token, key, params) {
+  if (token instanceof Mention) {
+    return (
+      <UserName
+        key={key}
+        user={{ username: token.text.slice(1).toLowerCase() }}
+        userHover={params.userHover}
+      >
+        {token.text}
+      </UserName>
+    );
+  }
+
+  if (token instanceof Email) {
+    return (
+      <Anchor key={key} href={`mailto:${token.text}`}>
+        {token.pretty}
+      </Anchor>
+    );
+  }
+
+  if (token instanceof HashTag) {
+    if (searchEngine) {
+      return (
+        <Anchor key={key} href={searchEngine + encodeURIComponent(token.text)}>
+          {token.pretty}
+        </Anchor>
+      );
+    }
+
+    return (
+      <Link key={key} to={{ pathname: '/search', query: { q: token.text } }}>
+        <bdi>{token.text}</bdi>
+      </Link>
+    );
+  }
+
+  if (token instanceof Arrows && (params.arrowHover || params.arrowClick)) {
+    return (
+      <span
+        key={key}
+        className="arrow-span"
+        data-arrows={token.level}
+        onMouseEnter={params.arrowHover.hover}
+        onMouseLeave={params.arrowHover.leave}
+        onClick={params.arrowClick}
+      >
+        {token.text}
+      </span>
+    );
+  }
+
+  if (token instanceof TLink) {
+    if (token.isLocal) {
+      let m, text;
+      // Special shortening of post links
+      if ((m = /^[^/]+\/[\w-]+\/[\da-f]{8}-/.exec(token.pretty))) {
+        text = `${m[0]}\u2026`;
+      } else {
+        text = token.shorten(MAX_URL_LENGTH);
+      }
+      return (
+        <Link key={key} to={token.localURI}>
+          {text}
+        </Link>
+      );
+    }
+
+    if (token.href.match(FRIENDFEED_POST)) {
+      return (
+        <Link key={key} to={{ pathname: '/archivePost', query: { url: token.href } }}>
+          {token.shorten(MAX_URL_LENGTH)}
+        </Link>
+      );
+    }
+
+    if (params.showMedia) {
+      const mediaType = getMediaType(token.href);
+      if (mediaType) {
+        return (
+          <MediaOpener
+            key={key}
+            url={token.href}
+            mediaType={mediaType}
+            attachmentsRef={params.attachmentsRef}
+            showMedia={params.showMedia}
+          >
+            {token.shorten(MAX_URL_LENGTH)}
+          </MediaOpener>
+        );
+      }
+    }
+
+    return (
+      <Anchor key={key} href={token.href}>
+        {token.shorten(MAX_URL_LENGTH)}
+      </Anchor>
+    );
+  }
+
+  if (token instanceof ForeignMention) {
+    const srv = shortCodeToService[token.service];
+    if (srv) {
+      const url = srv.linkTpl.replace(/{}/g, token.username);
+      return (
+        <Anchor key={key} href={url} title={`${srv.title} link`}>
+          {token.text}
+        </Anchor>
+      );
+    }
+  }
+
+  if (token instanceof LineBreak) {
+    return (
+      // ' ' is here for proper render in READMORE_STYLE_COMPACT mode
+      <Fragment key={key}>
+        {' '}
+        <br />
+      </Fragment>
+    );
+  }
+
+  if (token instanceof ParagraphBreak) {
+    // ' ' is here for proper render in READMORE_STYLE_COMPACT mode
+    return (
+      <span key={key} className="p-break">
+        <br /> <br />
+      </span>
+    );
+  }
+
+  if (token instanceof InitialCheckboxToken) {
+    return <InitialCheckbox key={key} checked={token.checked} />;
+  }
+
+  return token.text;
+}

--- a/src/components/linkify-links.jsx
+++ b/src/components/linkify-links.jsx
@@ -1,0 +1,17 @@
+import { Link as RLink } from 'react-router';
+
+export function Anchor({ href, title, children }) {
+  return (
+    <a href={href} target="_blank" dir="ltr" title={title}>
+      {children}
+    </a>
+  );
+}
+
+export function Link({ to, title, children }) {
+  return (
+    <RLink to={to} dir="ltr" title={title}>
+      {children}
+    </RLink>
+  );
+}

--- a/src/components/media-opener.jsx
+++ b/src/components/media-opener.jsx
@@ -1,0 +1,52 @@
+import { useCallback, useMemo } from 'react';
+import { faImage } from '@fortawesome/free-regular-svg-icons';
+import { faFilm as faVideo } from '@fortawesome/free-solid-svg-icons';
+import { faInstagram, faYoutube, faVimeo } from '@fortawesome/free-brands-svg-icons';
+import cn from 'classnames';
+import { Icon } from './fontawesome-icons';
+
+export function MediaOpener({ url, mediaType, attachmentsRef, showMedia, children }) {
+  const media = useMemo(() => {
+    const m = { url, id: 'comment', mediaType };
+    attachmentsRef.current.push(m);
+    return m;
+  }, [attachmentsRef, mediaType, url]);
+
+  const openMedia = useCallback(
+    (e) => {
+      if (e.button !== 0 || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+        return;
+      }
+      e.preventDefault();
+      showMedia({
+        attachments: attachmentsRef.current,
+        index: attachmentsRef.current.indexOf(media),
+      });
+    },
+    [attachmentsRef, media, showMedia],
+  );
+
+  const mediaIcon =
+    {
+      instagram: faInstagram,
+      T_YOUTUBE_VIDEO: faYoutube,
+      T_VIMEO_VIDEO: faVimeo,
+      image: faImage,
+    }[mediaType] || faVideo;
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      dir="ltr"
+      onClick={openMedia}
+      className={cn('media-link', mediaType)}
+      title="Click to view in Lightbox"
+    >
+      <span className="icon-bond">
+        <Icon icon={mediaIcon} className="media-icon" />
+      </span>
+      {children}
+    </a>
+  );
+}

--- a/src/utils/spoiler-tokens.js
+++ b/src/utils/spoiler-tokens.js
@@ -11,4 +11,45 @@ class EndSpoiler extends Token {}
 const tokenizerStartSpoiler = byRegexp(startSpoilerRegex, makeToken(StartSpoiler));
 const tokenizerEndSpoiler = byRegexp(endSpoilerRegex, makeToken(EndSpoiler));
 
-export { tokenizerStartSpoiler, tokenizerEndSpoiler, StartSpoiler, EndSpoiler };
+// Make sure that the list of tokens contains only
+// valid pairs of StartSpoiler/EndSpoiler tokens
+const validateSpoilerTags = (tokenizer) => {
+  return function (text) {
+    const validated = [];
+    let startSpoilerIndex = -1;
+    const tokens = tokenizer(text);
+
+    tokens.forEach((token, i) => {
+      if (token instanceof StartSpoiler) {
+        if (startSpoilerIndex !== -1) {
+          // previous StartSpoiler is invalid
+          validated[startSpoilerIndex] = null;
+        }
+        startSpoilerIndex = i;
+        validated.push(token);
+      } else if (token instanceof EndSpoiler) {
+        if (startSpoilerIndex !== -1) {
+          startSpoilerIndex = -1;
+          validated.push(token);
+        }
+      } else {
+        validated.push(token);
+      }
+    });
+
+    if (startSpoilerIndex !== -1) {
+      // un-closed StartSpoiler
+      validated[startSpoilerIndex] = null;
+    }
+
+    return validated.filter(Boolean);
+  };
+};
+
+export {
+  tokenizerStartSpoiler,
+  tokenizerEndSpoiler,
+  StartSpoiler,
+  EndSpoiler,
+  validateSpoilerTags,
+};

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -246,11 +246,20 @@ $post-line-height: rem(20px);
 
 // paragraph breaks
 .p-break {
+  display: block;
   height: 0.35em;
 
   .post-text & {
     height: 0.65em;
   }
+
+  .text-no-breaks & {
+    display: inline;
+  }
+}
+
+.text-no-breaks br {
+  display: none;
 }
 
 // Used in both create-post and edit-post

--- a/test/jest/__snapshots__/piece-of-text.test.jsx.snap
+++ b/test/jest/__snapshots__/piece-of-text.test.jsx.snap
@@ -32,23 +32,17 @@ exports[`PieceOfText > Renders a short piece of text 2`] = `
     dir="auto"
     role="region"
   >
-    <span>
-      First paragraph
-    </span>
-    <div
+    First paragraph
+    <span
       class="p-break"
     >
       <br />
-    </div>
-    <span>
-      <span>
-        Second paragraph, first line
-      </span>
+       
       <br />
-      <span>
-        Second paragraph, second line
-      </span>
     </span>
+    Second paragraph, first line 
+    <br />
+    Second paragraph, second line
   </span>
 </DocumentFragment>
 `;
@@ -92,7 +86,11 @@ exports[`PieceOfText > Renders a very long piece of text 2`] = `
 
 exports[`PieceOfText > Renders an empty span if empty 1`] = `
 <DocumentFragment>
-  <span />
+  <span
+    class="Linkify"
+    dir="auto"
+    role="region"
+  />
 </DocumentFragment>
 `;
 

--- a/test/jest/__snapshots__/post-comments.test.jsx.snap
+++ b/test/jest/__snapshots__/post-comments.test.jsx.snap
@@ -156,26 +156,22 @@ exports[`PostComments > Renders post comments and doesn't blow up 1`] = `
             dir="auto"
             role="region"
           >
-            <span>
-              <span
-                class="user-name-wrapper"
+            <span
+              class="user-name-wrapper"
+            >
+              <a
+                class=""
               >
-                <a
-                  class=""
+                <span
+                  dir="ltr"
                 >
-                  <span
-                    dir="ltr"
-                  >
-                    @author
-                  </span>
-                </a>
-              </span>
-               comment 2
+                  @author
+                </span>
+              </a>
             </span>
+             comment 2 
             <br />
-            <span>
-              Multilinebody
-            </span>
+            Multilinebody
           </span>
           <span
             aria-label="Comment by other"

--- a/test/jest/__snapshots__/post.test.jsx.snap
+++ b/test/jest/__snapshots__/post.test.jsx.snap
@@ -56,13 +56,9 @@ exports[`Post > Renders a post and doesn't blow up 1`] = `
             dir="auto"
             role="region"
           >
-            <span>
-              Line 1
-            </span>
+            Line 1 
             <br />
-            <span>
-              Line 2
-            </span>
+            Line 2
           </span>
         </div>
       </div>

--- a/test/unit/components/piece-of-text.jsx
+++ b/test/unit/components/piece-of-text.jsx
@@ -6,6 +6,8 @@ import PieceOfText from '../../../src/components/piece-of-text';
 import Spoiler from '../../../src/components/spoiler';
 import Linkify from '../../../src/components/linkify';
 import { ButtonLink } from '../../../src/components/button-link';
+import { Anchor } from '../../../src/components/linkify-links';
+import ErrorBoundary from '../../../src/components/error-boundary';
 
 const expect = unexpected.clone().use(unexpectedReact);
 
@@ -28,17 +30,7 @@ describe('<PieceOfText>', () => {
       <PieceOfText text={text} isExpanded />,
       'when rendered',
       'to have rendered with all children',
-      <Linkify>
-        <span>First paragraph</span>
-        <div className="p-break">
-          <br />
-        </div>
-        <span>
-          <span>Second paragraph, first line</span>
-          <br />
-          <span>Second paragraph, second line</span>
-        </span>
-      </Linkify>,
+      <Linkify>{text.trim()}</Linkify>,
     );
   });
 
@@ -100,16 +92,20 @@ describe('<PieceOfText>', () => {
       '123 <spoiler> <spoiler>456</spoiler> 789 <спойлер>https://example.com</спойлер> 123';
 
     expect(
-      <PieceOfText text={text} />,
+      <Linkify>{text}</Linkify>,
       'when rendered',
       'to have rendered with all children',
-      <Linkify>
-        123 &lt;spoiler&gt; &lt;spoiler&gt;
-        <Spoiler>456</Spoiler>
-        &lt;/spoiler&gt; 789 &lt;спойлер&gt;
-        <Spoiler>https://example.com</Spoiler>
-        &lt;/спойлер&gt; 123
-      </Linkify>,
+      <span>
+        <ErrorBoundary>
+          {'123 <spoiler> <spoiler>'}
+          <Spoiler>456</Spoiler>
+          {'</spoiler> 789 <спойлер>'}
+          <Spoiler>
+            <Anchor href="https://example.com/">example.com</Anchor>
+          </Spoiler>
+          {'</спойлер> 123'}
+        </ErrorBoundary>
+      </span>,
     );
   });
 });

--- a/test/unit/components/post-comments.jsx
+++ b/test/unit/components/post-comments.jsx
@@ -13,7 +13,7 @@ import { SignInLink } from '../../../src/components/sign-in-link';
 
 const expect = unexpected.clone().use(unexpectedReact);
 
-const generateArray = (n) => [...Array(n).keys()].map(() => ({}));
+const generateArray = (n) => [...Array(n).keys()].map((i) => ({ id: i }));
 const commentArrays = generateArray(5).map((_, index) => generateArray(index));
 
 describe('<PostComments>', () => {
@@ -27,7 +27,7 @@ describe('<PostComments>', () => {
     };
 
     expect(
-      <PostComments comments={[{}]} post={post} />,
+      <PostComments comments={[{ id: '1' }]} post={post} />,
       'when rendered',
       'to have rendered with all children',
       <div>
@@ -57,7 +57,7 @@ describe('<PostComments>', () => {
     );
 
     expect(
-      <PostComments comments={[{}]} post={post} />,
+      <PostComments comments={[{ id: '1' }]} post={post} />,
       'when rendered',
       'to have rendered with all children',
       <div>
@@ -66,7 +66,7 @@ describe('<PostComments>', () => {
     );
 
     const root = await expect(
-      <PostComments comments={[{}, {}, {}, {}]} post={post} />,
+      <PostComments comments={[{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }]} post={post} />,
       'when rendered',
       'queried for',
       <div className="comments" />,
@@ -88,7 +88,7 @@ describe('<PostComments>', () => {
     };
 
     expect(
-      <PostComments comments={[{}, {}]} post={post} />,
+      <PostComments comments={[{ id: '1' }, { id: '2' }]} post={post} />,
       'when rendered',
       'to contain',
       <ExpandComments omittedComments={2} />,


### PR DESCRIPTION
### Changed
- Spoiler tag can now contain line feeds. In addition, user text formatting utilizes simpler HTML, with fewer wrappers. Visually, the output for the user is not changed (except for line translations in spoilers).
