### PR TITLE
Some improvements in avatar display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.136.0] - Not released
+### Fixed
+- User's avatars in the posts are now shown without a loading="lazy" attribute.
+- If the avatar picture is not found, the default avatar is shown.
 
 ## [1.135.3] - 2024-10-22
 ### Fixed

--- a/src/components/post/post.jsx
+++ b/src/components/post/post.jsx
@@ -425,7 +425,6 @@ class Post extends Component {
                   className="post-userpic-img"
                   large={props.isSinglePost}
                   user={props.createdBy}
-                  loading="lazy"
                 />
               </div>
               <div className="post-body" role="region" aria-label="Post body">

--- a/src/components/user-picture.module.scss
+++ b/src/components/user-picture.module.scss
@@ -20,6 +20,16 @@
   img {
     width: 100%;
     height: 100%;
+    position: relative;
+
+    &::after {
+      content: '';
+      background: linear-gradient(0deg, #0000000d, #0000000d),
+        url('../../assets/images/default-userpic.svg');
+      background-size: contain;
+      position: absolute;
+      inset: 0;
+    }
   }
 }
 

--- a/test/jest/__snapshots__/post.test.jsx.snap
+++ b/test/jest/__snapshots__/post.test.jsx.snap
@@ -20,7 +20,6 @@ exports[`Post > Renders a post and doesn't blow up 1`] = `
             <img
               alt="Profile picture of author"
               height="75"
-              loading="lazy"
               width="75"
             />
           </a>


### PR DESCRIPTION
### Fixed
- User's avatars in the posts are now shown without a loading="lazy" attribute.
- If the avatar picture is not found, the default avatar is shown.
