### PR TITLE
Align RTL texts to right in post bodies and user descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   User can disable drafts saving on the Settings / Privacy page. In this case,
   drafts will still work, but will not be saved to persistent storage and will
   be lost on tab close/reload.
+### Changed
+- RTL texts are now right-aligned in the post bodies and in the user
+  descriptions.
 
 ## [1.127.3] - 2024-02-14
 ### Fixed

--- a/src/components/user-profile-head.module.scss
+++ b/src/components/user-profile-head.module.scss
@@ -102,6 +102,10 @@ $actions-padding: 0.75em;
   &:empty {
     display: none;
   }
+
+  & :global(.Linkify) {
+    display: block;
+  }
 }
 
 .stats {

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -98,6 +98,10 @@ $post-line-height: rem(20px);
         }
       }
 
+      .Linkify {
+        display: block;
+      }
+
       a {
         color: #000088;
       }


### PR DESCRIPTION
Before:
![image](https://github.com/FreeFeed/freefeed-react-client/assets/132120/c2d6460f-4b84-4506-b163-87c425ac92b6)

After:
![image](https://github.com/FreeFeed/freefeed-react-client/assets/132120/5850355d-9810-4ed8-ac99-4a691206a3ca)
