### PR TITLE
Fix the determination of the post's recipient list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.135.0] - Not released
+### Fixed
+- The recipients list of a post was determined incorrectly if some of the post
+  groups were not on the page.
 
 ## [1.134.4] - 2024-08-26
 ### Changed

--- a/src/components/select-utils.js
+++ b/src/components/select-utils.js
@@ -90,7 +90,7 @@ export const joinPostData = (state) => (postId) => {
       const isDirectToSelf = userId === post.createdBy && subscriptionType === 'Directs';
       return !isDirectToSelf ? userId : false;
     })
-    .map((userId) => state.subscribers[userId])
+    .map((userId) => state.subscribers[userId] || state.users[userId])
     .filter((user) => user);
 
   // All recipient names and the post's author name.


### PR DESCRIPTION
The recipients list of a post was determined incorrectly if some of the post groups were not on the page
