### PR TITLE
Add the post's attachments in the order they were added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.136.0] - Not released
+### Fixed
+- The post attachments now appear in the same order as they were added by user.
+  Previously, attachments were sorted by the upload order.
 
 ## [1.135.3] - 2024-10-22
 ### Fixed


### PR DESCRIPTION
### Fixed
- The post attachments now appear in the same order as they were added by user. Previously, attachments were sorted by the upload order.
