### PR TITLE
Use "Show blocked content..." wording in groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.125.0] - Not released
+### Changed
+- The wording "Disable blocked contingent..." (in the context of groups) has
+  been replaced by "Show blocked content..." as more clear.
 
 ## [1.124.2] - 2023-10-25
 ### Fixed

--- a/src/components/dialog/disable-bans-dialog.jsx
+++ b/src/components/dialog/disable-bans-dialog.jsx
@@ -12,12 +12,12 @@ export function useShowDisableBansDialog(group, isAdmin) {
   return useShowDialog(
     useMemo(
       () => ({
-        title: `Disable blocking in ${uname}`,
-        actionLabel: `Disable blocking`,
+        title: `Show blocked content in ${uname}`,
+        actionLabel: `Show blocked content`,
         action,
         body: (
           <>
-            <p>You are going to disable blocking in {uname}. What does this mean?</p>
+            <p>You are going to show blocked content in {uname}. What does this mean?</p>
             <ul>
               <li>
                 <p>You will see all the posts of your blocked users in {uname}.</p>
@@ -36,7 +36,7 @@ export function useShowDisableBansDialog(group, isAdmin) {
                 </li>
               )}
             </ul>
-            <p>You can enable blocks in {uname} at any time.</p>
+            <p>You can hide back blocked content in {uname} at any time.</p>
           </>
         ),
       }),

--- a/src/components/group-settings-form.jsx
+++ b/src/components/group-settings-form.jsx
@@ -128,7 +128,7 @@ export default function GroupSettingsForm({ username }) {
 
         <div className="form-group">
           <p>
-            <strong>Blocked users</strong>
+            <strong>Blocked content</strong>
           </p>
           <div className="checkbox">
             <label>

--- a/src/components/user-profile-head-actions.jsx
+++ b/src/components/user-profile-head-actions.jsx
@@ -153,14 +153,14 @@ export function UserProfileHeadActions({
                         {...toggleShowBans}
                         onClick={showDisableBansDialog}
                       >
-                        Disable blocking in group
+                        Show blocked content&hellip;
                       </ActionLink>
                     </li>
                   )}
                   {user.youCan.includes('undisable_bans') && (
                     <li className={menuStyles.item}>
                       <ActionLink className={menuStyles.link} {...toggleShowBans}>
-                        Enable blocking in group
+                        Don&#x2019;t show blocked content
                       </ActionLink>
                     </li>
                   )}


### PR DESCRIPTION
The wording "Disable blocked contingent..." (in the context of groups) has been replaced by "Show blocked content..." as more clear.

---

![image](https://github.com/FreeFeed/freefeed-react-client/assets/132120/37a1b364-5c58-414b-8328-2fdc2dbe5545)
---
![image](https://github.com/FreeFeed/freefeed-react-client/assets/132120/b3233454-043b-4aa3-8308-d75506895ed1)
