### PR TITLE
Previews in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.142.0] - Not released
 ### Added
 - Show found users and groups on the search results page.
+- Show previews of media links in comments (disabled by default). Supported link
+  types: FreeFeed images and videos, external images, YouTube videos and shorts.
 
 ## [1.141.3] - 2025-10-28
 ### Fixed

--- a/config/default.js
+++ b/config/default.js
@@ -71,6 +71,7 @@ export default {
         highlightComments: true,
         showTimestamps: false,
         hideRepliesToBanned: false,
+        showMediaPreviews: false,
       },
       allowLinksPreview: false,
       readMoreStyle: 'modern',

--- a/src/components/link-preview/video.jsx
+++ b/src/components/link-preview/video.jsx
@@ -174,7 +174,7 @@ export function getVideoType(url) {
   return null;
 }
 
-function getVideoId(url) {
+export function getVideoId(url) {
   let m;
   if ((m = YOUTUBE_VIDEO_RE.exec(url))) {
     return m[1];
@@ -200,7 +200,7 @@ function getVideoId(url) {
   return null;
 }
 
-function getDefaultAspectRatio(url) {
+export function getDefaultAspectRatio(url) {
   if (YOUTUBE_VIDEO_RE.test(url)) {
     return isYoutubeShort(url) ? 16 / 9 : 9 / 16;
   }

--- a/src/components/media-links/helpers.jsx
+++ b/src/components/media-links/helpers.jsx
@@ -105,7 +105,7 @@ export function createErrorItem(error) {
 
 const freefeedPathRegex = /^\/attachments\/(?:\w+\/)?([\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12})/;
 
-function freefeedAttachmentId(url) {
+export function freefeedAttachmentId(url) {
   try {
     const urlObj = new URL(url);
     if (!CONFIG.attachmentDomains.includes(urlObj.hostname)) {

--- a/src/components/media-links/helpers.jsx
+++ b/src/components/media-links/helpers.jsx
@@ -16,7 +16,7 @@ import { pauseVimeoVideo, playVimeoVideo } from './vimeo-api';
 
 export const mediaLinksContext = createContext([]);
 
-export function useMediaLink(url) {
+export function useMediaLink(url, { previewId } = {}) {
   const items = useContext(mediaLinksContext);
   const [mediaType, setMediaType] = useState(() => getMediaType(url));
   const index = useMemo(() => {
@@ -29,6 +29,9 @@ export function useMediaLink(url) {
         } else if (item.mediaType) {
           setMediaType(item.mediaType);
         }
+        if (previewId) {
+          item.pid = previewId;
+        }
         items[index] = item;
         return null;
       })
@@ -36,7 +39,7 @@ export function useMediaLink(url) {
     return index;
     // Items are reference-immutable, url is truly immutable
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [previewId]);
 
   const handleClick = useEvent((e) => {
     if (!mediaType || !isLeftClick(e)) {

--- a/src/components/media-links/media-link-preview.jsx
+++ b/src/components/media-links/media-link-preview.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { freefeedAttachmentId, IMAGE, useMediaLink, VIDEO } from './helpers';
 import { getAttachmentInfo } from '../../services/batch-attachments-info';
 import { attachmentPreviewUrl } from '../../services/api';
@@ -6,7 +6,8 @@ import { getDefaultAspectRatio, getVideoId, T_YOUTUBE_VIDEO } from '../link-prev
 import styles from './media-link-preview.module.scss';
 
 export function MediaLinkPreview({ href: url }) {
-  const [mediaType, handleClick] = useMediaLink(url);
+  const previewId = useId();
+  const [mediaType, handleClick] = useMediaLink(url, { previewId });
 
   if (mediaType !== IMAGE && mediaType !== VIDEO && mediaType !== T_YOUTUBE_VIDEO) {
     return null;
@@ -17,7 +18,7 @@ export function MediaLinkPreview({ href: url }) {
   if (attId) {
     return (
       <a href={url} target="_blank" rel="noreferrer" onClick={handleClick}>
-        <FreeFeedMediaPreview id={attId} />
+        <FreeFeedMediaPreview id={attId} previewId={previewId} />
       </a>
     );
   }
@@ -25,7 +26,7 @@ export function MediaLinkPreview({ href: url }) {
   if (mediaType === T_YOUTUBE_VIDEO) {
     return (
       <a href={url} target="_blank" rel="noreferrer" onClick={handleClick}>
-        <YouTubeMediaPreview url={url} />
+        <YouTubeMediaPreview url={url} previewId={previewId} />
       </a>
     );
   }
@@ -36,12 +37,20 @@ export function MediaLinkPreview({ href: url }) {
 
   return (
     <a href={url} target="_blank" rel="noreferrer" onClick={handleClick}>
-      <img src={url} alt="" width={60} height={60} className={styles.preview} loading="lazy" />
+      <img
+        src={url}
+        alt=""
+        width={60}
+        height={60}
+        className={styles.preview}
+        loading="lazy"
+        id={previewId}
+      />
     </a>
   );
 }
 
-function FreeFeedMediaPreview({ id }) {
+function FreeFeedMediaPreview({ id, previewId }) {
   const [attrs, setAttrs] = useState(null);
 
   useEffect(() => {
@@ -74,11 +83,12 @@ function FreeFeedMediaPreview({ id }) {
       style={{ '--ar': attrs.width / attrs.height }}
       className={styles.preview}
       loading="lazy"
+      id={previewId}
     />
   ) : null;
 }
 
-function YouTubeMediaPreview({ url }) {
+function YouTubeMediaPreview({ url, previewId }) {
   const aspectRatio = getDefaultAspectRatio(url);
   return (
     <img
@@ -89,6 +99,7 @@ function YouTubeMediaPreview({ url }) {
       style={{ '--ar': 1 / aspectRatio }}
       className={styles.preview}
       loading="lazy"
+      id={previewId}
     />
   );
 }

--- a/src/components/media-links/media-link-preview.jsx
+++ b/src/components/media-links/media-link-preview.jsx
@@ -49,7 +49,7 @@ function FreeFeedMediaPreview({ id }) {
       .then((info) => {
         if (info?.mediaType === 'image' || info?.mediaType === 'video') {
           const height = 120;
-          const width = Math.max(90, (info.width / info.height) * height);
+          const width = Math.round((info.width / info.height) * height);
           setAttrs({
             src: attachmentPreviewUrl(id, 'image', width, height),
             width,
@@ -71,6 +71,7 @@ function FreeFeedMediaPreview({ id }) {
       alt=""
       width={attrs.width}
       height={attrs.height}
+      style={{ '--ar': attrs.width / attrs.height }}
       className={styles.preview}
       loading="lazy"
     />
@@ -83,8 +84,9 @@ function YouTubeMediaPreview({ url }) {
     <img
       src={`https://img.youtube.com/vi/${getVideoId(url)}/default.jpg`}
       alt=""
-      width={60 / aspectRatio}
+      width={Math.round(60 / aspectRatio)}
       height={60}
+      style={{ '--ar': 1 / aspectRatio }}
       className={styles.preview}
       loading="lazy"
     />

--- a/src/components/media-links/media-link-preview.jsx
+++ b/src/components/media-links/media-link-preview.jsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import { freefeedAttachmentId, IMAGE, useMediaLink, VIDEO } from './helpers';
+import { getAttachmentInfo } from '../../services/batch-attachments-info';
+import { attachmentPreviewUrl } from '../../services/api';
+import { getDefaultAspectRatio, getVideoId, T_YOUTUBE_VIDEO } from '../link-preview/video';
+import styles from './media-link-preview.module.scss';
+
+export function MediaLinkPreview({ href: url }) {
+  const [mediaType, handleClick] = useMediaLink(url);
+
+  if (mediaType !== IMAGE && mediaType !== VIDEO && mediaType !== T_YOUTUBE_VIDEO) {
+    return null;
+  }
+
+  // Freefeed attachment?
+  const attId = freefeedAttachmentId(url);
+  if (attId) {
+    return (
+      <a href={url} target="_blank" rel="noreferrer" onClick={handleClick}>
+        <FreeFeedMediaPreview id={attId} />
+      </a>
+    );
+  }
+
+  if (mediaType === T_YOUTUBE_VIDEO) {
+    return (
+      <a href={url} target="_blank" rel="noreferrer" onClick={handleClick}>
+        <YouTubeMediaPreview url={url} />
+      </a>
+    );
+  }
+
+  if (mediaType === VIDEO) {
+    return null;
+  }
+
+  return (
+    <a href={url} target="_blank" rel="noreferrer" onClick={handleClick}>
+      <img src={url} alt="" width={60} height={60} className={styles.preview} loading="lazy" />
+    </a>
+  );
+}
+
+function FreeFeedMediaPreview({ id }) {
+  const [attrs, setAttrs] = useState(null);
+
+  useEffect(() => {
+    getAttachmentInfo(id)
+      .then((info) => {
+        if (info?.mediaType === 'image' || info?.mediaType === 'video') {
+          const height = 120;
+          const width = Math.max(90, (info.width / info.height) * height);
+          setAttrs({
+            src: attachmentPreviewUrl(id, 'image', width, height),
+            width,
+            height,
+          });
+        }
+        return null;
+      })
+      .catch((err) => {
+        // Just ignore
+        // eslint-disable-next-line no-console
+        console.error('Failed to get attachment info', id, err);
+      });
+  }, [id]);
+
+  return attrs ? (
+    <img
+      src={attrs.src}
+      alt=""
+      width={attrs.width}
+      height={attrs.height}
+      className={styles.preview}
+      loading="lazy"
+    />
+  ) : null;
+}
+
+function YouTubeMediaPreview({ url }) {
+  const aspectRatio = getDefaultAspectRatio(url);
+  return (
+    <img
+      src={`https://img.youtube.com/vi/${getVideoId(url)}/default.jpg`}
+      alt=""
+      width={60 / aspectRatio}
+      height={60}
+      className={styles.preview}
+      loading="lazy"
+    />
+  );
+}

--- a/src/components/media-links/media-link-preview.module.scss
+++ b/src/components/media-links/media-link-preview.module.scss
@@ -1,6 +1,7 @@
 .preview {
   height: 4em;
   width: auto;
+  aspect-ratio: clamp(0.8, var(--ar, 1), 1.2);
   object-fit: cover;
   box-shadow: 0 0 0 1px rgb(0, 0, 0, 0.2);
 

--- a/src/components/media-links/media-link-preview.module.scss
+++ b/src/components/media-links/media-link-preview.module.scss
@@ -1,0 +1,18 @@
+.preview {
+  height: 4em;
+  width: auto;
+  object-fit: cover;
+  box-shadow: 0 0 0 1px rgb(0, 0, 0, 0.2);
+
+  &:hover {
+    box-shadow: 0 0 0 1px rgb(0, 0, 0, 1);
+  }
+
+  :global(.dark-theme) & {
+    box-shadow: 0 0 0 1px rgb(255, 255, 255, 0.2);
+
+    &:hover {
+      box-shadow: 0 0 0 1px rgb(255, 255, 255, 0.8);
+    }
+  }
+}

--- a/src/components/post/comment-media-previews.jsx
+++ b/src/components/post/comment-media-previews.jsx
@@ -1,0 +1,41 @@
+import { isLocalLink, parseText } from '../../utils/parse-text';
+import ErrorBoundary from '../error-boundary';
+import { T_YOUTUBE_VIDEO } from '../link-preview/video';
+import { getMediaType, IMAGE, VIDEO } from '../media-links/helpers';
+import { MediaLinkPreview } from '../media-links/media-link-preview';
+import { MediaLinksProvider } from '../media-links/provider';
+import styles from './comment-media-previews.module.scss';
+
+export function CommentMediaPreviews({ text }) {
+  const result = [];
+
+  const tokens = text ? parseText(text) : [];
+
+  let inSpoiler = false;
+  for (const [index, token] of tokens.entries()) {
+    if (token.type === 'SPOILER_START') {
+      inSpoiler = true;
+    } else if (token.type === 'SPOILER_END') {
+      inSpoiler = false;
+    } else if (token.type === 'LINK' && !inSpoiler) {
+      if (
+        !isLocalLink(token.text) &&
+        /^https?:\/\//i.test(token.text) &&
+        text.charAt(token.offset - 1) !== '!'
+      ) {
+        const type = getMediaType(token.text);
+        if (type === IMAGE || type === VIDEO || type === T_YOUTUBE_VIDEO) {
+          result.push(<MediaLinkPreview key={index} href={token.text} />);
+        }
+      }
+    }
+  }
+
+  return (
+    <div className={styles.previews}>
+      <ErrorBoundary>
+        <MediaLinksProvider>{result}</MediaLinksProvider>
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/src/components/post/comment-media-previews.module.scss
+++ b/src/components/post/comment-media-previews.module.scss
@@ -1,0 +1,9 @@
+@use '../../../styles/shared/mixins';
+
+.previews {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.33em;
+  margin-left: mixins.rem(19px);
+  margin-top: 0.25em;
+}

--- a/src/components/post/comment-media-previews.module.scss
+++ b/src/components/post/comment-media-previews.module.scss
@@ -1,9 +1,9 @@
 @use '../../../styles/shared/mixins';
 
 .previews {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.33em;
   margin-left: mixins.rem(19px);
   margin-top: 0.25em;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
 }

--- a/src/components/post/post-comment.jsx
+++ b/src/components/post/post-comment.jsx
@@ -29,6 +29,7 @@ import { PostCommentMore } from './post-comment-more';
 import { PostCommentPreview } from './post-comment-preview';
 import { CommentProvider } from './post-comment-provider';
 import { DraftIndicator } from './draft-indicator';
+import { CommentMediaPreviews } from './comment-media-previews';
 
 class PostComment extends Component {
   commentContainer;
@@ -380,6 +381,10 @@ class PostComment extends Component {
     );
   }
 
+  renderMediaPreviews() {
+    return this.props.showMediaPreviews ? <CommentMediaPreviews text={this.props.body} /> : null;
+  }
+
   render() {
     const className = classnames({
       comment: true,
@@ -403,6 +408,7 @@ class PostComment extends Component {
       >
         {this.renderCommentIcon()}
         {this.renderBody()}
+        {this.renderMediaPreviews()}
         {this.renderPreview()}
       </div>
     );
@@ -415,6 +421,9 @@ function selectState(state, ownProps) {
   const showTimestamps =
     state.user.frontendPreferences?.comments?.showTimestamps ||
     CONFIG.frontendPreferences.defaultValues.comments.showTimestamps;
+  const showMediaPreviews =
+    state.user.frontendPreferences?.comments?.showMediaPreviews ||
+    CONFIG.frontendPreferences.defaultValues.comments.showMediaPreviews;
   const { highlightComments } = state.user.frontendPreferences.comments;
   const isReplyToBanned = (() => {
     if (
@@ -435,6 +444,7 @@ function selectState(state, ownProps) {
   return {
     ...editState,
     showTimestamps,
+    showMediaPreviews,
     highlightComments,
     isEditing: ownProps.isEditing || editState.isEditing,
     submitMode: state.submitMode,

--- a/src/components/settings/forms/appearance.jsx
+++ b/src/components/settings/forms/appearance.jsx
@@ -115,6 +115,7 @@ export default function AppearanceForm() {
   const hideNSFWContent = useField('hideNSFWContent', form.form);
   const isOrbitDisabledField = useField('isOrbitDisabledField', form.form);
   const commentsTimestamps = useField('commentsTimestamps', form.form);
+  const commentsShowMediaPreviews = useField('commentsShowMediaPreviews', form.form);
   const timeAmPm = useField('timeAmPm', form.form);
   const timeAbsolute = useField('timeAbsolute', form.form);
   const enableBeta = useField('enableBeta', form.form);
@@ -432,6 +433,13 @@ export default function AppearanceForm() {
               Show timestamps for comments
             </label>
           </div>
+
+          <div className="checkbox">
+            <label>
+              <CheckboxInput field={commentsShowMediaPreviews} />
+              Show previews of media links in comments
+            </label>
+          </div>
         </div>
         <h5>Completely hide (don&#x2019;t even show the placeholder):</h5>
         <div className="form-group">
@@ -674,6 +682,7 @@ function initialValues({
     allowLinksPreview: frontend.allowLinksPreview,
     hideNSFWContent: !isNSFWVisible,
     commentsTimestamps: frontend.comments.showTimestamps,
+    commentsShowMediaPreviews: frontend.comments.showMediaPreviews,
     timeAmPm: frontend.timeDisplay.amPm ? '1' : '0',
     timeAbsolute: frontend.timeDisplay.absolute ? '1' : '0',
     enableBeta: isBetaChannel,
@@ -735,6 +744,7 @@ function prefUpdaters(values) {
           highlightComments: values.highlightComments,
           showTimestamps: values.commentsTimestamps,
           hideRepliesToBanned: values.hideRepliesToBanned,
+          showMediaPreviews: values.commentsShowMediaPreviews,
         },
         allowLinksPreview: values.allowLinksPreview,
         timeDisplay: {

--- a/src/services/batch-attachments-info.js
+++ b/src/services/batch-attachments-info.js
@@ -2,7 +2,8 @@ import { getAttachmentsInfo } from './api';
 
 const maxBatchSize = 50; // items
 const batchTimeout = 50; // milliseconds
-const cache = new Map();
+const cache = new Map(); // Resolved results cache
+const pendingPromises = new Map(); // Pending promises cache
 
 let timer = 0;
 let resolvers = new Map();
@@ -16,21 +17,32 @@ let resolvers = new Map();
  * @returns {Promise<object|null>}
  */
 export async function getAttachmentInfo(id) {
+  // Return cached result
   if (cache.has(id)) {
     return cache.get(id);
   }
-  return new Promise((resolve) => {
+
+  // Return existing pending promise
+  if (pendingPromises.has(id)) {
+    return pendingPromises.get(id);
+  }
+
+  // Create new promise
+  const promise = new Promise((resolve, reject) => {
     if (resolvers.size === 0) {
       timer = setTimeout(executeBatch, batchTimeout);
     }
 
-    resolvers.set(id, resolve);
+    resolvers.set(id, { resolve, reject });
 
     if (resolvers.size >= maxBatchSize) {
       clearTimeout(timer);
       executeBatch();
     }
   });
+
+  pendingPromises.set(id, promise);
+  return promise;
 }
 
 async function executeBatch() {
@@ -43,7 +55,10 @@ async function executeBatch() {
     const { attachments, idsNotFound } = await getAttachmentsInfo(ids).then((r) => r.json());
     const resultsMap = new Map(attachments.map((a) => [a.id, a]));
 
-    for (const [id, resolve] of currentResolves) {
+    for (const [id, { resolve, reject }] of currentResolves) {
+      // Remove from pending promises
+      pendingPromises.delete(id);
+
       const result = resultsMap.get(id);
       if (result) {
         if (!result.meta?.inProgress) {
@@ -51,15 +66,17 @@ async function executeBatch() {
         }
         resolve(result);
       } else if (idsNotFound.includes(id)) {
-        resolve(null);
         cache.set(id, null);
+        resolve(null);
       } else {
-        resolve(Promise.reject(new Error('Attachment not found')));
+        reject(new Error('Attachment not found'));
       }
     }
   } catch (error) {
-    for (const resolve of resolvers.values()) {
-      resolve(Promise.reject(error));
+    for (const [id, { reject }] of currentResolves) {
+      // Remove from pending promises
+      pendingPromises.delete(id);
+      reject(error);
     }
   }
 }


### PR DESCRIPTION
Show previews of media links in comments (disabled by default). Supported link types: FreeFeed images and videos, external images, YouTube videos and shorts.

<img width="1236" height="581" alt="image" src="https://github.com/user-attachments/assets/31a4a00b-2d0f-49eb-bf05-28eeec976ceb" />

<img width="906" height="308" alt="image" src="https://github.com/user-attachments/assets/b01afdf0-b51f-4cd0-b25f-f2839d07f00c" />
