### PR TITLE
Set the proper "theme-color" meta tag in the startup script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.139.0] - Not released
+### Fixed
+- Set the proper "theme-color" meta tag in the startup script (i.e. as earlier
+  as possible).
 
 ## [1.138.0] - 2025-07-02
 ### Added

--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
     <title>FreeFeed</title>
     <meta name="description" content="FreeFeed is a small and free social network, that enables you to discover and discuss the interesting stuff your friends find on the web">
 
+    <meta name="theme-color" content="white" data-react-helmet="true">
+
     <link rel="icon" href="/assets/images/favicon.ico" sizes="48x48">
     <link rel="icon" href="/assets/images/favicon.svg" sizes="any" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon-180x180.png">

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -56,6 +56,7 @@ import { lazyRetry } from './utils/retry-promise';
 import { HomeAux } from './components/home-aux';
 import { NotFound } from './components/not-found';
 import { DialogProvider } from './components/dialog/context';
+import { ColorSchemeSetter } from './components/color-theme-setter';
 
 // Set initial history state.
 // Without this, there can be problems with third-party
@@ -117,6 +118,7 @@ function InitialLayout({ children }) {
 
   return (
     <div className="startup">
+      <ColorSchemeSetter />
       <h1 className="startup__logo-box">
         <a href="/" className="startup__logo-link">
           {CONFIG.siteTitle}

--- a/src/startup.js
+++ b/src/startup.js
@@ -33,6 +33,9 @@ try {
     (colorScheme !== 'light' && window.matchMedia?.('(prefers-color-scheme: dark)').matches)
   ) {
     document.documentElement.classList.add('dark-theme');
+    document
+      .querySelector('meta[name="theme-color"]')
+      ?.setAttribute('content', 'hsl(220, 9%, 10%)');
   }
 } catch {
   // pass


### PR DESCRIPTION
Set the proper "theme-color" meta tag in the startup script (i.e. as earlier as possible).