### PR TITLE
Add support for x.com in TWEET_RE regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     parses in texts as active links.
   - Old-fashion links, with long UIDs, are still fully supported.
 
+- Updated TWEET_RE regex to support matching x.com in addition to twitter.com.
+
 ### Changed
 - Spoiler tag can now contain line feeds. In addition, user text formatting
   utilizes simpler HTML, with fewer wrappers. Visually, the output for the user

--- a/src/components/link-preview/twitter.jsx
+++ b/src/components/link-preview/twitter.jsx
@@ -7,7 +7,7 @@ import { withEventListener } from '../hooks/sub-unsub';
 import * as heightCache from './helpers/size-cache';
 import FoldableContent from './helpers/foldable-content';
 
-const TWEET_RE = /^https?:\/\/twitter\.com\/[^/]+\/status\/(\d+)/i;
+const TWEET_RE = /^https?:\/\/(?:twitter|x)\.com\/[^/]+\/status\/(\d+)/i;
 
 export function canShowURL(url) {
   return TWEET_RE.test(url);


### PR DESCRIPTION
This PR updates the TWEET_RE regex to add support for matching x.com in addition to twitter.com.

Changes:

- Added x\.com as an alternate domain using (?:twitter|x)
- Escaped forward slashes to match them literally

This will now allow the regex to match:

https://twitter.com/user/status/12345
https://x.com/user/status/67890

This expands the functionality of TWEET_RE to support scraping tweet IDs from x.com in addition to twitter.com with minimal code changes.

Please review and let me know if any other changes are required.