### PR TITLE
Improve create post form and friendlist head line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.124.0] - Not released
+### Changed
+- The feed selector ('To:' line) is now always visible in the post creation
+  form.
 
 ## [1.123.3] - 2023-09-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The feed selector ('To:' line) is now always visible in the post creation
   form.
+- The "Edit list" link is no longer shown next to the Home or friend list page
+  title. It has been moved to the "•••" menu on the right side of the list
+  header.
 
 ## [1.123.3] - 2023-09-15
 ### Fixed

--- a/src/components/create-post.jsx
+++ b/src/components/create-post.jsx
@@ -43,7 +43,6 @@ export default function CreatePost({ sendTo, isDirects }) {
   const [commentsDisabled, toggleCommentsDisabled] = useBool(false);
   const [isMoreOpen, toggleIsMoreOpen] = useBool(false);
   const [postText, setPostText] = useState(sendTo.invitation || '');
-  const [selectorVisible, setSelectorVisible, expandSendTo] = useBool(isDirects);
 
   const defaultFeedNames = useMemo(() => {
     if (Array.isArray(sendTo.defaultFeed)) {
@@ -56,14 +55,14 @@ export default function CreatePost({ sendTo, isDirects }) {
 
   const [feeds, setFeeds] = useState(defaultFeedNames);
 
-  useEffect(() => setFeeds(defaultFeedNames), [defaultFeedNames, selectorVisible]);
+  // Update feed selector on new page
+  useEffect(() => setFeeds(defaultFeedNames), [defaultFeedNames]);
 
   const resetLocalState = useCallback(() => {
     toggleCommentsDisabled(false);
     toggleIsMoreOpen(false);
     setPostText(sendTo.invitation || '');
-    setSelectorVisible(isDirects);
-  }, [isDirects, sendTo.invitation, setSelectorVisible, toggleCommentsDisabled, toggleIsMoreOpen]);
+  }, [sendTo.invitation, toggleCommentsDisabled, toggleIsMoreOpen]);
 
   // Uploading files
   const {
@@ -74,9 +73,6 @@ export default function CreatePost({ sendTo, isDirects }) {
     uploadProgressProps,
     postAttachmentsProps,
   } = useUploader({ maxCount: maxFilesCount });
-
-  // Expand SendTo if we have some files
-  useEffect(() => void (fileIds.length > 0 && expandSendTo()), [expandSendTo, fileIds.length]);
 
   const doChooseFiles = useFileChooser(uploadFile, { multiple: true });
 
@@ -177,21 +173,18 @@ export default function CreatePost({ sendTo, isDirects }) {
       <ErrorBoundary>
         <PreventPageLeaving prevent={isFormDirty} />
         <div>
-          {selectorVisible && (
-            <Selector
-              mode={isDirects ? CREATE_DIRECT : CREATE_REGULAR}
-              feedNames={feeds}
-              onChange={setFeeds}
-              onError={setHasFeedsError}
-            />
-          )}
+          <Selector
+            mode={isDirects ? CREATE_DIRECT : CREATE_REGULAR}
+            feedNames={feeds}
+            onChange={setFeeds}
+            onError={setHasFeedsError}
+          />
           <SmartTextarea
             ref={textareaRef}
             className="post-textarea"
             dragOverClassName="post-textarea__dragged"
             value={postText}
             onText={setPostText}
-            onFocus={expandSendTo}
             onSubmit={doCreatePost}
             onFile={uploadFile}
             minRows={3}

--- a/src/components/feed-options-switch.jsx
+++ b/src/components/feed-options-switch.jsx
@@ -9,6 +9,7 @@ import {
   faCircle,
 } from '@fortawesome/free-regular-svg-icons';
 import { Portal } from 'react-portal';
+import { faEdit } from '@fortawesome/free-solid-svg-icons';
 import * as FeedOptions from '../utils/feed-options';
 import {
   toggleRealtime,
@@ -23,7 +24,7 @@ import styles from './feed-options-switch.module.scss';
 import { useDropDown, BOTTOM_LEFT } from './hooks/drop-down';
 import { ButtonLink } from './button-link';
 
-export default function FeedOptionsSwitch() {
+export default function FeedOptionsSwitch({ editHomeList }) {
   const { pivotRef, menuRef, opened, toggle } = useDropDown({ position: BOTTOM_LEFT });
 
   const dispatch = useDispatch();
@@ -69,6 +70,16 @@ export default function FeedOptionsSwitch() {
       {opened && (
         <Portal>
           <ul className={menuStyles.list} ref={menuRef}>
+            {editHomeList && (
+              <>
+                <DropOption value={'x'} current={''} clickHandler={editHomeList} icon={faEdit}>
+                  Edit list
+                </DropOption>
+                <li className={menuStyles.item}>
+                  <div className={menuStyles.spacer} />
+                </li>
+              </>
+            )}
             <DropOption
               value={FeedOptions.ACTIVITY}
               current={feedViewOptions.sort}
@@ -105,13 +116,13 @@ export default function FeedOptionsSwitch() {
   );
 }
 
-function DropOption({ children, value, current, clickHandler, checkbox = false }) {
+function DropOption({ children, value, current, clickHandler, checkbox = false, icon = null }) {
   const onClick = useCallback(() => clickHandler(value), [clickHandler, value]);
 
   const className = cn(menuStyles.link, { [styles.active]: value === current });
 
-  const iconOn = checkbox ? faCheckSquare : faDotCircle;
-  const iconOff = checkbox ? faSquare : faCircle;
+  const iconOn = icon ?? (checkbox ? faCheckSquare : faDotCircle);
+  const iconOff = icon ?? (checkbox ? faSquare : faCircle);
 
   return (
     <li className={menuStyles.item}>

--- a/src/components/home-aux.jsx
+++ b/src/components/home-aux.jsx
@@ -140,12 +140,9 @@ export function HomeAux({ router }) {
       <Helmet title={`${feed.title} - ${CONFIG.siteTitle}`} defer={false} />
       <ErrorBoundary>
         <div className="box-header-timeline" role="heading" aria-labelledby="feed-name">
-          <TopHomeSelector id={feed.id} feedLabelId="feed-name" />{' '}
-          <small>
-            (<ButtonLink onClick={showEditor}>Edit list</ButtonLink>)
-          </small>
+          <TopHomeSelector id={feed.id} feedLabelId="feed-name" />
           <div className="pull-right">
-            <FeedOptionsSwitch />
+            <FeedOptionsSwitch editHomeList={showEditor} />
           </div>
         </div>
         {isEditing && <ListEditor listId={feed.id} close={closeEditor} />}

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -10,7 +10,6 @@ import PaginatedView from './paginated-view';
 import FeedOptionsSwitch from './feed-options-switch';
 import { SubscriptionRequestsAlert } from './susbscription-requests-alert';
 import ErrorBoundary from './error-boundary';
-import { ButtonLink } from './button-link';
 import { useBool } from './hooks/bool';
 import { lazyComponent } from './lazy-component';
 import { InvisibleSelect } from './invisible-select';
@@ -62,13 +61,8 @@ const FeedHandler = (props) => {
       <ErrorBoundary>
         <div className="box-header-timeline" role="heading" aria-labelledby="feed-name">
           <TopHomeSelector id={feedId} feedLabelId="feed-name" />{' '}
-          {feedId && (
-            <small>
-              (<ButtonLink onClick={showEditor}>Edit list</ButtonLink>)
-            </small>
-          )}
           <div className="pull-right">
-            <FeedOptionsSwitch />
+            <FeedOptionsSwitch editHomeList={feedId ? showEditor : null} />
           </div>
         </div>
         {isEditing && <ListEditor listId={feedId} close={closeEditor} />}


### PR DESCRIPTION
### Changed
- The feed selector ('To:' line) is now always visible in the post creation form.
- The "Edit list" link is no longer shown next to the Home or friend list page title. It has been moved to the "•••" menu on the right side of the list header.

Discussion: https://freefeed.net/support/b14881

Before:
![image](https://github.com/FreeFeed/freefeed-react-client/assets/132120/8c955701-6479-46b3-9dd8-e2b1ebf04a0f)

After:
![image](https://github.com/FreeFeed/freefeed-react-client/assets/132120/f1687e61-0765-410b-8f73-318279014c6c)

![image](https://github.com/FreeFeed/freefeed-react-client/assets/132120/4960fe41-d9ed-4d3b-b4fd-a0eba9f1f1cb)
