### PR TITLE
Do not check access to the existing direct recipients during editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.124.0] - Not released
+### Fixed
+- During direct message editing, there is no access check of the existing
+  recipients (even if some of them are gone). This check is unnecessary because
+  the message author cannot remove the existing recipients anyway.
 
 ## [1.123.3] - 2023-09-15
 ### Fixed

--- a/src/components/feeds-selector/error.jsx
+++ b/src/components/feeds-selector/error.jsx
@@ -13,6 +13,9 @@ import {
 import styles from './selector.module.scss';
 
 export function SelectorError({ values, isDirect, isEditing, onError }) {
+  // We cannot modify the fixed values, so there is no point in reporting errors
+  // related to them
+  values = values.filter((v) => !v.isFixed);
   const [hasMyFeed, missing, badUsers, badGroups, allUsers, allGroups] = useMemo(
     () => [
       values.some((a) => a.type === ACC_ME),


### PR DESCRIPTION
This check is unnecessary because the message author cannot remove the existing recipients anyway.