### PR TITLE
Fix: Aparat Embed Not Displayed- 404 Error

### DIFF
--- a/src/components/link-preview/video.jsx
+++ b/src/components/link-preview/video.jsx
@@ -371,11 +371,8 @@ async function getGiphyVideoInfo(url) {
 
 async function getAparatVideoInfo(url) {
   const data = await cachedFetch(
-    `https://corsproxy.io/?${encodeURIComponent(
-      `https://www.aparat.com/oembed?url=${encodeURIComponent(url)}`,
-    )}`,
+    `https://proxy.gojet.net/api/oembed?url=${encodeURIComponent(url)}`,
   );
-
   if (data.error) {
     return { error: data.error };
   }


### PR DESCRIPTION
This pull request addresses the issue where Aparat video embeds fail to load in the feed and are replaced by simple hyperlinks. The root cause was traced to a 404 error from `https://corsproxy.io/`. 

### Changes Included:
- Updated the proxy URL to a functional alternative.

### Testing:
- Verified functionality across multiple platforms (Windows, macOS, and Android).
- Tested on major browsers (Chrome and Firefox) for both mobile and desktop views.
- Confirmed that Aparat embeds now display as expected without errors.

### Notes:
If any further adjustments or additional proxy services are required, please let me know!