### PR TITLE
Allow drafts to be completely disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.129.0] - Not released
+### Added
+- Drafts now can be completely disabled by user.
+- Post and comment creation forms now have a "Clear" button that resets the form
+  state.
 
 ## [1.128.2] - 2024-03-29
 ### Added

--- a/src/components/comment-edit-form.jsx
+++ b/src/components/comment-edit-form.jsx
@@ -41,10 +41,13 @@ export function CommentEditForm({
       if (text.trim() !== initialText.trim() && !confirm('Discard changes?')) {
         return;
       }
+      if (isPersistent) {
+        setText(initialText);
+      }
       onCancel(e);
       doneEditingAndDeleteDraft(draftKey);
     },
-    [draftKey, initialText, onCancel, text],
+    [draftKey, initialText, isPersistent, onCancel, text],
   );
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -135,16 +138,14 @@ export function CommentEditForm({
           Comment
         </button>
 
-        {!isPersistent && (
-          <ButtonLink
-            className="comment-cancel"
-            onClick={doCancel}
-            aria-disabled={submitStatus.loading}
-            aria-label={submitStatus.loading ? 'Cancel disabled (submitting)' : null}
-          >
-            Cancel
-          </ButtonLink>
-        )}
+        <ButtonLink
+          className="comment-cancel"
+          onClick={doCancel}
+          aria-disabled={submitStatus.loading}
+          aria-label={submitStatus.loading ? 'Cancel disabled (submitting)' : null}
+        >
+          {isPersistent ? 'Clear' : 'Cancel'}
+        </ButtonLink>
 
         <SubmitModeHint input={input} />
 

--- a/src/components/comment-edit-form.jsx
+++ b/src/components/comment-edit-form.jsx
@@ -38,7 +38,7 @@ export function CommentEditForm({
 
   const doCancel = useCallback(
     (e) => {
-      if (text !== initialText && !confirm('Discard changes?')) {
+      if (text.trim() !== initialText.trim() && !confirm('Discard changes?')) {
         return;
       }
       onCancel(e);

--- a/src/components/comment-edit-form.jsx
+++ b/src/components/comment-edit-form.jsx
@@ -3,6 +3,7 @@ import { useMemo, useCallback, useState, useRef, useEffect, useContext } from 'r
 import cn from 'classnames';
 
 import { faPaperclip } from '@fortawesome/free-solid-svg-icons';
+import { useSelector } from 'react-redux';
 import { initialAsyncState } from '../redux/async-helpers';
 import { doneEditingAndDeleteDraft, getDraft } from '../services/drafts';
 import { Throbber } from './throbber';
@@ -14,6 +15,7 @@ import { SmartTextarea } from './smart-textarea';
 import { useUploader } from './uploader/uploader';
 import { useFileChooser } from './uploader/file-chooser';
 import { UploadProgress } from './uploader/progress';
+import { PreventPageLeaving } from './prevent-page-leaving';
 
 export function CommentEditForm({
   initialText = '',
@@ -26,6 +28,7 @@ export function CommentEditForm({
   submitStatus = initialAsyncState,
   draftKey,
 }) {
+  const frontendPreferences = useSelector((state) => state.user.frontendPreferences);
   const { setInput } = useContext(PostContext);
   const input = useRef(null);
   const [text, setText] = useState(() => getDraft(draftKey)?.text ?? initialText);
@@ -99,6 +102,9 @@ export function CommentEditForm({
 
   return (
     <div className="comment-body" role="form">
+      <PreventPageLeaving
+        prevent={!frontendPreferences.saveDrafts && (canSubmit || submitStatus.loading)}
+      />
       <div>
         <SmartTextarea
           ref={input}

--- a/src/components/create-post.jsx
+++ b/src/components/create-post.jsx
@@ -27,6 +27,7 @@ import { Selector } from './feeds-selector/selector';
 import { CREATE_DIRECT, CREATE_REGULAR } from './feeds-selector/constants';
 import { CommaAndSeparated } from './separated';
 import { usePrivacyCheck } from './feeds-selector/privacy-check';
+import { PreventPageLeaving } from './prevent-page-leaving';
 
 const selectMaxFilesCount = (serverInfo) => serverInfo.attachments.maxCountPerPost;
 const selectMaxPostLength = (serverInfo) => serverInfo.maxTextLength.post;
@@ -36,6 +37,7 @@ export default function CreatePost({ sendTo, isDirects }) {
     const loc = state.routing.locationBeforeTransitions;
     return newPostURI(loc.pathname + loc.search);
   });
+  const frontendPreferences = useSelector((state) => state.user.frontendPreferences);
 
   // Cleaning up new post draft before the first render
   useMemo(() => deleteEmptyDraft(draftKey), [draftKey]);
@@ -196,6 +198,7 @@ export default function CreatePost({ sendTo, isDirects }) {
       ref={containerRef}
     >
       <ErrorBoundary>
+        <PreventPageLeaving prevent={!frontendPreferences.saveDrafts && isFormDirty} />
         <div>
           <Selector
             mode={isDirects ? CREATE_DIRECT : CREATE_REGULAR}

--- a/src/components/settings/forms/privacy.jsx
+++ b/src/components/settings/forms/privacy.jsx
@@ -121,14 +121,10 @@ export default (function PrivacyForm() {
           <div className="checkbox">
             <label>
               <CheckboxInput field={saveDrafts} />
-              Save unfinished posts and comments drafts to your browser&#x2019;s local storage.
+              Save unfinished posts and comments drafts to your browser&#x2019;s local storage
             </label>
           </div>
         </div>
-        <p className="text-muted">
-          If you disable saving, drafts will still work, but will not be saved to persistent storage
-          and will be lost when you close or reload the browser tab.
-        </p>
       </section>
 
       <div className="form-group">

--- a/src/services/drafts.js
+++ b/src/services/drafts.js
@@ -259,7 +259,7 @@ export function initializeDrafts(store) {
  * @param {{external?: boolean}} options
  */
 function setDraftData(key, data, { external = false } = {}) {
-  if (isUnchangedData(data, getDraft(key) ?? null)) {
+  if (!savingEnabled || isUnchangedData(data, getDraft(key) ?? null)) {
     return;
   }
   if (isEmptyData(data)) {

--- a/test/jest/__snapshots__/post-comments.test.jsx.snap
+++ b/test/jest/__snapshots__/post-comments.test.jsx.snap
@@ -385,6 +385,14 @@ exports[`PostComments > Renders post comments and doesn't blow up 1`] = `
           >
             Comment
           </button>
+          <a
+            aria-disabled="false"
+            class="comment-cancel"
+            role="button"
+            tabindex="0"
+          >
+            Clear
+          </a>
           <span
             class="submit-mode-hint"
           >


### PR DESCRIPTION
### Added
- Drafts now can be completely disabled by user.
- Post and comment creation forms now have a "Clear" button that resets the form state.
