### PR TITLE
Fix horizontal position of comment preview popover's arrow

### DIFF
--- a/src/components/post/post-comment-preview.module.scss
+++ b/src/components/post/post-comment-preview.module.scss
@@ -27,7 +27,7 @@
     position: absolute;
 
     // The #{} syntax is ugly but necessary to fight against Sass heuristics
-    left: #{m}in(#{m}ax(rem(14px), var(--arr-left)), #{100%} - rem(14px));
+    left: #{clamp }(rem(14px), var(--arr-left), #{'100% - '} rem(14px));
     top: 100%;
     width: $sz;
     height: $sz;


### PR DESCRIPTION
The old code produced CSS without spaces around the '-' (`100%-0.8rem`), resulting in broken styling. Also, now we use 'clamp' instead of min/max mess.