### PR TITLE
Lightbox improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The "Download" button in the lightbox was not displayed if the browser did not
   support the full-screen API.
-
+- Replace the source of the lightbox image with a JPEG version on 'contextmenu'
+  event. This allows user to save the image in JPEG format using the “Save image
+  as...” browser menu.
 ## [1.138.1] - 2025-07-09
 ### Fixed
 - Set the proper "theme-color" meta tag in the startup script (i.e. as earlier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.139.0] - Not released
+### Fixed
+- The "Download" button in the lightbox was not displayed if the browser did not
+  support the full-screen API.
 
 ## [1.138.1] - 2025-07-09
 ### Fixed

--- a/src/components/media-links/helpers.jsx
+++ b/src/components/media-links/helpers.jsx
@@ -9,7 +9,7 @@ import {
 import { getVideoInfo, getVideoType, T_VIMEO_VIDEO, T_YOUTUBE_VIDEO } from '../link-preview/video';
 import { isLeftClick } from '../../utils';
 import { openLightbox } from '../../services/lightbox';
-import { attachmentPreviewUrl } from '../../services/api';
+import { attachmentPreviewUrl, attachmentSaveAsUrl } from '../../services/api';
 import { getAttachmentInfo } from '../../services/batch-attachments-info';
 import { pauseYoutubeVideo, playYoutubeVideo } from './youtube-api';
 import { pauseVimeoVideo, playVimeoVideo } from './vimeo-api';
@@ -139,7 +139,7 @@ async function createLightboxItem(url, attempt = 0) {
         type: IMAGE,
         mediaType: 'image',
         src: attachmentPreviewUrl(att.id, 'image'),
-        jpegSrc: attachmentPreviewUrl(att.id, 'image', null, null, { format: 'jpeg' }),
+        saveAsSrc: attachmentSaveAsUrl(att),
         originalSrc: attachmentPreviewUrl(att.id, 'original', null, null, { download: true }),
         width: att.previewWidth ?? att.width,
         height: att.previewHeight ?? att.height,

--- a/src/components/media-links/helpers.jsx
+++ b/src/components/media-links/helpers.jsx
@@ -139,6 +139,7 @@ async function createLightboxItem(url, attempt = 0) {
         type: IMAGE,
         mediaType: 'image',
         src: attachmentPreviewUrl(att.id, 'image'),
+        jpegSrc: attachmentPreviewUrl(att.id, 'image', null, null, { format: 'jpeg' }),
         originalSrc: attachmentPreviewUrl(att.id, 'original', null, null, { download: true }),
         width: att.previewWidth ?? att.width,
         height: att.previewHeight ?? att.height,

--- a/src/components/post/attachments/visual/hooks.js
+++ b/src/components/post/attachments/visual/hooks.js
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useEvent } from 'react-use-event-hook';
-import { attachmentPreviewUrl } from '../../../../services/api';
+import { attachmentPreviewUrl, attachmentSaveAsUrl } from '../../../../services/api';
 import { openLightbox } from '../../../../services/lightbox';
 import { handleLeftClick } from '../../../../utils';
 
@@ -50,7 +50,7 @@ export function useLightboxItems(attachments, postId) {
           ? {
               type: 'image',
               src: attachmentPreviewUrl(a.id, 'image'),
-              jpegSrc: attachmentPreviewUrl(a.id, 'image', null, null, { format: 'jpeg' }),
+              saveAsSrc: attachmentSaveAsUrl(a),
             }
           : {
               type: a.meta?.inProgress ? 'in-progress' : 'video',

--- a/src/components/post/attachments/visual/hooks.js
+++ b/src/components/post/attachments/visual/hooks.js
@@ -47,7 +47,11 @@ export function useLightboxItems(attachments, postId) {
     () =>
       attachments.map((a) => ({
         ...(a.mediaType === 'image'
-          ? { type: 'image', src: attachmentPreviewUrl(a.id, 'image') }
+          ? {
+              type: 'image',
+              src: attachmentPreviewUrl(a.id, 'image'),
+              jpegSrc: attachmentPreviewUrl(a.id, 'image', null, null, { format: 'jpeg' }),
+            }
           : {
               type: a.meta?.inProgress ? 'in-progress' : 'video',
               videoSrc: attachmentPreviewUrl(a.id, 'video'),

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -814,6 +814,17 @@ export function attachmentPreviewUrl(
   return url.toString();
 }
 
+/**
+ * ULR for the right-click save-as browser action
+ */
+export function attachmentSaveAsUrl(attachment) {
+  if (attachment.mediaType === 'image' && !/\.(png|jpe?g|gif)$/i.test(attachment.fileName)) {
+    // Not a common image format, save as JPEG for compatibility
+    return attachmentPreviewUrl(attachment.id, 'image', null, null, { format: 'jpeg' });
+  }
+  return attachmentPreviewUrl(attachment.id, 'original');
+}
+
 export function sanitizeMedia() {
   return fetch(`${apiPrefix}/attachments/my/sanitize`, postRequestOptions());
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -795,7 +795,7 @@ export function attachmentPreviewUrl(
   type,
   width = null,
   height = null,
-  { redirect = true, download = false } = {},
+  { redirect = true, download = false, format = null } = {},
 ) {
   const url = new URL(`${apiPrefix}/attachments/${attId}/${type}`);
   if (redirect) {
@@ -803,6 +803,9 @@ export function attachmentPreviewUrl(
   }
   if (download) {
     url.searchParams.set('download', '');
+  }
+  if (format) {
+    url.searchParams.set('format', format);
   }
   if (width && height) {
     url.searchParams.set('width', width);

--- a/src/services/lightbox-actual.js
+++ b/src/services/lightbox-actual.js
@@ -254,8 +254,8 @@ function initLightbox() {
 
   lightbox.on('contentLoadImage', (e) => {
     const { data, element } = e.content;
-    if (data.jpegSrc) {
-      onContextMenu(element, () => (element.src = data.jpegSrc));
+    if (data.saveAsSrc) {
+      onContextMenu(element, () => (element.src = data.saveAsSrc));
     }
   });
 

--- a/src/services/lightbox-actual.js
+++ b/src/services/lightbox-actual.js
@@ -242,14 +242,11 @@ function initLightbox() {
     }
     if (data.type === 'video') {
       handlePip(element);
-      console.log(data);
       if (isGifLike(data)) {
-        console.log('Gif-like');
         element.muted = true;
         element.loop = true;
         element.controls = false;
       } else if (data.meta.silent) {
-        console.log('Silent');
         element.muted = true;
       }
     }

--- a/src/services/lightbox-actual.js
+++ b/src/services/lightbox-actual.js
@@ -255,7 +255,7 @@ function initLightbox() {
   lightbox.on('contentLoadImage', (e) => {
     const { data, element } = e.content;
     if (data.jpegSrc) {
-      element.addEventListener('contextmenu', () => (element.src = data.jpegSrc), { once: true });
+      onContextMenu(element, () => (element.src = data.jpegSrc));
     }
   });
 
@@ -310,4 +310,31 @@ function whenVideoAndPswpLoaded(video, lightbox, action) {
       lightbox.on('afterInit', () => action(video, lightbox.pswp));
     }
   });
+}
+
+function onContextMenu(element, action) {
+  // We need to apply 'action' when user right-clicks or long-taps on the image.
+  // Normally it is the 'contextmenu' event, but...
+
+  // Desktop browsers allows to intercept 'contextmenu' event
+  element.addEventListener('contextmenu', action, { once: true });
+
+  // Some mobile browsers don't support 'contextmenu' event (iOS), and other
+  // showing context menu _before_ the event is handled. So we need to use some
+  // timey wimey to intercept long taps before the menu is showing.
+  const longTapTime = 300; // ms
+  let timeout = null;
+  const abortController = new AbortController();
+  const { signal } = abortController;
+  const clean = () => {
+    clearTimeout(timeout);
+    abortController.abort();
+  };
+
+  element.addEventListener('touchstart', () => (timeout = setTimeout(action, longTapTime)), {
+    signal,
+  });
+  element.addEventListener('touchend', clean, { signal });
+  element.addEventListener('touchcancel', clean, { signal });
+  element.addEventListener('touchmove', clean, { signal });
 }

--- a/src/services/lightbox-actual.js
+++ b/src/services/lightbox-actual.js
@@ -19,7 +19,7 @@ export function openLightbox(index, dataSource) {
   initLightbox().loadAndOpen(index, dataSource);
 }
 
-const fsApi = getFullscreenAPI();
+const fullScreenAPI = getFullscreenAPI();
 
 // @see https://github.com/dimsemenov/PhotoSwipe/issues/1759#issue-914638063
 const fullscreenIconsHtml = `<svg aria-hidden="true" class="pswp__icn" viewBox="0 0 32 32" width="32" height="32">
@@ -58,26 +58,38 @@ function initLightbox() {
 
   new PhotoSwipeVideoPlugin(lightbox, {});
 
-  // Add fullscreen button
-  lightbox.on('uiRegister', () => {
-    if (!fsApi) {
-      return;
-    }
-    lightbox.pswp.ui.registerElement({
-      name: 'fs',
-      ariaLabel: 'Full screen',
-      order: 9,
-      isButton: true,
-      html: fullscreenIconsHtml,
-      onClick: () => {
-        if (fsApi.isFullscreen()) {
-          fsApi.exit();
-        } else {
-          fsApi.request(lightbox.pswp.element);
-        }
-      },
-    });
+  if (fullScreenAPI) {
+    // Add Fullscreen button
+    lightbox.on('uiRegister', () => {
+      lightbox.pswp.ui.registerElement({
+        name: 'fs',
+        ariaLabel: 'Full screen',
+        order: 9,
+        isButton: true,
+        html: fullscreenIconsHtml,
+        onClick: () => {
+          if (fullScreenAPI.isFullscreen()) {
+            fullScreenAPI.exit();
+          } else {
+            fullScreenAPI.request(lightbox.pswp.element);
+          }
+        },
+      });
 
+      const h = () =>
+        document.documentElement.classList.toggle(
+          'pswp__fullscreen-mode',
+          !!fullScreenAPI.isFullscreen(),
+        );
+
+      document.addEventListener(fullScreenAPI.changeEvent, h);
+      lightbox.on('destroy', () => document.removeEventListener(fullScreenAPI.changeEvent, h));
+      lightbox.on('close', () => fullScreenAPI.isFullscreen() && fullScreenAPI.exit());
+    });
+  }
+
+  // Add Download button
+  lightbox.on('uiRegister', () => {
     lightbox.pswp.ui.registerElement({
       name: 'download-button',
       order: 10,
@@ -98,13 +110,6 @@ function initLightbox() {
         });
       },
     });
-
-    const h = () =>
-      document.documentElement.classList.toggle('pswp__fullscreen-mode', !!fsApi.isFullscreen());
-
-    document.addEventListener(fsApi.changeEvent, h);
-    lightbox.on('destroy', () => document.removeEventListener(fsApi.changeEvent, h));
-    lightbox.on('close', () => fsApi.isFullscreen() && fsApi.exit());
   });
 
   lightbox.on('bindEvents', () => {

--- a/src/services/lightbox-actual.js
+++ b/src/services/lightbox-actual.js
@@ -255,6 +255,13 @@ function initLightbox() {
     }
   });
 
+  lightbox.on('contentLoadImage', (e) => {
+    const { data, element } = e.content;
+    if (data.jpegSrc) {
+      element.addEventListener('contextmenu', () => (element.src = data.jpegSrc), { once: true });
+    }
+  });
+
   // Init
   lightbox.init();
   return lightbox;


### PR DESCRIPTION
### Fixed
- The "Download" button in the lightbox was not displayed if the browser did not support the full-screen API.
- Replace the source of the lightbox image with a JPEG version on 'contextmenu' event. This allows user to save the image in JPEG format using the “Save image as...” browser menu.