### PR TITLE
Do not use Helvetica on the Windows platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   utilizes simpler HTML, with fewer wrappers. Visually, the output for the user
   is not changed (except for line translations in spoilers).
 
+### Fixed
+- The default font set no longer includes the Helvetica family when the client
+  platform is Windows. Helvetica is not a native font in Windows, and the
+  manually installed version of the font may be incomplete (for example, not
+  contain Cyrillic).
+
 ## [1.122.1] - 2023-08-10
 ### Changed
 - Disable player for video attachments until we can deal with the increased

--- a/src/startup.js
+++ b/src/startup.js
@@ -48,3 +48,10 @@ try {
     });
   ga.l = 1 * new Date();
 }
+
+// Windows platform detection
+{
+  const platform = navigator.userAgentData?.platform;
+  const isWindows = platform ? platform === 'Windows' : navigator.userAgent.includes('Win');
+  document.documentElement.classList.toggle('windows-platform', isWindows);
+}

--- a/styles/common/common.scss
+++ b/styles/common/common.scss
@@ -4,7 +4,13 @@ $icon-font-path: '../../assets/fonts/bootstrap/';
 
 // override default bootstrap fonts
 $font-family-sans-serif: Vazir, 'Helvetica Neue', Helvetica, Arial, sans-serif !default;
+$font-family-sans-serif-windows: Vazir, Arial, sans-serif !default;
 $font-family-serif: Vazir, Georgia, 'Times New Roman', Times, serif !default;
 $font-family-monospace: Vazir, Menlo, Monaco, Consolas, 'Courier New', monospace !default;
 
 @import 'bootstrap/bootstrap.3.3.4.scss';
+
+.windows-platform body {
+  // Use special fonts set for Windows platform
+  font-family: $font-family-sans-serif-windows;
+}


### PR DESCRIPTION
Helvetica is not a native font in Windows, and the manually installed version of the font may be incomplete (for example, not contain Cyrillic).
