### PR TITLE
Limit feed entries to prevent indefinite growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.145.0] - Not released
+### Changed
+- Limit feed entries number to 60 (configurable via `CONFIG.feed.maxEntries`) to
+  prevent the feed from growing indefinitely on long-running sessions.
 
 ## [1.144.0] - 2026-01-12
 ### Added

--- a/config/default.js
+++ b/config/default.js
@@ -212,4 +212,8 @@ export default {
     storagePrefix: 'draft:',
     maxDraftAge: 7 * DAY_IN_MILLISECONDS,
   },
+
+  feed: {
+    maxEntries: 60, // Prevent the feed from growing indefinitely on long-running sessions
+  },
 };

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -171,6 +171,20 @@ const initFeed = {
   feedRequestType: null,
 };
 
+/**
+ * Prevent the feed from growing indefinitely
+ *
+ * @param {string[]} entries
+ * @returns {string[]}
+ */
+function limitFeedEntries(entries) {
+  const maxEntries = CONFIG.feed.maxEntries;
+  if (entries.length <= maxEntries) {
+    return entries;
+  }
+  return entries.slice(0, maxEntries);
+}
+
 export function feedViewState(state = initFeed, action) {
   if (ActionHelpers.isFeedRequest(action)) {
     return state;
@@ -232,7 +246,7 @@ export function feedViewState(state = initFeed, action) {
       }
       return {
         ...state,
-        entries: [postId, ...state.entries],
+        entries: limitFeedEntries([postId, ...state.entries]),
       };
     }
     case response(ActionTypes.GET_SINGLE_POST): {
@@ -255,7 +269,7 @@ export function feedViewState(state = initFeed, action) {
         entries = [...entries.slice(0, p), action.post.id, ...entries.slice(p)];
       }
 
-      return { ...state, entries };
+      return { ...state, entries: limitFeedEntries(entries) };
     }
     case ActionTypes.REALTIME_LIKE_NEW:
     case ActionTypes.REALTIME_COMMENT_NEW: {
@@ -263,7 +277,7 @@ export function feedViewState(state = initFeed, action) {
         const postId = action.post.posts.id;
         return {
           ...state,
-          entries: [postId, ...state.entries],
+          entries: limitFeedEntries([postId, ...state.entries]),
         };
       }
       return state;

--- a/test/unit/redux/reducers/feed-entries-limit.js
+++ b/test/unit/redux/reducers/feed-entries-limit.js
@@ -1,0 +1,258 @@
+import { describe, it, beforeEach } from 'vitest';
+import expect from 'unexpected';
+
+import { feedViewState } from '../../../../src/redux/reducers';
+import { response } from '../../../../src/redux/action-helpers';
+import * as ActionTypes from '../../../../src/redux/action-types';
+
+// Mock CONFIG to use test values
+global.CONFIG = {
+  ...global.CONFIG,
+  feed: {
+    maxEntries: 60,
+  },
+};
+
+describe('feedViewState entries limit', () => {
+  let state;
+
+  beforeEach(() => {
+    // Create initial state with 50 entries (less than maxEntries = 60)
+    state = {
+      ...feedViewState(undefined, { type: 'init' }),
+      entries: Array.from({ length: 50 }, (_, i) => `post${i}`),
+    };
+  });
+
+  describe('CREATE_POST', () => {
+    it('should keep entries within limit when adding new post', () => {
+      const action = {
+        type: response(ActionTypes.CREATE_POST),
+        payload: { posts: { id: 'new-post' } },
+      };
+
+      const result = feedViewState(state, action);
+
+      expect(result.entries, 'to have length', 51); // 50 + 1 = 51 (still under limit)
+      expect(result.entries[0], 'to equal', 'new-post'); // new post at beginning
+    });
+
+    it('should limit entries when exceeding maxEntries', () => {
+      // Create state with 60 entries (at limit)
+      const fullState = {
+        ...state,
+        entries: Array.from({ length: 60 }, (_, i) => `post${i}`),
+      };
+
+      const action = {
+        type: response(ActionTypes.CREATE_POST),
+        payload: { posts: { id: 'new-post' } },
+      };
+
+      const result = feedViewState(fullState, action);
+
+      expect(result.entries, 'to have length', 60); // Should stay at limit
+      expect(result.entries[0], 'to equal', 'new-post'); // new post at beginning
+      expect(result.entries, 'not to contain', 'post59'); // oldest post removed
+    });
+
+    it('should not add duplicate post', () => {
+      const stateWithDuplicate = {
+        ...state,
+        entries: ['existing-post', ...state.entries.slice(1)],
+      };
+
+      const action = {
+        type: response(ActionTypes.CREATE_POST),
+        payload: { posts: { id: 'existing-post' } },
+      };
+
+      const result = feedViewState(stateWithDuplicate, action);
+
+      expect(result.entries, 'to have length', 50); // No change
+      expect(result.entries[0], 'to equal', 'existing-post');
+    });
+  });
+
+  describe('REALTIME_POST_NEW', () => {
+    it('should limit entries when realtime post exceeds limit', () => {
+      const fullState = {
+        ...state,
+        entries: Array.from({ length: 60 }, (_, i) => `post${i}`),
+      };
+
+      const action = {
+        type: ActionTypes.REALTIME_POST_NEW,
+        post: { id: 'realtime-post' },
+        shouldBump: true,
+        insertBefore: 'post10', // Insert at position 10
+      };
+
+      const result = feedViewState(fullState, action);
+
+      expect(result.entries, 'to have length', 60);
+      expect(result.entries, 'to contain', 'realtime-post');
+      expect(result.entries, 'not to contain', 'post59'); // oldest post removed
+      const insertIndex = result.entries.indexOf('realtime-post');
+      const post10Index = result.entries.indexOf('post10');
+      expect(insertIndex, 'to be', post10Index - 1);
+    });
+
+    it('should not add post if shouldBump is false', () => {
+      const action = {
+        type: ActionTypes.REALTIME_POST_NEW,
+        post: { id: 'realtime-post' },
+        shouldBump: false,
+      };
+
+      const result = feedViewState(state, action);
+
+      expect(result.entries, 'to have length', 50); // No change
+      expect(result.entries, 'not to contain', 'realtime-post');
+    });
+
+    it('should not add duplicate post', () => {
+      const stateWithDuplicate = {
+        ...state,
+        entries: ['existing-post', ...state.entries.slice(1)],
+      };
+
+      const action = {
+        type: ActionTypes.REALTIME_POST_NEW,
+        post: { id: 'existing-post' },
+        shouldBump: true,
+      };
+
+      const result = feedViewState(stateWithDuplicate, action);
+
+      expect(result.entries, 'to have length', 50); // No change
+    });
+
+    it('should insert post at correct position when insertBefore is specified', () => {
+      const action = {
+        type: ActionTypes.REALTIME_POST_NEW,
+        post: { id: 'inserted-post' },
+        shouldBump: true,
+        insertBefore: 'post25',
+      };
+
+      const result = feedViewState(state, action);
+
+      expect(result.entries, 'to have length', 51);
+      const insertIndex = result.entries.indexOf('inserted-post');
+      const post25Index = result.entries.indexOf('post25');
+      expect(insertIndex, 'to be', post25Index - 1);
+    });
+
+    it('should add post to end when insertBefore is null', () => {
+      const action = {
+        type: ActionTypes.REALTIME_POST_NEW,
+        post: { id: 'end-post' },
+        shouldBump: true,
+        insertBefore: null,
+      };
+
+      const result = feedViewState(state, action);
+
+      expect(result.entries, 'to have length', 51);
+      expect(result.entries[50], 'to equal', 'end-post'); // Last position
+    });
+  });
+
+  describe('REALTIME_LIKE_NEW', () => {
+    it('should limit entries when liked post exceeds limit', () => {
+      const fullState = {
+        ...state,
+        entries: Array.from({ length: 60 }, (_, i) => `post${i}`),
+      };
+
+      const action = {
+        type: ActionTypes.REALTIME_LIKE_NEW,
+        post: { posts: { id: 'liked-post' } },
+        shouldBump: true,
+      };
+
+      const result = feedViewState(fullState, action);
+
+      expect(result.entries, 'to have length', 60);
+      expect(result.entries[0], 'to equal', 'liked-post'); // liked post at beginning
+      expect(result.entries, 'not to contain', 'post59'); // oldest post removed
+    });
+
+    it('should not add post if shouldBump is false', () => {
+      const action = {
+        type: ActionTypes.REALTIME_LIKE_NEW,
+        post: { posts: { id: 'liked-post' } },
+        shouldBump: false,
+      };
+
+      const result = feedViewState(state, action);
+
+      expect(result.entries, 'to have length', 50); // No change
+      expect(result.entries, 'not to contain', 'liked-post');
+    });
+
+    it('should not add post if post is missing', () => {
+      const action = {
+        type: ActionTypes.REALTIME_LIKE_NEW,
+        shouldBump: true,
+      };
+
+      const result = feedViewState(state, action);
+
+      expect(result.entries, 'to have length', 50); // No change
+    });
+  });
+
+  describe('REALTIME_COMMENT_NEW', () => {
+    it('should limit entries when commented post exceeds limit', () => {
+      const fullState = {
+        ...state,
+        entries: Array.from({ length: 60 }, (_, i) => `post${i}`),
+      };
+
+      const action = {
+        type: ActionTypes.REALTIME_COMMENT_NEW,
+        post: { posts: { id: 'commented-post' } },
+        shouldBump: true,
+      };
+
+      const result = feedViewState(fullState, action);
+
+      expect(result.entries, 'to have length', 60);
+      expect(result.entries[0], 'to equal', 'commented-post'); // commented post at beginning
+      expect(result.entries, 'not to contain', 'post59'); // oldest post removed
+    });
+
+    it('should not add post if shouldBump is false', () => {
+      const action = {
+        type: ActionTypes.REALTIME_COMMENT_NEW,
+        post: { posts: { id: 'commented-post' } },
+        shouldBump: false,
+      };
+
+      const result = feedViewState(state, action);
+
+      expect(result.entries, 'to have length', 50); // No change
+      expect(result.entries, 'not to contain', 'commented-post');
+    });
+  });
+
+  describe('Feed loading', () => {
+    it('should not limit entries on initial feed load', () => {
+      // This simulates server-side pagination, which should not be limited
+      const action = {
+        type: response(ActionTypes.GET_EVERYTHING),
+        payload: {
+          posts: Array.from({ length: 100 }, (_, i) => ({ id: `post${i}` })),
+          isLastPage: false,
+        },
+      };
+
+      const result = feedViewState(state, action);
+
+      // Feed response should replace entries entirely, not apply limit
+      expect(result.entries, 'to have length', 100);
+    });
+  });
+});


### PR DESCRIPTION
### Changed
- Limit feed entries number to 60 (configurable via `CONFIG.feed.maxEntries`) to prevent the feed from growing indefinitely on long-running sessions.
