### PR TITLE
Add resetPasswordCompleteMiddleware to Redux

### DIFF
--- a/src/redux/configure-store.js
+++ b/src/redux/configure-store.js
@@ -26,6 +26,7 @@ import {
   appVersionMiddleware,
   reloadFeedMiddleware,
   draftsMiddleware,
+  resetPasswordCompleteMiddleware,
 } from './middlewares';
 
 import * as reducers from './reducers';
@@ -50,6 +51,7 @@ const middleware = [
   realtimeMiddleware,
   appearanceMiddleware,
   initialWhoamiMiddleware,
+  resetPasswordCompleteMiddleware,
   subscriptionMiddleware,
   onResponseMiddleware,
   betaChannelMiddleware,

--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -873,6 +873,13 @@ export const initialWhoamiMiddleware = (store) => (next) => (action) => {
   next(action);
 };
 
+export const resetPasswordCompleteMiddleware = () => (next) => (action) => {
+  if (action.type === response(ActionTypes.RESET_PASSWORD)) {
+    browserHistory.push('/signin');
+  }
+  next(action);
+};
+
 /**
  * Completes incomplete post comments states
  *


### PR DESCRIPTION
A new middleware titled 'resetPasswordCompleteMiddleware' has been introduced to the Redux store management. Upon successful password reset, it directs the user to the signin page. This middleware has been included in the configure-store.js file alongside other middlewares.
https://github.com/FreeFeed/freefeed-react-client/issues/1675



