### PR TITLE
Preformatted code (single and triple `) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.134.0] - Not released
+### Added
+- Add support for inline code (single backticks) and code blocks (triple backticks)
+  to post/comment text parser.
 
 ## [1.133.0] - 2024-07-04
 ### Added

--- a/src/components/code-block.jsx
+++ b/src/components/code-block.jsx
@@ -6,17 +6,20 @@ import styles from './code-block.module.scss';
 export default function CodeBlock({ text, className = '' }) {
   const clsName = cn(styles.codeBlock, className);
 
+  const [, start, body, end] = /^([^\n]+)(.*?)([^\n]+)$/s.exec(text);
+
   return (
     <>
       <span className="p-break">
         <br /> <br />
       </span>
       <pre className={clsName}>
-        <code>{text}</code>
+        <code>
+          <span className="code--backticks">{start}</span>
+          {body}
+          <span className="code--backticks">{end}</span>
+        </code>
       </pre>
-      <span className="p-break">
-        <br /> <br />
-      </span>
     </>
   );
 }

--- a/src/components/code-block.jsx
+++ b/src/components/code-block.jsx
@@ -1,0 +1,27 @@
+import cn from 'classnames';
+import PropTypes from 'prop-types';
+import styles from './code-block.module.scss';
+
+/** @argument {{ text: string, className: [string] }} */
+export default function CodeBlock({ text, className = '' }) {
+  const clsName = cn(styles.codeBlock, className);
+
+  return (
+    <>
+      <span className="p-break">
+        <br /> <br />
+      </span>
+      <pre className={clsName}>
+        <code>{text}</code>
+      </pre>
+      <span className="p-break">
+        <br /> <br />
+      </span>
+    </>
+  );
+}
+
+CodeBlock.propTypes = {
+  text: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};

--- a/src/components/code-block.module.scss
+++ b/src/components/code-block.module.scss
@@ -1,13 +1,14 @@
 .codeBlock {
   display: inline;
   padding: unset;
-  font-size: 90%;
   word-break: auto-phrase;
   white-space: pre-wrap;
   background-color: transparent;
   border: none;
   position: relative;
   margin: unset;
+  color: inherit;
+  font-size: 100%; // Compensate the Bootstrap font size
 
   :global(.dark-theme) & code {
     background-color: unset;

--- a/src/components/code-block.module.scss
+++ b/src/components/code-block.module.scss
@@ -8,4 +8,8 @@
   border: none;
   position: relative;
   margin: unset;
+
+  :global(.dark-theme) & code {
+    background-color: unset;
+  }
 }

--- a/src/components/code-block.module.scss
+++ b/src/components/code-block.module.scss
@@ -1,0 +1,11 @@
+.codeBlock {
+  display: inline;
+  padding: unset;
+  font-size: 90%;
+  word-break: auto-phrase;
+  white-space: pre-wrap;
+  background-color: transparent;
+  border: none;
+  position: relative;
+  margin: unset;
+}

--- a/src/components/linkify-elements.jsx
+++ b/src/components/linkify-elements.jsx
@@ -140,12 +140,16 @@ export function tokenToElement(token, key, params) {
     case INITIAL_CHECKBOX:
       return <InitialCheckbox key={key} checked={isChecked(token.text)} />;
 
-    case CODE_INLINE:
+    case CODE_INLINE: {
+      const [, start, text, end] = /^(`+)(.*)(\1)$/.exec(token.text);
       return (
         <code key={key} className="inline-code">
-          {token.text}
+          <span className="code--backticks">{start}</span>
+          {text}
+          <span className="code--backticks">{end}</span>
         </code>
       );
+    }
 
     case CODE_BLOCK:
       return <CodeBlock key={key} text={token.text} />;

--- a/src/components/linkify-elements.jsx
+++ b/src/components/linkify-elements.jsx
@@ -16,13 +16,14 @@ import {
   SHORT_LINK,
   isShortLink,
   CODE_INLINE,
-  trimBackticks,
+  CODE_BLOCK,
 } from '../utils/parse-text';
 import { INITIAL_CHECKBOX, isChecked } from '../utils/initial-checkbox';
 import UserName from './user-name';
 import { MediaOpener, getMediaType } from './media-opener';
 import { InitialCheckbox } from './initial-checkbox';
 import { Anchor, Link } from './linkify-links';
+import CodeBlock from './code-block';
 
 const { searchEngine } = CONFIG.search;
 const MAX_URL_LENGTH = 50;
@@ -140,7 +141,14 @@ export function tokenToElement(token, key, params) {
       return <InitialCheckbox key={key} checked={isChecked(token.text)} />;
 
     case CODE_INLINE:
-      return <code key={key}>{trimBackticks(token.text)}</code>;
+      return (
+        <code key={key} className="inline-code">
+          {token.text}
+        </code>
+      );
+
+    case CODE_BLOCK:
+      return <CodeBlock key={key} text={token.text} />;
   }
   return token.text;
 }

--- a/src/components/linkify-elements.jsx
+++ b/src/components/linkify-elements.jsx
@@ -15,6 +15,8 @@ import {
   redditLinkHref,
   SHORT_LINK,
   isShortLink,
+  CODE_INLINE,
+  trimBackticks,
 } from '../utils/parse-text';
 import { INITIAL_CHECKBOX, isChecked } from '../utils/initial-checkbox';
 import UserName from './user-name';
@@ -136,6 +138,9 @@ export function tokenToElement(token, key, params) {
 
     case INITIAL_CHECKBOX:
       return <InitialCheckbox key={key} checked={isChecked(token.text)} />;
+
+    case CODE_INLINE:
+      return <code key={key}>{trimBackticks(token.text)}</code>;
   }
   return token.text;
 }

--- a/src/components/settings/forms/notifications.jsx
+++ b/src/components/settings/forms/notifications.jsx
@@ -77,10 +77,13 @@ export default function NotificationsForm() {
       <section className={settingsStyles.formSection}>
         <h4 id="telegram-bot">Telegram notifications</h4>
         <p>You can use our Telegram bot to receive notifications and send replies:</p>
-        <p><a href="https://t.me/FreeFeedTgBot" target="_blank">@FreeFeedTgBot</a></p>
+        <p>
+          <a href="https://t.me/FreeFeedTgBot" target="_blank">
+            @FreeFeedTgBot
+          </a>
+        </p>
       </section>
-      
-      
+
       <section className={settingsStyles.formSection}>
         <h4 id="email-me">Email me:</h4>
 

--- a/src/utils/parse-text.js
+++ b/src/utils/parse-text.js
@@ -99,6 +99,7 @@ export const PARAGRAPH_BREAK = 'PARAGRAPH_BREAK';
 export const REDDIT_LINK = 'REDDIT_LINK';
 export const SHORT_LINK = 'SHORT_LINK';
 export const CODE_INLINE = 'CODE_INLINE';
+export const CODE_BLOCK = 'CODE_BLOCK';
 
 const redditLinks = withFilters(
   reTokenizer(/\/?r\/[A-Za-z\d]\w{1,20}/g, makeToken(REDDIT_LINK)),
@@ -126,10 +127,14 @@ export const lineBreaks = reTokenizer(/[^\S\n]*\n\s*/g, (offset, text) => {
   return makeToken(PARAGRAPH_BREAK)(offset, text);
 });
 
-export const trimBackticks = (code) => code.replace(/^`+/, '').replace(/`+$/, '');
-
 export const codeInline = withFilters(
-  reTokenizer(/``.+?``|`[^`]+`/g, makeToken(CODE_INLINE)),
+  reTokenizer(/``.+?``|`[^`]+`/gs, makeToken(CODE_INLINE)),
+  withCharsBefore(wordAdjacentChars.withoutChars('`').withChars('-')),
+  withCharsAfter(wordAdjacentChars.withoutChars('`').withChars('-')),
+);
+
+export const codeBlocks = withFilters(
+  reTokenizer(/```.+?```/gs, makeToken(CODE_BLOCK)),
   withCharsBefore(wordAdjacentChars.withoutChars('`').withChars('-')),
   withCharsAfter(wordAdjacentChars.withoutChars('`').withChars('-')),
 );
@@ -149,6 +154,7 @@ export const parseText = withTexts(
       checkboxParser,
       lineBreaks,
       codeInline,
+      codeBlocks,
     ),
   ),
 );

--- a/src/utils/parse-text.js
+++ b/src/utils/parse-text.js
@@ -98,6 +98,7 @@ export const LINE_BREAK = 'LINE_BREAK';
 export const PARAGRAPH_BREAK = 'PARAGRAPH_BREAK';
 export const REDDIT_LINK = 'REDDIT_LINK';
 export const SHORT_LINK = 'SHORT_LINK';
+export const CODE_INLINE = 'CODE_INLINE';
 
 const redditLinks = withFilters(
   reTokenizer(/\/?r\/[A-Za-z\d]\w{1,20}/g, makeToken(REDDIT_LINK)),
@@ -125,6 +126,14 @@ export const lineBreaks = reTokenizer(/[^\S\n]*\n\s*/g, (offset, text) => {
   return makeToken(PARAGRAPH_BREAK)(offset, text);
 });
 
+export const trimBackticks = (code) => code.replace(/^`+/, '').replace(/`+$/, '');
+
+export const codeInline = withFilters(
+  reTokenizer(/``.+?``|`[^`]+`/g, makeToken(CODE_INLINE)),
+  withCharsBefore(wordAdjacentChars.withoutChars('`').withChars('-')),
+  withCharsAfter(wordAdjacentChars.withoutChars('`').withChars('-')),
+);
+
 export const parseText = withTexts(
   validateSpoilerTags(
     combine(
@@ -139,6 +148,7 @@ export const parseText = withTexts(
       spoilerTags,
       checkboxParser,
       lineBreaks,
+      codeInline,
     ),
   ),
 );

--- a/src/utils/parse-text.js
+++ b/src/utils/parse-text.js
@@ -133,10 +133,14 @@ export const codeInline = withFilters(
   withCharsAfter(wordAdjacentChars.withoutChars('`').withChars('-')),
 );
 
+const makeCodeBlock = makeToken(CODE_BLOCK);
 export const codeBlocks = withFilters(
-  reTokenizer(/```.+?```/gs, makeToken(CODE_BLOCK)),
-  withCharsBefore(wordAdjacentChars.withoutChars('`').withChars('-')),
-  withCharsAfter(wordAdjacentChars.withoutChars('`').withChars('-')),
+  reTokenizer(
+    /^(\s*)(`{3,}(?!`)).*?^\s*(\2)[^\S\n]*$/gms,
+    // Trim whitespace before and after the code block. We need this to prevent
+    // collisions with LINE_BREAK and PARAGRAPH_BREAK.
+    (offset, text, match) => makeCodeBlock(offset + match[1].length, text.trim()),
+  ),
 );
 
 export const parseText = withTexts(

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -266,9 +266,18 @@ code.inline-code {
   color: unset;
   background-color: unset;
   padding: unset;
+  font-size: 100%; // Compensate the Bootstrap font size
 
   .dark-theme & {
     background-color: unset;
+  }
+}
+
+.code--backticks {
+  color: #999;
+
+  .dark-theme & {
+    color: $text-color-darker;
   }
 }
 

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -266,6 +266,10 @@ code.inline-code {
   color: unset;
   background-color: unset;
   padding: unset;
+
+  .dark-theme & {
+    background-color: unset;
+  }
 }
 
 .text-no-breaks br {

--- a/styles/shared/post.scss
+++ b/styles/shared/post.scss
@@ -261,6 +261,13 @@ $post-line-height: rem(20px);
   }
 }
 
+// Inline code elements
+code.inline-code {
+  color: unset;
+  background-color: unset;
+  padding: unset;
+}
+
 .text-no-breaks br {
   display: none;
 }

--- a/test/jest/__snapshots__/piece-of-text.test.jsx.snap
+++ b/test/jest/__snapshots__/piece-of-text.test.jsx.snap
@@ -94,6 +94,51 @@ exports[`PieceOfText > Renders an empty span if empty 1`] = `
 </DocumentFragment>
 `;
 
+exports[`PieceOfText > Renders text with code block 1`] = `
+<DocumentFragment>
+  <span
+    class="Linkify"
+    dir="auto"
+    role="region"
+  >
+    <span
+      dir="auto"
+    >
+      <span
+        class="p-break"
+      >
+        <br />
+         
+        <br />
+      </span>
+      <pre
+        class="codeBlock"
+      >
+        <code>
+          \`\`\` 1+1=2; foo(); @mention user@example.com #hashtag ^ &lt;spoiler&gt;https://example.com \`\`\`
+        </code>
+      </pre>
+      <span
+        class="p-break"
+      >
+        <br />
+         
+        <br />
+      </span>
+    </span>
+     
+    <a
+      aria-disabled="false"
+      class="read-more"
+      role="button"
+      tabindex="0"
+    >
+      Expand
+    </a>
+  </span>
+</DocumentFragment>
+`;
+
 exports[`PieceOfText > Renders text with inline code 1`] = `
 <DocumentFragment>
   <span
@@ -104,8 +149,10 @@ exports[`PieceOfText > Renders text with inline code 1`] = `
     <span
       dir="auto"
     >
-      <code>
-        1+1=2; foo(); @mention user@example.com #hashtag ^ &lt;spoiler&gt;https://example.com
+      <code
+        class="inline-code"
+      >
+        \`1+1=2; foo(); @mention user@example.com #hashtag ^ &lt;spoiler&gt;https://example.com\`
       </code>
     </span>
      

--- a/test/jest/__snapshots__/piece-of-text.test.jsx.snap
+++ b/test/jest/__snapshots__/piece-of-text.test.jsx.snap
@@ -94,6 +94,33 @@ exports[`PieceOfText > Renders an empty span if empty 1`] = `
 </DocumentFragment>
 `;
 
+exports[`PieceOfText > Renders text with inline code 1`] = `
+<DocumentFragment>
+  <span
+    class="Linkify"
+    dir="auto"
+    role="region"
+  >
+    <span
+      dir="auto"
+    >
+      <code>
+        1+1=2; foo(); @mention user@example.com #hashtag ^ &lt;spoiler&gt;https://example.com
+      </code>
+    </span>
+     
+    <a
+      aria-disabled="false"
+      class="read-more"
+      role="button"
+      tabindex="0"
+    >
+      Expand
+    </a>
+  </span>
+</DocumentFragment>
+`;
+
 exports[`PieceOfText > Renders text with spoilers 1`] = `
 <DocumentFragment>
   <span

--- a/test/jest/__snapshots__/piece-of-text.test.jsx.snap
+++ b/test/jest/__snapshots__/piece-of-text.test.jsx.snap
@@ -112,7 +112,12 @@ exports[`PieceOfText > Renders text with code block 1`] = `
       class="codeBlock"
     >
       <code>
-        \`\`\`
+        <span
+          class="code--backticks"
+        >
+          \`\`\`
+        </span>
+        
 1+1=2;
 foo();
 @mention 
@@ -122,16 +127,14 @@ user@example.com
 ^ 
 
 &lt;spoiler&gt;https://example.com
-\`\`\`
+
+        <span
+          class="code--backticks"
+        >
+          \`\`\`
+        </span>
       </code>
     </pre>
-    <span
-      class="p-break"
-    >
-      <br />
-       
-      <br />
-    </span>
   </span>
 </DocumentFragment>
 `;
@@ -149,7 +152,17 @@ exports[`PieceOfText > Renders text with inline code 1`] = `
       <code
         class="inline-code"
       >
-        \`1+1=2; foo(); @mention user@example.com #hashtag ^ &lt;spoiler&gt;https://example.com\`
+        <span
+          class="code--backticks"
+        >
+          \`
+        </span>
+        1+1=2; foo(); @mention user@example.com #hashtag ^ &lt;spoiler&gt;https://example.com
+        <span
+          class="code--backticks"
+        >
+          \`
+        </span>
       </code>
     </span>
      

--- a/test/jest/__snapshots__/piece-of-text.test.jsx.snap
+++ b/test/jest/__snapshots__/piece-of-text.test.jsx.snap
@@ -102,39 +102,36 @@ exports[`PieceOfText > Renders text with code block 1`] = `
     role="region"
   >
     <span
-      dir="auto"
+      class="p-break"
     >
-      <span
-        class="p-break"
-      >
-        <br />
-         
-        <br />
-      </span>
-      <pre
-        class="codeBlock"
-      >
-        <code>
-          \`\`\` 1+1=2; foo(); @mention user@example.com #hashtag ^ &lt;spoiler&gt;https://example.com \`\`\`
-        </code>
-      </pre>
-      <span
-        class="p-break"
-      >
-        <br />
-         
-        <br />
-      </span>
+      <br />
+       
+      <br />
     </span>
-     
-    <a
-      aria-disabled="false"
-      class="read-more"
-      role="button"
-      tabindex="0"
+    <pre
+      class="codeBlock"
     >
-      Expand
-    </a>
+      <code>
+        \`\`\`
+1+1=2;
+foo();
+@mention 
+user@example.com 
+
+#hashtag 
+^ 
+
+&lt;spoiler&gt;https://example.com
+\`\`\`
+      </code>
+    </pre>
+    <span
+      class="p-break"
+    >
+      <br />
+       
+      <br />
+    </span>
   </span>
 </DocumentFragment>
 `;

--- a/test/jest/piece-of-text.test.jsx
+++ b/test/jest/piece-of-text.test.jsx
@@ -49,4 +49,12 @@ describe('PieceOfText', () => {
 
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('Renders text with inline code', () => {
+    const code =
+      '`1+1=2; foo(); @mention \n user@example.com \n\n #hashtag \n ^ \n\n <spoiler>https://example.com`';
+    const { asFragment } = render(<PieceOfText text={code} />);
+
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/test/jest/piece-of-text.test.jsx
+++ b/test/jest/piece-of-text.test.jsx
@@ -61,7 +61,7 @@ describe('PieceOfText', () => {
   it('Renders text with code block', () => {
     const code =
       '```\n1+1=2;\nfoo();\n@mention \nuser@example.com \n\n#hashtag \n^ \n\n<spoiler>https://example.com\n```';
-    const { asFragment } = render(<PieceOfText text={code} />);
+    const { asFragment } = render(<PieceOfText isExpanded text={code} />);
 
     expect(asFragment()).toMatchSnapshot();
   });

--- a/test/jest/piece-of-text.test.jsx
+++ b/test/jest/piece-of-text.test.jsx
@@ -57,4 +57,12 @@ describe('PieceOfText', () => {
 
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('Renders text with code block', () => {
+    const code =
+      '```\n1+1=2;\nfoo();\n@mention \nuser@example.com \n\n#hashtag \n^ \n\n<spoiler>https://example.com\n```';
+    const { asFragment } = render(<PieceOfText text={code} />);
+
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/test/unit/components/piece-of-text.jsx
+++ b/test/unit/components/piece-of-text.jsx
@@ -108,4 +108,22 @@ describe('<PieceOfText>', () => {
       </span>,
     );
   });
+
+  it('should correctly process texts with inline code', () => {
+    const code =
+      '1+1=2; foo(); @mention \n user@example.com \n\n #hashtag \n ^ \n\n <spoiler>https://example.com';
+    const text = `Here is the code \`${code}\`. </spoiler> Read it carefully`;
+    expect(
+      <Linkify>{text}</Linkify>, //<PieceOfText text={text} readMoreStyle={READMORE_STYLE_COMFORT} />,
+      'when rendered',
+      'to have rendered with all children',
+      <span>
+        <ErrorBoundary>
+          {'Here is the code '}
+          <code>{code}</code>
+          {'. </spoiler> Read it carefully'}
+        </ErrorBoundary>
+      </span>,
+    );
+  });
 });

--- a/test/unit/components/piece-of-text.jsx
+++ b/test/unit/components/piece-of-text.jsx
@@ -130,8 +130,8 @@ describe('<PieceOfText>', () => {
 
   it('should correctly process texts with code blocks', () => {
     const codeBlock =
-      '```1+1=2; foo(); @mention \n user@example.com \n\n #hashtag \n ^ \n\n <spoiler>https://example.com```';
-    const text = `Here is the code block\n ${codeBlock}.\n</spoiler> Read it carefully`;
+      '```\n1+1=2; foo(); @mention \n user@example.com \n\n #hashtag \n ^ \n\n <spoiler>https://example.com\n```';
+    const text = `Here is the code block\n ${codeBlock}\n</spoiler> Read it carefully`;
     expect(
       <Linkify>{text}</Linkify>,
       'when rendered',
@@ -144,7 +144,6 @@ describe('<PieceOfText>', () => {
             <br />
           </no-display-name>
           <CodeBlock text={codeBlock} />
-          {'.'}
           <no-display-name>
             {' '}
             <br />

--- a/test/unit/components/piece-of-text.jsx
+++ b/test/unit/components/piece-of-text.jsx
@@ -111,9 +111,8 @@ describe('<PieceOfText>', () => {
   });
 
   it('should correctly process texts with inline code', () => {
-    const code =
-      '`1+1=2; foo(); @mention user@example.com #hashtag ^ <spoiler>https://example.com`';
-    const text = `Here is the code ${code}. </spoiler> Read it carefully`;
+    const code = '1+1=2; foo(); @mention user@example.com #hashtag ^ <spoiler>https://example.com';
+    const text = `Here is the code \`${code}\`. </spoiler> Read it carefully`;
     expect(
       <Linkify>{text}</Linkify>,
       'when rendered',
@@ -121,7 +120,11 @@ describe('<PieceOfText>', () => {
       <span>
         <ErrorBoundary>
           {'Here is the code '}
-          <code>{code}</code>
+          <code>
+            <span className="code--backticks">`</span>
+            {code}
+            <span className="code--backticks">`</span>
+          </code>
           {'. </spoiler> Read it carefully'}
         </ErrorBoundary>
       </span>,

--- a/test/unit/components/piece-of-text.jsx
+++ b/test/unit/components/piece-of-text.jsx
@@ -112,7 +112,7 @@ describe('<PieceOfText>', () => {
 
   it('should correctly process texts with inline code', () => {
     const code =
-      '`1+1=2; foo(); @mention \n user@example.com \n\n #hashtag \n ^ \n\n <spoiler>https://example.com`';
+      '`1+1=2; foo(); @mention user@example.com #hashtag ^ <spoiler>https://example.com`';
     const text = `Here is the code ${code}. </spoiler> Read it carefully`;
     expect(
       <Linkify>{text}</Linkify>,

--- a/test/unit/components/piece-of-text.jsx
+++ b/test/unit/components/piece-of-text.jsx
@@ -8,6 +8,7 @@ import Linkify from '../../../src/components/linkify';
 import { ButtonLink } from '../../../src/components/button-link';
 import { Anchor } from '../../../src/components/linkify-links';
 import ErrorBoundary from '../../../src/components/error-boundary';
+import CodeBlock from '../../../src/components/code-block';
 
 const expect = unexpected.clone().use(unexpectedReact);
 
@@ -111,10 +112,10 @@ describe('<PieceOfText>', () => {
 
   it('should correctly process texts with inline code', () => {
     const code =
-      '1+1=2; foo(); @mention \n user@example.com \n\n #hashtag \n ^ \n\n <spoiler>https://example.com';
-    const text = `Here is the code \`${code}\`. </spoiler> Read it carefully`;
+      '`1+1=2; foo(); @mention \n user@example.com \n\n #hashtag \n ^ \n\n <spoiler>https://example.com`';
+    const text = `Here is the code ${code}. </spoiler> Read it carefully`;
     expect(
-      <Linkify>{text}</Linkify>, //<PieceOfText text={text} readMoreStyle={READMORE_STYLE_COMFORT} />,
+      <Linkify>{text}</Linkify>,
       'when rendered',
       'to have rendered with all children',
       <span>
@@ -122,6 +123,33 @@ describe('<PieceOfText>', () => {
           {'Here is the code '}
           <code>{code}</code>
           {'. </spoiler> Read it carefully'}
+        </ErrorBoundary>
+      </span>,
+    );
+  });
+
+  it('should correctly process texts with code blocks', () => {
+    const codeBlock =
+      '```1+1=2; foo(); @mention \n user@example.com \n\n #hashtag \n ^ \n\n <spoiler>https://example.com```';
+    const text = `Here is the code block\n ${codeBlock}.\n</spoiler> Read it carefully`;
+    expect(
+      <Linkify>{text}</Linkify>,
+      'when rendered',
+      'to have rendered with all children',
+      <span>
+        <ErrorBoundary>
+          {'Here is the code block'}
+          <no-display-name>
+            {' '}
+            <br />
+          </no-display-name>
+          <CodeBlock text={codeBlock} />
+          {'.'}
+          <no-display-name>
+            {' '}
+            <br />
+          </no-display-name>
+          {'</spoiler> Read it carefully'}
         </ErrorBoundary>
       </span>,
     );

--- a/test/unit/utils/parse-text.js
+++ b/test/unit/utils/parse-text.js
@@ -1,7 +1,14 @@
 import { describe, it } from 'vitest';
 import expect from 'unexpected';
 
-import { getFirstLinkToEmbed, isLocalLink, redditLinkHref } from '../../../src/utils/parse-text';
+import {
+  getFirstLinkToEmbed,
+  isLocalLink,
+  redditLinkHref,
+  CODE_INLINE,
+  codeInline,
+  parseText,
+} from '../../../src/utils/parse-text';
 
 const localDomains = ['freefeed.net', 'omega.freefeed.net'];
 
@@ -64,6 +71,244 @@ describe('parse-text', () => {
         'to be',
         'https://link2.com/',
       );
+    });
+  });
+
+  describe('codeInline tokenizer', () => {
+    it('should decode inline code in single backticks surrounded by spaces/punctuation or text start/end', () => {
+      const testData = [
+        {
+          text: '`code`',
+          found: [{ code: '`code`', offset: 0 }],
+        },
+        {
+          text: '``code``',
+          found: [{ code: '``code``', offset: 0 }],
+        },
+        {
+          text: '` `',
+          found: [{ code: '` `', offset: 0 }],
+        },
+        {
+          text: 'here it is: `foo()` - an example of function call in JS',
+          found: [{ code: '`foo()`', offset: 12 }],
+        },
+        {
+          text: '`foo()` is an example of function call in JS',
+          found: [{ code: '`foo()`', offset: 0 }],
+        },
+        {
+          text: 'here is an example of function call in JS: `foo()`',
+          found: [{ code: '`foo()`', offset: 43 }],
+        },
+        {
+          text: 'here it is: `foo()`-an example of function call in JS',
+          found: [{ code: '`foo()`', offset: 12 }],
+        },
+        {
+          text: 'here is an example of function call in JS >`foo()`!',
+          found: [{ code: '`foo()`', offset: 43 }],
+        },
+        {
+          text: `
+here is the list of function calls:
+- \`foo()\`;
+\t\`bar()\`,
+-\`baz()\`.
+`,
+          found: [
+            { code: '`foo()`', offset: 39 },
+            { code: '`bar()`', offset: 49 },
+            { code: '`baz()`', offset: 59 },
+          ],
+        },
+        {
+          text: '(`code`)',
+          found: [{ code: '`code`', offset: 1 }],
+        },
+        {
+          text: '[`code`]',
+          found: [{ code: '`code`', offset: 1 }],
+        },
+        {
+          text: '{`code`}',
+          found: [{ code: '`code`', offset: 1 }],
+        },
+        {
+          text: '`code\\` text`',
+          found: [{ code: '`code\\`', offset: 0 }],
+        },
+      ];
+
+      for (const { text, found } of testData) {
+        expect(
+          codeInline(text),
+          'to equal',
+          found.map(({ code, offset }) => ({
+            type: CODE_INLINE,
+            offset,
+            text: code,
+          })),
+        );
+      }
+    });
+
+    it('should not decode regular text without backticks as inline code', () => {
+      expect(codeInline('there is no code here'), 'to be empty');
+    });
+
+    it('should not decode inline code in single backticks not surrounded by spaces/punctuation or text start/end', () => {
+      const testData = [
+        'here it is`foo()` - is not a correct inline code',
+        '#`foo()` is not a correct example of inline code',
+        'here is not a correct example of inline code`foo()`',
+        `
+here is the list of incorrect examples of inline codes:
+1\`foo()\`;
+b\`bar()\`,
+III\`baz()\`.
+@\`bazar()\`.
+`,
+      ];
+
+      for (const text of testData) {
+        expect(codeInline(text), 'to be empty');
+      }
+    });
+
+    it('should not decode empty inline code', () => {
+      expect(codeInline('there is no code >``< here'), 'to be empty');
+    });
+
+    it('should not decode unbalanced or escaped backticks', () => {
+      const testData = ['not-a`code', 'not a co`de, /`and this one`'];
+
+      for (const text of testData) {
+        expect(codeInline(text), 'to be empty');
+      }
+    });
+
+    it('should not decode single backticks inside of inline code surrounded by backticks', () => {
+      expect(codeInline('`single backtick` inside code should not be decoded`'), 'to equal', [
+        {
+          type: CODE_INLINE,
+          offset: 0,
+          text: '`single backtick`',
+        },
+      ]);
+    });
+
+    it('should decode single backticks inside of inline code surrounded by double backticks', () => {
+      expect(codeInline('``single backtick ` inside code should be decoded``'), 'to equal', [
+        {
+          type: CODE_INLINE,
+          offset: 0,
+          text: '``single backtick ` inside code should be decoded``',
+        },
+      ]);
+    });
+
+    it('should not decode nested inline code', () => {
+      expect(codeInline('`inline code should not have ` nested ` code blocks`'), 'to equal', [
+        {
+          type: CODE_INLINE,
+          offset: 0,
+          text: '`inline code should not have `',
+        },
+        {
+          type: CODE_INLINE,
+          offset: 38,
+          text: '` code blocks`',
+        },
+      ]);
+    });
+
+    it('should decode nested inline code inside of double backticks', () => {
+      expect(
+        codeInline('``inline code in double backticks can have ` nested ` code blocks``'),
+        'to equal',
+        [
+          {
+            type: CODE_INLINE,
+            offset: 0,
+            text: '``inline code in double backticks can have ` nested ` code blocks``',
+          },
+        ],
+      );
+    });
+  });
+
+  describe('parseText tokenizer', () => {
+    const inlineCodeToken = (text, offset = 0) => ({
+      type: CODE_INLINE,
+      offset,
+      text,
+    });
+
+    it('should not decode mentions in inline code', () => {
+      expect(parseText('`inline code @mention qwerty`'), 'to equal', [
+        inlineCodeToken('`inline code @mention qwerty`'),
+      ]);
+    });
+
+    it('should not decode emails in inline code', () => {
+      expect(parseText('`user@example.com`'), 'to equal', [inlineCodeToken('`user@example.com`')]);
+    });
+
+    it('should not decode hashtags in inline code', () => {
+      expect(parseText('`#hashtag`'), 'to equal', [inlineCodeToken('`#hashtag`')]);
+    });
+
+    it('should not decode arrows in inline code', () => {
+      expect(parseText('text `^ code ^`'), 'to equal', [
+        {
+          type: 'TEXT',
+          offset: 0,
+          text: 'text ',
+        },
+        inlineCodeToken('`^ code ^`', 5),
+      ]);
+    });
+
+    it('should not decode links in inline code', () => {
+      expect(parseText('`https://example.com`'), 'to equal', [
+        inlineCodeToken('`https://example.com`'),
+      ]);
+    });
+
+    it('should not decode foreign mentions in inline code', () => {
+      expect(parseText('`alice@tg`'), 'to equal', [inlineCodeToken('`alice@tg`')]);
+    });
+
+    it('should not decode line breaks in inline code', () => {
+      const multiline = '`\nmulti\nline\ninline\ncode\n`';
+      expect(parseText(multiline), 'to equal', [inlineCodeToken(multiline)]);
+    });
+
+    it('should not decode paragraph breaks in inline code', () => {
+      const multiline = `\`
+multi
+
+
+
+line\``;
+      expect(parseText(multiline), 'to equal', [inlineCodeToken(multiline)]);
+    });
+
+    it('should not decode spoilers in inline code', () => {
+      expect(parseText('`<spoiler>code</spoiler>`'), 'to equal', [
+        inlineCodeToken('`<spoiler>code</spoiler>`'),
+      ]);
+    });
+    it('should not decode spoilers intersecting with inline code', () => {
+      expect(parseText('`<spoiler> code`</spoiler>'), 'to equal', [
+        inlineCodeToken('`<spoiler> code`'),
+        {
+          type: 'TEXT',
+          offset: 16,
+          text: '</spoiler>',
+        },
+      ]);
     });
   });
 });

--- a/test/unit/utils/parse-text.js
+++ b/test/unit/utils/parse-text.js
@@ -8,6 +8,8 @@ import {
   CODE_INLINE,
   codeInline,
   parseText,
+  codeBlocks,
+  CODE_BLOCK,
 } from '../../../src/utils/parse-text';
 
 const localDomains = ['freefeed.net', 'omega.freefeed.net'];
@@ -102,12 +104,12 @@ describe('parse-text', () => {
           found: [{ code: '`foo()`', offset: 43 }],
         },
         {
-          text: 'here it is: `foo()`-an example of function call in JS',
-          found: [{ code: '`foo()`', offset: 12 }],
+          text: 'here it is: `foo()   `-an example of function call in JS',
+          found: [{ code: '`foo()   `', offset: 12 }],
         },
         {
-          text: 'here is an example of function call in JS >`foo()`!',
-          found: [{ code: '`foo()`', offset: 43 }],
+          text: 'here is an example of function call in JS >`\tfoo()`!',
+          found: [{ code: '`\tfoo()`', offset: 43 }],
         },
         {
           text: `
@@ -137,6 +139,14 @@ here is the list of function calls:
         {
           text: '`code\\` text`',
           found: [{ code: '`code\\`', offset: 0 }],
+        },
+        {
+          text: '`code; \n code;` text',
+          found: [{ code: '`code; \n code;`', offset: 0 }],
+        },
+        {
+          text: '``code; \n code;`` text',
+          found: [{ code: '``code; \n code;``', offset: 0 }],
         },
       ];
 
@@ -180,8 +190,8 @@ III\`baz()\`.
       expect(codeInline('there is no code >``< here'), 'to be empty');
     });
 
-    it('should not decode unbalanced or escaped backticks', () => {
-      const testData = ['not-a`code', 'not a co`de, /`and this one`'];
+    it('should not decode unbalanced backticks', () => {
+      const testData = ['not-a`code', 'not a co`de, a`nd this one`'];
 
       for (const text of testData) {
         expect(codeInline(text), 'to be empty');
@@ -189,11 +199,11 @@ III\`baz()\`.
     });
 
     it('should not decode single backticks inside of inline code surrounded by backticks', () => {
-      expect(codeInline('`single backtick` inside code should not be decoded`'), 'to equal', [
+      expect(codeInline('`single backtick ` inside code should not be decoded`'), 'to equal', [
         {
           type: CODE_INLINE,
           offset: 0,
-          text: '`single backtick`',
+          text: '`single backtick `',
         },
       ]);
     });
@@ -238,6 +248,150 @@ III\`baz()\`.
     });
   });
 
+  describe('codeBlocks tokenizer', () => {
+    it('should decode code block in triple backticks surrounded by spaces/punctuation or text start/end', () => {
+      const testData = [
+        {
+          text: '```code```',
+          found: [{ code: '```code```', offset: 0 }],
+        },
+        {
+          text: '``` ```',
+          found: [{ code: '``` ```', offset: 0 }],
+        },
+        {
+          text: 'here it is: ```\nfoo()\n``` - an example of function call in JS',
+          found: [{ code: '```\nfoo()\n```', offset: 12 }],
+        },
+        {
+          text: '```\nfoo()\n``` is an example of function call in JS',
+          found: [{ code: '```\nfoo()\n```', offset: 0 }],
+        },
+        {
+          text: 'here is an example of function call in JS: ```\nfoo()\n```',
+          found: [{ code: '```\nfoo()\n```', offset: 43 }],
+        },
+        {
+          text: 'here it is: ```\nfoo()\n```-an example of function call in JS',
+          found: [{ code: '```\nfoo()\n```', offset: 12 }],
+        },
+        {
+          text: 'here is an example of function call in JS >```\nfoo()\n```!',
+          found: [{ code: '```\nfoo()\n```', offset: 43 }],
+        },
+        {
+          text: `
+here is the list of function calls:
+- \`\`\`foo()\`\`\`;
+\t\`\`\`bar()\`\`\`,
+-\`\`\`baz()\`\`\`.
+`,
+          found: [
+            { code: '```foo()```', offset: 39 },
+            { code: '```bar()```', offset: 53 },
+            { code: '```baz()```', offset: 67 },
+          ],
+        },
+        {
+          text: '(```code```)',
+          found: [{ code: '```code```', offset: 1 }],
+        },
+        {
+          text: '[```code```]',
+          found: [{ code: '```code```', offset: 1 }],
+        },
+        {
+          text: '{```code```}',
+          found: [{ code: '```code```', offset: 1 }],
+        },
+        {
+          text: '```code\\``` text```',
+          found: [{ code: '```code\\```', offset: 0 }],
+        },
+      ];
+
+      for (const { text, found } of testData) {
+        expect(
+          codeBlocks(text),
+          'to equal',
+          found.map(({ code, offset }) => ({
+            type: CODE_BLOCK,
+            offset,
+            text: code,
+          })),
+        );
+      }
+    });
+
+    it('should not decode regular text without backticks as code block', () => {
+      expect(codeBlocks('there are no code blocks here'), 'to be empty');
+    });
+
+    it('should not decode code blocks in triple backticks not surrounded by spaces/punctuation or text start/end', () => {
+      const testData = [
+        'here it is```foo()``` - is not a correct code block',
+        '#```foo()``` is not a correct example of code block',
+        'here is not a correct example of code block```foo()```',
+        `
+here is the list of incorrect examples of code blocks:
+1\`\`\`foo()\`\`\`;
+b\`\`\`bar()\`\`\`,
+III\`\`\`baz()\`\`\`.
+@\`\`\`bazar()\`\`\`.
+`,
+      ];
+
+      for (const text of testData) {
+        expect(codeBlocks(text), 'to be empty');
+      }
+    });
+
+    it('should not decode empty code block', () => {
+      expect(codeBlocks('there is no code >``````< here'), 'to be empty');
+    });
+
+    it('should not decode unbalanced backticks', () => {
+      const testData = ['not-a```code', 'not a co```de, a```nd this one```'];
+
+      for (const text of testData) {
+        expect(codeBlocks(text), 'to be empty');
+      }
+    });
+
+    it('should not decode triple backticks inside of code blocks', () => {
+      expect(
+        codeBlocks('``` triple backticks ``` inside code block should not be decoded```'),
+        'to equal',
+        [
+          {
+            type: CODE_BLOCK,
+            offset: 0,
+            text: '``` triple backticks ```',
+          },
+        ],
+      );
+    });
+
+    it('should not decode nested code blocks', () => {
+      expect(
+        codeBlocks('``` code blocks should not have ``` nested ``` code blocks```'),
+        'to equal',
+        [
+          {
+            type: CODE_BLOCK,
+            offset: 0,
+            text: '``` code blocks should not have ```',
+          },
+          {
+            type: CODE_BLOCK,
+            offset: 43,
+            text: '``` code blocks```',
+          },
+        ],
+      );
+    });
+  });
+
   describe('parseText tokenizer', () => {
     const inlineCodeToken = (text, offset = 0) => ({
       type: CODE_INLINE,
@@ -245,70 +399,157 @@ III\`baz()\`.
       text,
     });
 
-    it('should not decode mentions in inline code', () => {
-      expect(parseText('`inline code @mention qwerty`'), 'to equal', [
-        inlineCodeToken('`inline code @mention qwerty`'),
-      ]);
+    const codeBlockToken = (text, offset = 0) => ({
+      type: CODE_BLOCK,
+      offset,
+      text,
     });
 
-    it('should not decode emails in inline code', () => {
-      expect(parseText('`user@example.com`'), 'to equal', [inlineCodeToken('`user@example.com`')]);
+    describe('inline code checks', () => {
+      it('should not decode mentions in inline code', () => {
+        expect(parseText('`inline code @mention qwerty`'), 'to equal', [
+          inlineCodeToken('`inline code @mention qwerty`'),
+        ]);
+      });
+
+      it('should not decode emails in inline code', () => {
+        expect(parseText('`user@example.com`'), 'to equal', [
+          inlineCodeToken('`user@example.com`'),
+        ]);
+      });
+
+      it('should not decode hashtags in inline code', () => {
+        expect(parseText('`#hashtag`'), 'to equal', [inlineCodeToken('`#hashtag`')]);
+      });
+
+      it('should not decode arrows in inline code', () => {
+        expect(parseText('text `^ code ^`'), 'to equal', [
+          {
+            type: 'TEXT',
+            offset: 0,
+            text: 'text ',
+          },
+          inlineCodeToken('`^ code ^`', 5),
+        ]);
+      });
+
+      it('should not decode links in inline code', () => {
+        expect(parseText('`https://example.com`'), 'to equal', [
+          inlineCodeToken('`https://example.com`'),
+        ]);
+      });
+
+      it('should not decode foreign mentions in inline code', () => {
+        expect(parseText('`alice@tg`'), 'to equal', [inlineCodeToken('`alice@tg`')]);
+      });
+
+      it('should not decode line breaks in inline code', () => {
+        const multiline = '`\nmulti\nline\ninline\ncode\n`';
+        expect(parseText(multiline), 'to equal', [inlineCodeToken(multiline)]);
+      });
+
+      it('should not decode paragraph breaks in inline code', () => {
+        const multiline = `\`
+  multi
+
+
+
+  line\``;
+        expect(parseText(multiline), 'to equal', [inlineCodeToken(multiline)]);
+      });
+
+      it('should not decode spoilers in inline code', () => {
+        expect(parseText('`<spoiler>code</spoiler>`'), 'to equal', [
+          inlineCodeToken('`<spoiler>code</spoiler>`'),
+        ]);
+      });
+
+      it('should not decode spoilers intersecting with inline code', () => {
+        expect(parseText('` <spoiler> code ` </spoiler>'), 'to equal', [
+          inlineCodeToken('` <spoiler> code `'),
+          {
+            type: 'TEXT',
+            offset: 18,
+            text: ' </spoiler>',
+          },
+        ]);
+      });
     });
 
-    it('should not decode hashtags in inline code', () => {
-      expect(parseText('`#hashtag`'), 'to equal', [inlineCodeToken('`#hashtag`')]);
-    });
+    describe('code block checks', () => {
+      it('should not decode mentions in code blocks', () => {
+        expect(parseText('``` code block @mention qwerty```'), 'to equal', [
+          codeBlockToken('``` code block @mention qwerty```'),
+        ]);
+      });
 
-    it('should not decode arrows in inline code', () => {
-      expect(parseText('text `^ code ^`'), 'to equal', [
-        {
-          type: 'TEXT',
-          offset: 0,
-          text: 'text ',
-        },
-        inlineCodeToken('`^ code ^`', 5),
-      ]);
-    });
+      it('should not decode emails in code blocks', () => {
+        expect(parseText('```user@example.com```'), 'to equal', [
+          codeBlockToken('```user@example.com```'),
+        ]);
+      });
 
-    it('should not decode links in inline code', () => {
-      expect(parseText('`https://example.com`'), 'to equal', [
-        inlineCodeToken('`https://example.com`'),
-      ]);
-    });
+      it('should not decode hashtags in code blocks', () => {
+        expect(parseText('```#hashtag```'), 'to equal', [codeBlockToken('```#hashtag```')]);
+      });
 
-    it('should not decode foreign mentions in inline code', () => {
-      expect(parseText('`alice@tg`'), 'to equal', [inlineCodeToken('`alice@tg`')]);
-    });
+      it('should not decode arrows in code blocks', () => {
+        expect(parseText('text ```^ code ^```'), 'to equal', [
+          {
+            type: 'TEXT',
+            offset: 0,
+            text: 'text ',
+          },
+          codeBlockToken('```^ code ^```', 5),
+        ]);
+      });
 
-    it('should not decode line breaks in inline code', () => {
-      const multiline = '`\nmulti\nline\ninline\ncode\n`';
-      expect(parseText(multiline), 'to equal', [inlineCodeToken(multiline)]);
-    });
+      it('should not decode links in code blocks', () => {
+        expect(parseText('```https://example.com```'), 'to equal', [
+          codeBlockToken('```https://example.com```'),
+        ]);
+      });
 
-    it('should not decode paragraph breaks in inline code', () => {
-      const multiline = `\`
-multi
+      it('should not decode foreign mentions in code blocks', () => {
+        expect(parseText('```alice@tg```'), 'to equal', [codeBlockToken('```alice@tg```')]);
+      });
+
+      it('should not decode line breaks in code blocks', () => {
+        const multiline = '```\nmulti\nline\ncode\nblock\n```';
+        expect(parseText(multiline), 'to equal', [codeBlockToken(multiline)]);
+      });
+
+      it('should not decode paragraph breaks in code blocks', () => {
+        const multiline = `\`\`\`
+  multi
 
 
 
-line\``;
-      expect(parseText(multiline), 'to equal', [inlineCodeToken(multiline)]);
-    });
+  line\`\`\``;
+        expect(parseText(multiline), 'to equal', [codeBlockToken(multiline)]);
+      });
 
-    it('should not decode spoilers in inline code', () => {
-      expect(parseText('`<spoiler>code</spoiler>`'), 'to equal', [
-        inlineCodeToken('`<spoiler>code</spoiler>`'),
-      ]);
-    });
-    it('should not decode spoilers intersecting with inline code', () => {
-      expect(parseText('`<spoiler> code`</spoiler>'), 'to equal', [
-        inlineCodeToken('`<spoiler> code`'),
-        {
-          type: 'TEXT',
-          offset: 16,
-          text: '</spoiler>',
-        },
-      ]);
+      it('should not decode spoilers in code blocks', () => {
+        expect(parseText('```<spoiler>code</spoiler>```'), 'to equal', [
+          codeBlockToken('```<spoiler>code</spoiler>```'),
+        ]);
+      });
+
+      it('should not decode spoilers intersecting with code blocks', () => {
+        expect(parseText('``` <spoiler> code ``` </spoiler>'), 'to equal', [
+          codeBlockToken('``` <spoiler> code ```'),
+          {
+            type: 'TEXT',
+            offset: 22,
+            text: ' </spoiler>',
+          },
+        ]);
+      });
+
+      it('should not decode inline code in code blocks', () => {
+        const codeBlock = '```code line 1;\n`inline code`;\ncode line 2; ```';
+        expect(parseText(codeBlock), 'to equal', [codeBlockToken(codeBlock)]);
+      });
     });
   });
 });

--- a/test/unit/utils/parse-text.js
+++ b/test/unit/utils/parse-text.js
@@ -67,7 +67,7 @@ describe('parse-text', () => {
       );
     });
 
-    it('should not return links inside spoilders', () => {
+    it('should not return links inside spoilers', () => {
       expect(
         getFirstLinkToEmbed('abc <spoiler>https://link1.com</spoiler> https://link2.com def'),
         'to be',


### PR DESCRIPTION
This PR adds support for `inline code` and 
```
code blocks

```

 to text parser and display in FF frontend. Here are the examples:
<img width="754" alt="spoiler-shown" src="https://github.com/FreeFeed/freefeed-react-client/assets/1212834/1b676906-a6bc-4f10-904e-29a523f8db98">

<img width="706" alt="inline" src="https://github.com/FreeFeed/freefeed-react-client/assets/1212834/bcdacf3a-3316-4b7b-872b-09b8a0336af8">
