### PR TITLE
Use our own CORS proxy for link previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.137.0] - Not released
+### Changed
+- We now use the our own CORS proxy when showing the link previews for Coub,
+  Giphy and Aparat services.
 
 ## [1.136.2] - 2024-12-04
 ### Changed


### PR DESCRIPTION
We now use the our own CORS proxy when showing the link previews for Coub, Giphy and Aparat services
