### PR TITLE
Improve comments preview aspect ratio

### DIFF
--- a/src/components/media-links/media-link-preview.jsx
+++ b/src/components/media-links/media-link-preview.jsx
@@ -8,19 +8,19 @@ import styles from './media-link-preview.module.scss';
 export function MediaLinkPreview({ href: url }) {
   const previewId = useId();
   const [mediaType, handleClick] = useMediaLink(url, { previewId });
-
-  if (mediaType !== IMAGE && mediaType !== VIDEO && mediaType !== T_YOUTUBE_VIDEO) {
-    return null;
-  }
-
-  // Freefeed attachment?
   const attId = freefeedAttachmentId(url);
+
+  // Freefeed attachment — render even when mediaType unknown (e.g. /v4/attachments/UUID)
   if (attId) {
     return (
       <a href={url} target="_blank" rel="noreferrer" onClick={handleClick}>
         <FreeFeedMediaPreview id={attId} previewId={previewId} />
       </a>
     );
+  }
+
+  if (mediaType !== IMAGE && mediaType !== VIDEO && mediaType !== T_YOUTUBE_VIDEO) {
+    return null;
   }
 
   if (mediaType === T_YOUTUBE_VIDEO) {
@@ -58,11 +58,17 @@ function FreeFeedMediaPreview({ id, previewId }) {
       .then((info) => {
         if (info?.mediaType === 'image' || info?.mediaType === 'video') {
           const height = 120;
-          const width = Math.round((info.width / info.height) * height);
+          const w = info.width ?? info.imageSizes?.o?.w;
+          const h = info.height ?? info.imageSizes?.o?.h;
+          const width = w && h ? Math.round((w / h) * height) : height;
+          const ar = w && h ? w / h : 1;
+          const aspectType = ar >= 0.5 && ar <= 2 ? 'normal' : 'extreme';
           setAttrs({
             src: attachmentPreviewUrl(id, 'image', width, height),
             width,
             height,
+            ar,
+            aspectType,
           });
         }
         return null;
@@ -80,7 +86,8 @@ function FreeFeedMediaPreview({ id, previewId }) {
       alt=""
       width={attrs.width}
       height={attrs.height}
-      style={{ '--ar': attrs.width / attrs.height }}
+      style={{ '--ar': attrs.ar }}
+      data-aspect-type={attrs.aspectType}
       className={styles.preview}
       loading="lazy"
       id={previewId}

--- a/src/components/media-links/media-link-preview.jsx
+++ b/src/components/media-links/media-link-preview.jsx
@@ -40,8 +40,8 @@ export function MediaLinkPreview({ href: url }) {
       <img
         src={url}
         alt=""
-        width={60}
-        height={60}
+        width={90}
+        height={90}
         className={styles.preview}
         loading="lazy"
         id={previewId}
@@ -57,7 +57,7 @@ function FreeFeedMediaPreview({ id, previewId }) {
     getAttachmentInfo(id)
       .then((info) => {
         if (info?.mediaType === 'image' || info?.mediaType === 'video') {
-          const height = 120;
+          const height = 180;
           const w = info.width ?? info.imageSizes?.o?.w;
           const h = info.height ?? info.imageSizes?.o?.h;
           const width = w && h ? Math.round((w / h) * height) : height;
@@ -101,8 +101,8 @@ function YouTubeMediaPreview({ url, previewId }) {
     <img
       src={`https://img.youtube.com/vi/${getVideoId(url)}/default.jpg`}
       alt=""
-      width={Math.round(60 / aspectRatio)}
-      height={60}
+      width={Math.round(90 / aspectRatio)}
+      height={90}
       style={{ '--ar': 1 / aspectRatio }}
       className={styles.preview}
       loading="lazy"

--- a/src/components/media-links/media-link-preview.module.scss
+++ b/src/components/media-links/media-link-preview.module.scss
@@ -1,9 +1,22 @@
 .preview {
   height: 4em;
   width: auto;
+  /* Default for external images and YouTube: dimensions unknown or limited */
   aspect-ratio: clamp(0.8, var(--ar, 1), 1.2);
   object-fit: cover;
   box-shadow: 0 0 0 1px rgb(0, 0, 0, 0.2);
+
+  /* Freefeed: normal proportions (0.5 ≤ ar ≤ 2) — show full image */
+  &[data-aspect-type='normal'] {
+    aspect-ratio: var(--ar);
+    object-fit: contain;
+  }
+
+  /* Freefeed: extreme proportions (panoramas, vertical strips) — limit preview size */
+  &[data-aspect-type='extreme'] {
+    aspect-ratio: clamp(0.5, var(--ar), 2);
+    object-fit: cover;
+  }
 
   &:hover {
     box-shadow: 0 0 0 1px rgb(0, 0, 0, 1);

--- a/src/components/media-links/media-link-preview.module.scss
+++ b/src/components/media-links/media-link-preview.module.scss
@@ -1,5 +1,5 @@
 .preview {
-  height: 4em;
+  height: 6em;
   width: auto;
   /* Default for external images and YouTube: dimensions unknown or limited */
   aspect-ratio: clamp(0.8, var(--ar, 1), 1.2);


### PR DESCRIPTION
Обсуждение - https://freefeed.net/deetan/e87e2f

Increase comment image preview height from 4em to 6em. FreeFeed attachments with normal aspect ratios (0.5–2.0) are now shown without cropping, using the real dimensions from the API. Extreme proportions (panoramas, narrow strips) are still clamp-limited to keep previews compact.

Увеличен размер превью картинок в комментариях с 4em до 6em. Вложения FreeFeed с нормальными пропорциями (0.5–2.0) теперь показываются целиком, без обрезки, с использованием реальных размеров из API. Экстремальные пропорции (панорамы, узкие полоски) по-прежнему ограничиваются clamp, чтобы превью не разрасталось.