### PR TITLE
Fix the onPaste logic of the SmartTextarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.135.0] - Not released
+### Fixed
+- The SmartTextarea component now handles the 'onPaste' event more precisely.
+  When the clipboard contains the text and the image in the same time, both are
+  pasted.
 
 ## [1.134.4] - 2024-08-26
 ### Changed

--- a/src/components/smart-textarea.jsx
+++ b/src/components/smart-textarea.jsx
@@ -178,11 +178,6 @@ function useFile(onFile, ref) {
 
       const items = [...e.clipboardData.items];
 
-      // If there is some plain text in clipboard, use it and don't try to find image
-      if (items.some((it) => it.type.startsWith('text/plain'))) {
-        return;
-      }
-
       const imagePromises = [];
       for (const it of items) {
         if (!it.type.startsWith('image/')) {
@@ -207,9 +202,6 @@ function useFile(onFile, ref) {
           // Probably a regular file copy/paste
           imagePromises.push(Promise.resolve(blob));
         }
-      }
-      if (imagePromises.length > 0) {
-        e.preventDefault();
       }
 
       // Call 'onFile' in order of imagePromises


### PR DESCRIPTION
The SmartTextarea component now handles the 'onPaste' event more precisely. When the clipboard contains the text and the image in the same time, both are pasted.