### PR TITLE
Prevent the unwanted auto-zoom on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.128.0] - Not released
+### Fixed
+- Return the 'maximum-scale=1' back to the "viewport" meta tag, but remove it on
+  non-iOS platforms. This allows to zoom in page on all platforms, but prevents
+  the unwanted auto-zoom on iOS.
 
 ## [1.127.1] - 2024-02-02
 ### Changed

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1" />
 
     <!-- Support for FB OpenGraph and Twitter -->
     <!--#if expr="${request_uri} = /^\/([a-zA-Z0-9]+)\/([a-fA-F0-9\-]{36}|[a-fA-F0-9]{4,6})/" -->

--- a/src/startup.js
+++ b/src/startup.js
@@ -49,9 +49,23 @@ try {
   ga.l = 1 * new Date();
 }
 
-// Windows platform detection
+// Platform specific tuning
 {
-  const platform = navigator.userAgentData?.platform;
+  const platform = navigator.userAgentData?.platform ?? navigator.platform;
   const isWindows = platform ? platform === 'Windows' : navigator.userAgent.includes('Win');
+  const isIos =
+    !isWindows &&
+    ['iPad Simulator', 'iPhone Simulator', 'iPod Simulator', 'iPad', 'iPhone', 'iPod'].includes(
+      platform,
+    );
+
+  // Set Windows platform class
   document.documentElement.classList.toggle('windows-platform', isWindows);
+
+  // Remove 'maximum-scale=1' on non-iOS platforms to allow pinch zoom
+  if (!isIos) {
+    document
+      .querySelector('meta[name="viewport"]')
+      ?.setAttribute('content', 'width=device-width,initial-scale=1');
+  }
 }


### PR DESCRIPTION
Set the 'maximum-scale=1' by default but remove it on non-iOS platforms